### PR TITLE
VSCODE-16 Add initial extension commands

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,9 @@
 // Place your settings in this file to overwrite default and user settings.
 {
   "editor.formatOnSave": true,
+  "editor.tabSize": 2,
+  // Insert spaces when pressing Tab.
+  "editor.insertSpaces": true,
   "files.trimTrailingWhitespace": true,
   "files.insertFinalNewline": true,
   "files.exclude": {

--- a/README.md
+++ b/README.md
@@ -1,71 +1,34 @@
-# :construction: [Design in Progress](https://github.com/mongodb-js/vscode/pull/1) 
+# :construction: [Work in Progress] :construction:
+
+**Not Yet Released**
 
 Official MongoDB Visual Studio Code Extension
 
 > brought to you by the Compass team
 
-# mongodb README
-
-This is the README for your extension "mongodb". After writing up a brief description, we recommend including the following sections.
-
 ## Features
 
-Describe specific features of your extension including screenshots of your extension in action. Image paths are relative to this README file.
-
-For example if there is an image subfolder under your extension project workspace:
-
-\!\[feature X\]\(images/feature-x.png\)
-
-> Tip: Many popular extensions utilize animations. This is an excellent way to show off your extension! We recommend short, focused animations that are easy to follow.
-
-## Requirements
-
-If you have any requirements or dependencies, add a section describing those and how to install and configure them.
+### :construction:
 
 ## Extension Settings
 
-Include if your extension adds any VS Code settings through the `contributes.configuration` extension point.
+* `mdb.show`: Show/Hide the MongoDB extension.
 
-For example:
+## Contributing
 
-This extension contributes the following settings:
+For issues, please create a ticket in our [JIRA
+Project](https://jira.mongodb.org/browse/VSCODE).
 
-* `myExtension.enable`: enable/disable this extension
-* `myExtension.thing`: set to `blah` to do something
+## Development
 
-## Known Issues
+First, we recommend familiarizing yourself with the VSCode extension documentation:
+[code.visualstudio.com/api](https://code.visualstudio.com/api)
 
-Calling out known issues can help limit users opening duplicate issues against your extension.
+Running the MongoDB VSCode plugin requires [Node.js](https://nodejs.org) and npm
 
-## Release Notes
+```shell
+npm install
+npm run watch
+```
 
-Users appreciate release notes as you update your extension.
-
-### 1.0.0
-
-Initial release of ...
-
-### 1.0.1
-
-Fixed issue #.
-
-### 1.1.0
-
-Added features X, Y, and Z.
-
------------------------------------------------------------------------------------------------------------
-
-## Working with Markdown
-
-**Note:** You can author your README using Visual Studio Code.  Here are some useful editor keyboard shortcuts:
-
-* Split the editor (`Cmd+\` on macOS or `Ctrl+\` on Windows and Linux)
-* Toggle preview (`Shift+CMD+V` on macOS or `Shift+Ctrl+V` on Windows and Linux)
-* Press `Ctrl+Space` (Windows, Linux) or `Cmd+Space` (macOS) to see a list of Markdown snippets
-
-### For more information
-
-* [Visual Studio Code's Markdown Support](http://code.visualstudio.com/docs/languages/markdown)
-* [Markdown Syntax Reference](https://help.github.com/articles/markdown-basics/)
-
-**Enjoy!**
+Inside of [VS Code Insiders](https://code.visualstudio.com/insiders/) press `F5` to begin debugging the extension.

--- a/package.json
+++ b/package.json
@@ -4,15 +4,27 @@
   "description": "MongoDB for Visual Studio Code",
   "version": "0.0.1",
   "engines": {
-    "vscode": "^1.40.0"
+    "vscode": "^1.40.0",
+    "node": "^12.4.0",
+    "npm": ">=6.13.0"
   },
   "categories": [
     "Other"
   ],
   "activationEvents": [
-    "onCommand:extension.helloWorld"
+    "onCommand:mdb.connect",
+    "onCommand:mdb.connectWithURI",
+    "onCommand:mdb.addConnection",
+    "onCommand:mdb.addConnectionWithURI",
+    "onCommand:mdb.removeConnection",
+    "onView:mongoDB"
   ],
   "main": "./out/extension.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mongodb-js/vscode"
+  },
+  "icon": "images/mongodb.png",
   "contributes": {
     "viewsContainers": {
       "activitybar": [
@@ -26,7 +38,7 @@
     "views": {
       "mongodb": [
         {
-          "id": "MongoDB",
+          "id": "mongoDB",
           "name": "MongoDB",
           "when": "config.mdb.show == true"
         }
@@ -34,10 +46,36 @@
     },
     "commands": [
       {
-        "command": "extension.helloWorld",
-        "title": "Hello World"
+        "command": "mdb.connect",
+        "title": "MongoDB: Connect"
+      },
+      {
+        "command": "mdb.connectWithURI",
+        "title": "MongoDB: Connect with Connection String..."
+      },
+      {
+        "command": "mdb.addConnection",
+        "title": "MongoDB: Add Connection"
+      },
+      {
+        "command": "mdb.addConnectionWithURI",
+        "title": "MongoDB: Add Connection by Connection String..."
+      },
+      {
+        "command": "mdb.removeConnection",
+        "title": "MongoDB: Remove Connection..."
       }
-    ]
+    ],
+    "configuration": {
+      "title": "MongoDB",
+      "properties": {
+        "mdb.show": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show or hide the MongoDB view."
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,10 @@
       {
         "command": "mdb.removeConnection",
         "title": "MongoDB: Remove Connection..."
+      },
+      {
+        "command": "mdb.launchShell",
+        "title": "MongoDB: Launch Mongo Shell"
       }
     ],
     "configuration": {

--- a/src/commands/README.md
+++ b/src/commands/README.md
@@ -1,34 +1,57 @@
+# Extension Commands
 
-All defined in `package.json`, registered from `extension.ts` to handlers defined in this directory. From skunkworks, commands looked like below. Think RPC handlers.
+This README contains a list of all of the commands the extension handles.
 
+These commands are defined in `package.json`, registered from `extension.ts` to
+handlers defined in this directory.
+Think RPC handlers.
+
+## Connection commands
 - `onCommand:mdb.connect`
+- `onCommand:mdb.connectWithURI`
 - `onCommand:mdb.addConnection`
+- `onCommand:mdb.addConnectionWithURI`
 - `onCommand:mdb.removeConnection`
+- `onCommand:mdb.reload`
+- `onCommand:mdb.refresh`
+
+## General database commands
 - `onCommand:mdb.createDatabase`
 - `onCommand:mdb.dropDatabase`
 - `onCommand:mdb.createCollection`
 - `onCommand:mdb.dropCollection`
-- `onCommand:mdb.dropCollection`
-- `onCommand:mdb.import`
-- `onCommand:mdb.cancelImport`
-- `onCommand:mdb.export`
-- `onCommand:mdb.cancelExport`
+
 - `onCommand:mdb.createDocument`
 - `onCommand:mdb.removeDocument`
 - `onCommand:mdb.updateDocument`
+
+- `onCommand:mdb.launchMongoShell`
+
+## Query commands (json input fields)
 - `onCommand:mdb.aggregate`
 - `onCommand:mdb.explainAggregate`
 - `onCommand:mdb.find`
 - `onCommand:mdb.findOne`
 - `onCommand:mdb.findBy", // -> pick(value) -> pick(key) -> sho`
-- `onCommand:mdb.explain`
-- `onCommand:mdb.getMore`
-- `onCommand:mdb.reload`
-- `onCommand:mdb.refresh`
+- `onCommand:mdb.explain` *Uses the active cursor (only possible after a query)*
+- `onCommand:mdb.getMore` *Uses the active cursor (only possible after a query)*
+
+## Playground commands
 - `onCommand:mdb.playground`
 - `onCommand:mdb.createPlayground`
 - `onCommand:mdb.removePlayground`
 - `onCommand:mdb.runPlaygroundBlock`
 - `onCommand:mdb.runAllPlaygroundBlocks`
-- `onCommand:mdb.openInBrowser`
--
+
+## Index commands
+- `onCommand:mdb.createIndex`
+- `onCommand:mdb.getIndex`
+- `onCommand:mdb.removeIndex`
+
+## Import/Export commands
+- `onCommand:mdb.importDocument`
+
+- `onCommand:mdb.import`
+- `onCommand:mdb.cancelImport`
+- `onCommand:mdb.export`
+- `onCommand:mdb.cancelExport`

--- a/src/commands/README.md
+++ b/src/commands/README.md
@@ -7,51 +7,51 @@ handlers defined in this directory.
 Think RPC handlers.
 
 ## Connection commands
-- `onCommand:mdb.connect`
-- `onCommand:mdb.connectWithURI`
-- `onCommand:mdb.addConnection`
-- `onCommand:mdb.addConnectionWithURI`
-- `onCommand:mdb.removeConnection`
-- `onCommand:mdb.reload`
-- `onCommand:mdb.refresh`
+- `mdb.connect`
+- `mdb.connectWithURI`
+- `mdb.addConnection`
+- `mdb.addConnectionWithURI`
+- `mdb.removeConnection`
+- `mdb.reload`
+- `mdb.refresh`
 
 ## General database commands
-- `onCommand:mdb.createDatabase`
-- `onCommand:mdb.dropDatabase`
-- `onCommand:mdb.createCollection`
-- `onCommand:mdb.dropCollection`
+- `mdb.createDatabase`
+- `mdb.dropDatabase`
+- `mdb.createCollection`
+- `mdb.dropCollection`
 
-- `onCommand:mdb.createDocument`
-- `onCommand:mdb.removeDocument`
-- `onCommand:mdb.updateDocument`
+- `mdb.createDocument`
+- `mdb.removeDocument`
+- `mdb.updateDocument`
 
-- `onCommand:mdb.launchMongoShell`
+- `mdb.launchMongoShell`
 
 ## Query commands (json input fields)
-- `onCommand:mdb.aggregate`
-- `onCommand:mdb.explainAggregate`
-- `onCommand:mdb.find`
-- `onCommand:mdb.findOne`
-- `onCommand:mdb.findBy", // -> pick(value) -> pick(key) -> sho`
-- `onCommand:mdb.explain` *Uses the active cursor (only possible after a query)*
-- `onCommand:mdb.getMore` *Uses the active cursor (only possible after a query)*
+- `mdb.aggregate`
+- `mdb.explainAggregate`
+- `mdb.find`
+- `mdb.findOne`
+- `mdb.findBy`  *-> pick(value) -> pick(key) -> show*
+- `mdb.explain` *Uses the active cursor (only possible after a query)*
+- `mdb.getMore` *Uses the active cursor (only possible after a query)*
 
 ## Playground commands
-- `onCommand:mdb.playground`
-- `onCommand:mdb.createPlayground`
-- `onCommand:mdb.removePlayground`
-- `onCommand:mdb.runPlaygroundBlock`
-- `onCommand:mdb.runAllPlaygroundBlocks`
+- `mdb.playground`
+- `mdb.createPlayground`
+- `mdb.removePlayground`
+- `mdb.runPlaygroundBlock`
+- `mdb.runAllPlaygroundBlocks`
 
 ## Index commands
-- `onCommand:mdb.createIndex`
-- `onCommand:mdb.getIndex`
-- `onCommand:mdb.removeIndex`
+- `mdb.createIndex`
+- `mdb.getIndex`
+- `mdb.removeIndex`
 
 ## Import/Export commands
-- `onCommand:mdb.importDocument`
+- `mdb.importDocument`
 
-- `onCommand:mdb.import`
-- `onCommand:mdb.cancelImport`
-- `onCommand:mdb.export`
-- `onCommand:mdb.cancelExport`
+- `mdb.import`
+- `mdb.cancelImport`
+- `mdb.export`
+- `mdb.cancelExport`

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -3,14 +3,134 @@ import * as vscode from 'vscode';
 import { createLogger } from '../logging';
 const log = createLogger('commands');
 
+
+function getConnectWebviewContent() {
+  return `<!DOCTYPE html>
+  <html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Connect to MongoDB</title>
+    </head>
+    <body>
+      <img src="https://media.giphy.com/media/JIX9t2j0ZTN9S/giphy.gif" width="300" />
+      <h1>MongoDB Connection Details Form</h1>
+      <h2>Also try connecting with URI.</h2>
+    </body>
+  </html>`;
+}
+
+const addMongoDBConnection = (...args: any[]) => {
+  console.log('mdb.connect', args);
+  log.info('mdb.connect command called');
+
+  // Display a message box to the user.
+  vscode.window.showInformationMessage('mdb.connect command run.');
+
+  // TODO: Open connect dialogue web view.
+  // Create and show a new webview
+  const panel = vscode.window.createWebviewPanel(
+    'connectDialogueWebview',
+    'Connect to MongoDB', // Title
+    vscode.ViewColumn.One // Editor column to show the webview panel in.
+  );
+
+  panel.webview.html = getConnectWebviewContent();
+};
+
+const connectWithURI = async (...args: any[]) => {
+  console.log('mdb.connectWithURI', args);
+  log.info('connectWithURI command called');
+
+  const connectionString = await vscode.window.showInputBox({
+    value: '',
+    // valueSelection: [2, 4],
+    placeHolder: 'MongoDB connection string',
+    prompt: 'Enter your connection string (SRV or standard)',
+    validateInput: text => {
+      // TODO: Validate the connection string.
+      // Parse URI - https://github.com/mongodb-js/connection-model or mongosh service model.
+
+      const mockInvalidConnectionString = text.length > 0;
+      return mockInvalidConnectionString ? 'Invalid connection string' : null;
+    }
+  });
+
+  if (!connectionString) {
+    return;
+  }
+
+  // TODO: If the user inputted a valid connection then connect to that uri.
+  // This can be done asynchronously, with a `Status Bar Item` message showing
+  // the state of the connection.
+
+  let mockConnectionError = true;
+  if (mockConnectionError) {
+    vscode.window.showErrorMessage(
+      'Failed to connect'
+    );
+
+    return;
+  }
+
+  vscode.window.showInformationMessage('Successfully created new database connection.');
+};
+
+const removeMongoDBConnection = async () => {
+  console.log('mdb.removeMongoDBConnection');
+  log.info('mdb.removeMongoDBConnection command called');
+
+  const mockConnections = [
+    'example connection 1',
+    'example connection 2',
+    'example connection 3'
+  ];
+
+  if (mockConnections.length === 0) {
+    // No active connection(s) to remove.
+    vscode.window.showWarningMessage('There are currently no active connections to remove.', {
+      modal: true
+    });
+
+    return;
+  }
+
+  let connectionToRemove;
+  if (mockConnections.length === 1) {
+    connectionToRemove = mockConnections[0];
+  } else {
+    // More than 1 possible connection to remove.
+    connectionToRemove = await vscode.window.showQuickPick(mockConnections, {
+      placeHolder: 'Choose a connection to remove...'
+    });
+  }
+
+  if (connectionToRemove) {
+    const removeConfirmationResponse = await vscode.window.showInformationMessage(
+      `Are you sure to want to remove connection ${connectionToRemove}?`,
+      { modal: true },
+      'Yes'
+    );
+
+    if (removeConfirmationResponse === 'Yes') {
+      // TODO: Disconnect from the chosen connection.
+      vscode.window.showInformationMessage('MongoDB connection removed.');
+    }
+  }
+};
+
 const registerCommands = (context: vscode.ExtensionContext) => {
   console.group('registerCommands');
 
   console.log('context', context);
-  vscode.commands.registerCommand('mdb.connect', (...args) => {
-    console.log('connect', args);
-    log.info('connect command called');
-  });
+
+  vscode.commands.registerCommand('mdb.connect', addMongoDBConnection);
+  vscode.commands.registerCommand('mdb.addConnection', addMongoDBConnection);
+
+  vscode.commands.registerCommand('mdb.connectWithURI', connectWithURI);
+  vscode.commands.registerCommand('mdb.addConnectionWithURI', connectWithURI);
+
+  vscode.commands.registerCommand('mdb.removeConnection', removeMongoDBConnection);
 
   console.groupEnd();
 };

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -119,10 +119,14 @@ const removeMongoDBConnection = async () => {
   }
 };
 
+function launchMongoShell() {
+  const mongoShell = vscode.window.createTerminal('Mongo Shell');
+  mongoShell.sendText('mongo');
+  mongoShell.show();
+}
+
 const registerCommands = (context: vscode.ExtensionContext) => {
   console.group('registerCommands');
-
-  console.log('context', context);
 
   vscode.commands.registerCommand('mdb.connect', addMongoDBConnection);
   vscode.commands.registerCommand('mdb.addConnection', addMongoDBConnection);
@@ -132,7 +136,9 @@ const registerCommands = (context: vscode.ExtensionContext) => {
 
   vscode.commands.registerCommand('mdb.removeConnection', removeMongoDBConnection);
 
+  vscode.commands.registerCommand('mdb.launchShell', launchMongoShell);
+
   console.groupEnd();
 };
 
-export { registerCommands };
+export { launchMongoShell, registerCommands };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,32 +8,21 @@ import { activate as createExplorerView } from './explorer';
 // TODO: lucas: Future usage: shared state for across modules. Maybe. If needed. ;)
 import { mdb } from './mdb';
 
-// this method is called when your extension is activated
-// your extension is activated the very first time the command is executed
+// Called when our extension is activated.
+// See "activationEvents" in `package.json` for the events that cause activation.
 export function activate(context: vscode.ExtensionContext) {
-  createExplorerView(context);
-  registerCommands(context);
+    createExplorerView(context);
 
-  // <--- boilerplate below
-  // Use the console to output diagnostic information (console.log) and errors (console.error)
-  // This line of code will only be executed once when your extension is activated
-  console.log('Congratulations, your extension "mongodb" is now active!');
+    // Register our extension's commands. These are the event handlers and control
+    // the functionality of our extension.
+    registerCommands(context);
 
-  // The command has been defined in the package.json file
-  // Now provide the implementation of the command with registerCommand
-  // The commandId parameter must match the command field in package.json
-  let disposable = vscode.commands.registerCommand(
-    'extension.helloWorld',
-    () => {
-      // The code you place here will be executed every time your command is executed
+    // TODO: Connect to any existing database connections.
 
-      // Display a message box to the user
-      vscode.window.showInformationMessage('Hello World!');
-    }
-  );
-
-  context.subscriptions.push(disposable);
+    console.log('Congratulations, your extension "mongodb" is now active!');
 }
 
-// this method is called when your extension is deactivated
-export function deactivate() {}
+// Called when our extension is deactivated.
+export function deactivate() {
+    // TODO: Close all active connections & end active queries/playgrounds.
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,18 +11,18 @@ import { mdb } from './mdb';
 // Called when our extension is activated.
 // See "activationEvents" in `package.json` for the events that cause activation.
 export function activate(context: vscode.ExtensionContext) {
-    createExplorerView(context);
+  createExplorerView(context);
 
-    // Register our extension's commands. These are the event handlers and control
-    // the functionality of our extension.
-    registerCommands(context);
+  // Register our extension's commands. These are the event handlers and control
+  // the functionality of our extension.
+  registerCommands(context);
 
-    // TODO: Connect to any existing database connections.
+  // TODO: Resume the context we were in when we last closed (re-open live connections).
 
-    console.log('Congratulations, your extension "mongodb" is now active!');
+  console.log('Congratulations, your extension "mongodb" is now active!');
 }
 
 // Called when our extension is deactivated.
 export function deactivate() {
-    // TODO: Close all active connections & end active queries/playgrounds.
+  // TODO: Close all active connections & end active queries/playgrounds.
 }

--- a/src/mdb.ts
+++ b/src/mdb.ts
@@ -7,11 +7,6 @@ import * as vscode from 'vscode';
 
 export namespace mdb {
   /**
-   * Set on extension.activate()
-   */
-  export let context: vscode.ExtensionContext;
-
-  /**
    * https://github.com/microsoft/vscode-extension-samples/tree/master/tree-view-sample
    */
   export let treeDataProvider: any;

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -3,21 +3,21 @@ import * as path from 'path';
 import { runTests } from 'vscode-test';
 
 async function main() {
-	try {
-		// The folder containing the Extension Manifest package.json
-		// Passed to `--extensionDevelopmentPath`
-		const extensionDevelopmentPath = path.resolve(__dirname, '../../');
+  try {
+    // The folder containing the Extension Manifest package.json
+    // Passed to `--extensionDevelopmentPath`
+    const extensionDevelopmentPath = path.resolve(__dirname, '../../');
 
-		// The path to test runner
-		// Passed to --extensionTestsPath
-		const extensionTestsPath = path.resolve(__dirname, './suite/index');
+    // The path to test runner
+    // Passed to --extensionTestsPath
+    const extensionTestsPath = path.resolve(__dirname, './suite/index');
 
-		// Download VS Code, unzip it and run the integration test
-		await runTests({ extensionDevelopmentPath, extensionTestsPath });
-	} catch (err) {
-		console.error('Failed to run tests');
-		process.exit(1);
-	}
+    // Download VS Code, unzip it and run the integration test
+    await runTests({ extensionDevelopmentPath, extensionTestsPath });
+  } catch (err) {
+    console.error('Failed to run tests');
+    process.exit(1);
+  }
 }
 
 main();

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -7,52 +7,52 @@ import { registerCommands, launchMongoShell } from '../../commands';
 import { TestExtensionContext } from './stubs';
 
 suite('Extension Test Suite', () => {
-	vscode.window.showInformationMessage('Starting tests...');
+  vscode.window.showInformationMessage('Starting tests...');
 
-	let disposables: vscode.Disposable[] = [];
+  let disposables: vscode.Disposable[] = [];
 
-	teardown(() => {
-		disposables.forEach(d => d.dispose());
-		disposables.length = 0;
-	});
+  teardown(() => {
+    disposables.forEach(d => d.dispose());
+    disposables.length = 0;
+  });
 
-	test('commands are registered in vscode', done => {
-		const mockExtensionContext = new TestExtensionContext();
+  test('commands are registered in vscode', done => {
+    const mockExtensionContext = new TestExtensionContext();
 
-		registerCommands(mockExtensionContext);
+    registerCommands(mockExtensionContext);
 
-		vscode.commands.getCommands().then(registeredCommands => {
-			const expectedCommands = [
-				'mdb.connect',
-				'mdb.addConnection',
-				'mdb.connectWithURI',
-				'mdb.addConnectionWithURI',
-				'mdb.removeConnection',
-				'mdb.launchShell'
-			];
+    vscode.commands.getCommands().then(registeredCommands => {
+      const expectedCommands = [
+        'mdb.connect',
+        'mdb.addConnection',
+        'mdb.connectWithURI',
+        'mdb.addConnectionWithURI',
+        'mdb.removeConnection',
+        'mdb.launchShell'
+      ];
 
-			for (let i = 0; i < expectedCommands.length; i++) {
-				try {
-					assert.notEqual(
-						registeredCommands.indexOf(expectedCommands[i]),
-						-1,
-						`command ${expectedCommands[i]} not registered and was expected`
-					);
-				} catch (e) {
-					done(e);
-					return;
-				}
-			}
+      for (let i = 0; i < expectedCommands.length; i++) {
+        try {
+          assert.notEqual(
+            registeredCommands.indexOf(expectedCommands[i]),
+            -1,
+            `command ${expectedCommands[i]} not registered and was expected`
+          );
+        } catch (e) {
+          done(e);
+          return;
+        }
+      }
 
-			done();
-		});
-	});
+      done();
+    });
+  });
 
-	test('launchMongoShell should open a terminal', done => {
-		disposables.push(vscode.window.onDidOpenTerminal(() => {
-			done();
-		}));
+  test('launchMongoShell should open a terminal', done => {
+    disposables.push(vscode.window.onDidOpenTerminal(() => {
+      done();
+    }));
 
-		launchMongoShell();
-	});
+    launchMongoShell();
+  });
 });

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -7,18 +7,13 @@ import { registerCommands, launchMongoShell } from '../../commands';
 import { TestExtensionContext } from './stubs';
 
 suite('Extension Test Suite', () => {
-	vscode.window.showInformationMessage('Start all tests.');
+	vscode.window.showInformationMessage('Starting tests...');
 
 	let disposables: vscode.Disposable[] = [];
 
 	teardown(() => {
 		disposables.forEach(d => d.dispose());
 		disposables.length = 0;
-	});
-
-	test('Sample test', () => {
-		assert.equal(-1, [1, 2, 3].indexOf(5));
-		assert.equal(-1, [1, 2, 3].indexOf(0));
 	});
 
 	test('commands are registered in vscode', done => {

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -3,35 +3,35 @@ import * as Mocha from 'mocha';
 import * as glob from 'glob';
 
 export function run(): Promise<void> {
-	// Create the mocha test
-	const mocha = new Mocha({
-		ui: 'tdd',
-	});
-	mocha.useColors(true);
+  // Create the mocha test
+  const mocha = new Mocha({
+    ui: 'tdd',
+  });
+  mocha.useColors(true);
 
-	const testsRoot = path.resolve(__dirname, '..');
+  const testsRoot = path.resolve(__dirname, '..');
 
-	return new Promise((c, e) => {
-		glob('**/**.test.js', { cwd: testsRoot }, (err, files) => {
-			if (err) {
-				return e(err);
-			}
+  return new Promise((c, e) => {
+    glob('**/**.test.js', { cwd: testsRoot }, (err, files) => {
+      if (err) {
+        return e(err);
+      }
 
-			// Add files to the test suite
-			files.forEach(f => mocha.addFile(path.resolve(testsRoot, f)));
+      // Add files to the test suite
+      files.forEach(f => mocha.addFile(path.resolve(testsRoot, f)));
 
-			try {
-				// Run the mocha test
-				mocha.run(failures => {
-					if (failures > 0) {
-						e(new Error(`${failures} tests failed.`));
-					} else {
-						c();
-					}
-				});
-			} catch (err) {
-				e(err);
-			}
-		});
-	});
+      try {
+        // Run the mocha test
+        mocha.run(failures => {
+          if (failures > 0) {
+            e(new Error(`${failures} tests failed.`));
+          } else {
+            c();
+          }
+        });
+      } catch (err) {
+        e(err);
+      }
+    });
+  });
 }

--- a/src/test/suite/stubs.ts
+++ b/src/test/suite/stubs.ts
@@ -1,0 +1,38 @@
+import * as vscode from 'vscode';
+
+// Bare mock of the extension context for vscode.
+class TestExtensionContext implements vscode.ExtensionContext {
+  globalStoragePath: string;
+  logPath: string;
+  subscriptions: { dispose(): any }[];
+  workspaceState: vscode.Memento;
+  globalState: vscode.Memento;
+  extensionPath: string;
+  storagePath: string;
+
+  asAbsolutePath(relativePath: string): string {
+    return '';
+  }
+
+  constructor() {
+    this.globalStoragePath = '';
+    this.logPath = '';
+    this.subscriptions = [];
+    this.workspaceState = {
+      get: () => { },
+      update: (key: string, value: any) => {
+        return new Promise(() => { });
+      }
+    };
+    this.globalState = {
+      get: () => { },
+      update: (key: string, value: any) => {
+        return new Promise(() => { });
+      }
+    };
+    this.extensionPath = '';
+    this.storagePath = '';
+  }
+}
+
+export { TestExtensionContext };

--- a/tslint.json
+++ b/tslint.json
@@ -9,7 +9,12 @@
 			true,
 			"always"
 		],
-		"triple-equals": true
+		"triple-equals": true,
+		"indent": [
+			true,
+			"spaces",
+			2
+		]
 	},
 	"defaultSeverity": "warning"
 }


### PR DESCRIPTION
https://jira.mongodb.org/browse/VSCODE-16

This PR adds the command handling for the following commands:
- `mdb.connect`
- `mdb.addConnection`
- `mdb.connectWithURI`
- `mdb.addConnectionWithURI`
- `mdb.removeConnection`
- `mdb.launchMongoShell`
They don't yet talk to mongo, that's coming in [VSCODE-12](https://jira.mongodb.org/browse/VSCODE-12). We're just doing some basic handling here and dialogue windows.

I also cleaned up the commands listed in the [commands README](https://github.com/mongodb-js/vscode/blob/VSCODE-16/initial-command-definition/src/commands/README.md) so we can use that as more of a solid resource for which commands we'll handle going forward. I opted not to add stubs for not yet implemented commands just yet to keep things a little more readable.

Adding/removing a connection:
![Screen Shot 2020-01-30 at 3 23 19 PM](https://user-images.githubusercontent.com/1791149/73457856-9dbe8e80-4374-11ea-8a83-441371312eee.png)
![Screen Shot 2020-01-30 at 3 24 15 PM](https://user-images.githubusercontent.com/1791149/73457855-9dbe8e80-4374-11ea-804f-0d131dd16433.png)
![Screen Shot 2020-01-30 at 3 24 26 PM](https://user-images.githubusercontent.com/1791149/73471234-4bd43380-4389-11ea-9372-32bc17ac6e69.png)

Opening mongo shell `mdb.launchMongoShell`:
![Screen Shot 2020-01-30 at 5 52 29 PM](https://user-images.githubusercontent.com/1791149/73471650-0401dc00-438a-11ea-9ce9-72fc185f4645.png)