### PR TITLE
Launch shell connected to active connection

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,25 +27,20 @@
   "icon": "images/mongodb.png",
   "contributes": {
     "viewsContainers": {
-      "activitybar": [
-        {
-          "id": "mongoDB",
-          "title": "MongoDB",
-          "icon": "images/mongodb.svg"
-        }
-      ]
+      "activitybar": [{
+        "id": "mongoDB",
+        "title": "MongoDB",
+        "icon": "images/mongodb.svg"
+      }]
     },
     "views": {
-      "mongoDB": [
-        {
-          "id": "mongoDB",
-          "name": "MongoDB",
-          "when": "config.mdb.show == true"
-        }
-      ]
+      "mongoDB": [{
+        "id": "mongoDB",
+        "name": "MongoDB",
+        "when": "config.mdb.show == true"
+      }]
     },
-    "commands": [
-      {
+    "commands": [{
         "command": "mdb.connect",
         "title": "MongoDB: Connect"
       },
@@ -73,6 +68,16 @@
           "type": "boolean",
           "default": true,
           "description": "Show or hide the MongoDB view."
+        },
+        "mdb.shell": {
+          "type": "string",
+          "enum": ["mongo", "mongosh"],
+          "enumDescriptions": [
+            "Use the legacy mongosh",
+            "Use the new mongosh"
+          ],
+          "default": "mongo",
+          "description": "The mongodb shell to use"
         }
       }
     }

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -35,6 +35,7 @@ export default class ConnectionController {
   } = {};
 
   private _currentConnection: any;
+  private _currentConnectionConfig: any;
   private _currentConnectionInstanceId: string | null = null;
 
   private _connecting: boolean = false;
@@ -163,6 +164,7 @@ export default class ConnectionController {
           this._connectionConfigs[instanceId] = (connectionConfig);
         }
         this._currentConnectionInstanceId = instanceId;
+        this._currentConnectionConfig = connectionConfig;
         this._currentConnection = newConnection;
         this._connecting = false;
 
@@ -301,6 +303,9 @@ export default class ConnectionController {
   }
   public getActiveConnection() {
     return this._currentConnection;
+  }
+  public getActiveConnectionConfig() {
+    return this._currentConnectionConfig;
   }
   public setActiveConnection(newActiveConnection: any) {
     this._currentConnection = newActiveConnection;

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -45,7 +45,7 @@ export default class MDBExtensionController implements vscode.Disposable {
     vscode.commands.registerCommand('mdb.disconnect', () => this._connectionController.disconnect());
     vscode.commands.registerCommand('mdb.removeConnection', () => this._connectionController.removeMongoDBConnection());
 
-    vscode.commands.registerCommand('mdb.openMongoDBShell', this.openMongoDBShell);
+    vscode.commands.registerCommand('mdb.openMongoDBShell', () => this.openMongoDBShell());
 
     vscode.commands.registerCommand('mdb.refresh', () => this._explorerController.refresh());
     vscode.commands.registerCommand('mdb.reload', () => this._explorerController.refresh());
@@ -56,8 +56,14 @@ export default class MDBExtensionController implements vscode.Disposable {
   }
 
   public openMongoDBShell() {
-    const mongoDBShell = vscode.window.createTerminal('MongoDB Shell');
-    mongoDBShell.sendText('mongo');
+    let mdbConnectionString;
+    if (this._connectionController) {
+      const activeConnectionConfig = this._connectionController.getActiveConnectionConfig();
+      mdbConnectionString = activeConnectionConfig ? activeConnectionConfig.driverUrl : '';
+    }
+    const mongoDBShell = vscode.window.createTerminal({ name: 'MongoDB Shell', env: { MDB_CONNECTION_STRING: mdbConnectionString } });
+    const shellCommand = vscode.workspace.getConfiguration('mdb').get('shell');
+    mongoDBShell.sendText(`${shellCommand} $MDB_CONNECTION_STRING`);
     mongoDBShell.show();
   }
 


### PR DESCRIPTION
* Env variable hack to launch a shell that is connected
to the same cluster the extension is already connected to.
* Configuration to select what shell to use (mongo or mongosh)