### PR TITLE
VSCODE-35: Set correct client metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mongodb",
+  "name": "mongodb-vscode",
   "displayName": "MongoDB",
   "description": "MongoDB for Visual Studio Code",
   "version": "0.0.1",

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -116,7 +116,7 @@ export default class ConnectionController {
           return reject('Failed to connect: connection already exists.');
         }
 
-        //Override default `appname`
+        // Override default `appname`
         newConnectionConfig.appname = `${name} ${version}`;
 
         this.connect(newConnectionConfig).then(resolve, reject);

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -1,5 +1,6 @@
 const Connection = require('mongodb-connection-model');
 const DataService = require('mongodb-data-service');
+const { name, version } = require('../package.json');
 import * as vscode from 'vscode';
 
 import { createLogger } from './logging';
@@ -114,6 +115,9 @@ export default class ConnectionController {
         if (this._connectionConfigs[instanceId]) {
           return reject('Failed to connect: connection already exists.');
         }
+
+        //Override default `appname`
+        newConnectionConfig.appname = `${name} ${version}`;
 
         this.connect(newConnectionConfig).then(resolve, reject);
       });


### PR DESCRIPTION
## Description

As the extension is using Compass' connection model and data service, the client metadata was set to `MongoDB Compass` by default.

With this change we set it with name + version from `package.json`.

Also, changed the name in package.json to `mongodb-vscode` as it makes it more npm-searchable.