### PR TITLE
VSCODE-31: escape dollars in comments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "mongodb",
+  "name": "mongodb-vscode",
   "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/src/scripts/get-snippets.ts
+++ b/src/scripts/get-snippets.ts
@@ -12,12 +12,16 @@ const snippetTemplate = (
   comment?: string
 ): { prefix: string; body: Array<string>; description: string } => {
   const body = snippet.split('\n');
+  const find = /[$]/;
+  const re = new RegExp(find, 'g');
 
   body[0] = `\\${prefix}: ${body[0]}`;
 
   return {
     prefix,
-    body: comment ? [...comment.split('\n'), ...body] : [...body],
+    body: comment
+      ? [...comment.replace(re, '\\$').split('\n'), ...body]
+      : [...body],
     description
   };
 };

--- a/src/scripts/get-snippets.ts
+++ b/src/scripts/get-snippets.ts
@@ -5,25 +5,43 @@ const STAGE_OPERATORS = require('mongodb-ace-autocompleter').STAGE_OPERATORS;
 const config = require(path.resolve(__dirname, '../../package.json'));
 const SNIPPETS_DIR = path.resolve(__dirname, '../../src/snippets/');
 
+/**
+ * Transforms `mongodb-ace-autocompleter` snippets
+ * into the vscode snippets.
+ *
+ * @param {String} prefix - The stage operator.
+ * @param {String} description - The stage description.
+ * @param {String} snippet - The stage snippet.
+ * @param {String} comment - The optional comment.
+ *
+ * @returns {String} - The vscode snippet.
+ */
 const snippetTemplate = (
   prefix: string,
   description: string,
   snippet: string,
   comment?: string
 ): { prefix: string; body: Array<string>; description: string } => {
-  const body = snippet.split('\n');
   const find = /[$]/;
   const re = new RegExp(find, 'g');
+  let body = snippet.split('\n');
 
+  // The `mongodb-ace-autocompleter` stores the stage prefix separately
+  // from the stage body. In vscode extension we want to autopopulate
+  // the body together with the prefix.
+  // We also need to escape the `$` symbol in prefix.
   body[0] = `\\${prefix}: ${body[0]}`;
 
-  return {
-    prefix,
-    body: comment
-      ? [...comment.replace(re, '\\$').split('\n'), ...body]
-      : [...body],
-    description
-  };
+  // The stage comments are also stored separately
+  // and might contain the `$` symbol
+  // that is being interpreted by vscode as variable name,
+  // but the variable is not known.
+  // The solution is to escape this symbol before building the stage body.
+  body = comment
+    ? [...comment.replace(re, '\\$').split('\n'), ...body]
+    : [...body];
+
+  return { prefix, body, description };
 };
 
 const snippets = STAGE_OPERATORS.reduce(
@@ -48,8 +66,10 @@ const snippets = STAGE_OPERATORS.reduce(
   {}
 );
 
+// Create the `snippets` folder.
 fs.mkdir(SNIPPETS_DIR, (mkdirError: any) => {
   if (!mkdirError || (mkdirError && mkdirError.code === 'EEXIST')) {
+    // Create the `stage-autocompleter.json` file with the vscode snippets.
     fs.writeFile(
       `${SNIPPETS_DIR}/stage-autocompleter.json`,
       JSON.stringify(snippets, null, 2),
@@ -68,6 +88,9 @@ fs.mkdir(SNIPPETS_DIR, (mkdirError: any) => {
 
         const readme = `Generated from mongodb-ace-autocompleter@${config.devDependencies['mongodb-ace-autocompleter']}`;
 
+        // Create the `README.md` file to inform the user of the extension
+        // that the `stage-autocompleter.json` is being generated automatically.
+        // Any manual changes will be overwritten with the next compilation.
         fs.writeFile(
           `${SNIPPETS_DIR}/README.md`,
           readme,
@@ -86,6 +109,6 @@ fs.mkdir(SNIPPETS_DIR, (mkdirError: any) => {
       }
     );
   } else {
-    return console.log(mkdirError);
+    console.log(mkdirError);
   }
 });

--- a/src/snippets/stage-autocompleter.json
+++ b/src/snippets/stage-autocompleter.json
@@ -271,7 +271,7 @@
     "body": [
       "/**",
       " * expression: Any valid expression that",
-      " *   evaluates to $$DESCEND, $$PRUNE, or $$KEEP.",
+      " *   evaluates to \\$\\$DESCEND, \\$\\$PRUNE, or \\$\\$KEEP.",
       " */",
       "",
       "\\$redact: {",


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
Some agg stages' comments contain `$` symbol that is being interpreted as variable name, but the variable is not known. The solution is to escape this symbol before building the stage body.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
