### PR TITLE
VSCODE-34: Save connection models

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
             "Don't save new connections (connections are lost when the session is closed)."
           ],
           "default": "Workspace",
-          "description": "When the setting to hide the option of choosing where to save new connections is checked, this setting sets where new connections are saved to, or if they are not to be saved."
+          "description": "When the setting that hides the option to choose where to save new connections is checked, this setting sets if and where new connections are saved."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -88,10 +88,25 @@
     "configuration": {
       "title": "MongoDB",
       "properties": {
-        "mdb.show": {
+        "mdb.defaultConnectionSavingLocation": {
+          "type": "string",
+          "enum": [
+            "WORKSPACE",
+            "GLOBAL",
+            "DONT_SAVE"
+          ],
+          "enumDescriptions": [
+            "Save new connections globally on vscode.",
+            "Save new connections to the active workspace.",
+            "Don't save new connections (connections are lost when the session is closed)."
+          ],
+          "default": "WORKSPACE",
+          "description": "When the setting to hide the option of choosing where to save new connections is checked, this setting sets where new connections are saved to, or if they are not to be saved."
+        },
+        "mdb.hideOptionToChooseWhereToSaveNewConnections": {
           "type": "boolean",
-          "default": true,
-          "description": "Show or hide the MongoDB view."
+          "default": false,
+          "description": "When a connection is added, a prompt is shown that let's the user decide where the new connection should be saved. When this setting is checked, the prompt is not shown and the default connection saving location setting is used."
         },
         "mdb.shell": {
           "type": "string",
@@ -105,6 +120,11 @@
           ],
           "default": "mongo",
           "description": "The mongodb shell to use"
+        },
+        "mdb.show": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show or hide the MongoDB view."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -88,26 +88,6 @@
     "configuration": {
       "title": "MongoDB",
       "properties": {
-        "mdb.defaultConnectionSavingLocation": {
-          "type": "string",
-          "enum": [
-            "Workspace",
-            "Global",
-            "Session Only"
-          ],
-          "enumDescriptions": [
-            "Save new connections globally on vscode.",
-            "Save new connections to the active workspace.",
-            "Don't save new connections (connections are lost when the session is closed)."
-          ],
-          "default": "Global",
-          "description": "When the setting to hide the option of choosing where to save new connections is checked, this setting sets where new connections are saved to, or if they are not to be saved."
-        },
-        "mdb.hideOptionToChooseWhereToSaveNewConnections": {
-          "type": "boolean",
-          "default": false,
-          "description": "When a connection is added, a prompt is shown that let's the user decide where the new connection should be saved. When this setting is checked, the prompt is not shown and the default connection saving location setting is used."
-        },
         "mdb.shell": {
           "type": "string",
           "enum": [
@@ -125,6 +105,26 @@
           "type": "boolean",
           "default": true,
           "description": "Show or hide the MongoDB view."
+        },
+        "mdb.connectionSaving.hideOptionToChooseWhereToSaveNewConnections": {
+          "type": "boolean",
+          "default": false,
+          "description": "When a connection is added, a prompt is shown that let's the user decide where the new connection should be saved. When this setting is checked, the prompt is not shown and the default connection saving location setting is used."
+        },
+        "mdb.connectionSaving.defaultConnectionSavingLocation": {
+          "type": "string",
+          "enum": [
+            "Workspace",
+            "Global",
+            "Session Only"
+          ],
+          "enumDescriptions": [
+            "Save new connections globally on vscode.",
+            "Save new connections to the active workspace.",
+            "Don't save new connections (connections are lost when the session is closed)."
+          ],
+          "default": "Workspace",
+          "description": "When the setting to hide the option of choosing where to save new connections is checked, this setting sets where new connections are saved to, or if they are not to be saved."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -91,16 +91,16 @@
         "mdb.defaultConnectionSavingLocation": {
           "type": "string",
           "enum": [
-            "WORKSPACE",
-            "GLOBAL",
-            "DONT_SAVE"
+            "Workspace",
+            "Global",
+            "Session Only"
           ],
           "enumDescriptions": [
             "Save new connections globally on vscode.",
             "Save new connections to the active workspace.",
             "Don't save new connections (connections are lost when the session is closed)."
           ],
-          "default": "WORKSPACE",
+          "default": "Global",
           "description": "When the setting to hide the option of choosing where to save new connections is checked, this setting sets where new connections are saved to, or if they are not to be saved."
         },
         "mdb.hideOptionToChooseWhereToSaveNewConnections": {
@@ -135,9 +135,9 @@
     "lint": "./node_modules/.bin/eslint ./src/**/*.ts",
     "compile": "ts-node ./src/scripts/get-snippets.ts && tsc -p ./",
     "watch": "tsc -watch -p ./",
-    "pretest": "npm run compile && mongodb-runner start",
+    "pretest": "npm run compile && mongodb-runner start --port=27018",
     "test": "node ./out/test/runTest.js",
-    "posttest": "mongodb-runner stop",
+    "posttest": "mongodb-runner stop --port=27018",
     "vscode:prepublish": "npm run compile",
     "check": "mongodb-js-precommit './src/**/*{.ts}'"
   },

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -260,6 +260,13 @@ export default class ConnectionController {
     });
   }
 
+  public removeConnectionConfig(connectionId: string) {
+    delete this._connectionConfigs[connectionId];
+    this._storageController.removeConnection(connectionId);
+
+    this.eventEmitter.emit(DataServiceEventTypes.CONNECTIONS_DID_CHANGE);
+  }
+
   public async removeMongoDBConnection(): Promise<boolean> {
     log.info('mdb.removeMongoDBConnection command called');
 
@@ -311,7 +318,8 @@ export default class ConnectionController {
       await this.disconnect();
     }
 
-    delete this._connectionConfigs[connectionToRemove];
+    this.removeConnectionConfig(connectionToRemove);
+
     vscode.window.showInformationMessage('MongoDB connection removed.');
     return Promise.resolve(true);
   }

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -4,6 +4,7 @@ import { createLogger } from './logging';
 import { StatusView } from './views';
 import { EventEmitter } from 'events';
 import { StorageController, StorageVariables } from './storage';
+import { StorageScope } from './storage/storageController';
 
 const Connection = require('mongodb-connection-model');
 const DataService = require('mongodb-data-service');
@@ -58,7 +59,8 @@ export default class ConnectionController {
   activate(): void {
     // Pull in existing connections from storage.
     const existingGlobalConnectionModels = this._storageController.get(StorageVariables.GLOBAL_CONNECTION_MODELS) || {};
-    const existingWorkspaceConnectionModels = this._storageController.get(StorageVariables.GLOBAL_CONNECTION_MODELS) || {};
+    const existingWorkspaceConnectionModels = this._storageController.get(StorageVariables.WORKSPACE_CONNECTION_MODELS, StorageScope.WORKSPACE) || {};
+
     this._connectionConfigs = {
       ...existingGlobalConnectionModels,
       ...existingWorkspaceConnectionModels

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 import { createLogger } from './logging';
 import { StatusView } from './views';
 import { EventEmitter } from 'events';
+import { StorageController, StorageVariables } from './storage';
 
 const Connection = require('mongodb-connection-model');
 const DataService = require('mongodb-data-service');
@@ -44,12 +45,20 @@ export default class ConnectionController {
   private _disconnecting = false;
 
   private _statusView: StatusView;
+  private _storageController: StorageController;
 
   // Used by other parts of the extension that respond to changes in the connections.
   private eventEmitter: EventEmitter = new EventEmitter();
 
-  constructor(_statusView: StatusView) {
+  constructor(_statusView: StatusView, storageController: StorageController) {
     this._statusView = _statusView;
+    this._storageController = storageController;
+  }
+
+  activate(): void {
+    // Pull in existing connections from storage.
+    const existingConnectionModels = this._storageController.get(StorageVariables.CONNECTION_MODELS);
+    this._connectionConfigs = existingConnectionModels || {};
   }
 
   public addMongoDBConnection(): Promise<boolean> {

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -75,6 +75,7 @@ export default class ConnectionController {
           loadedGlobalConnectionConfig.appname = `${name} ${version}`;
 
           this._connectionConfigs[connectionId] = loadedGlobalConnectionConfig;
+          this.eventEmitter.emit(DataServiceEventTypes.CONNECTIONS_DID_CHANGE);
         });
       });
     }
@@ -97,12 +98,9 @@ export default class ConnectionController {
           loadedWorkspaceConnectionConfig.appname = `${name} ${version}`;
 
           this._connectionConfigs[connectionId] = loadedWorkspaceConnectionConfig;
+          this.eventEmitter.emit(DataServiceEventTypes.CONNECTIONS_DID_CHANGE);
         });
       });
-    }
-
-    if (Object.keys(this._connectionConfigs).length > 0) {
-      this.eventEmitter.emit(DataServiceEventTypes.CONNECTIONS_DID_CHANGE);
     }
   }
 

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -42,7 +42,7 @@ export default class ConnectionController {
   private _currentConnectionInstanceId: string | null = null;
 
   private _connecting = false;
-  private _connectingInstanceId = '';
+  private _connectingInstanceId: string | null = null;
   private _disconnecting = false;
 
   private _statusView: StatusView;
@@ -260,7 +260,7 @@ export default class ConnectionController {
     });
   }
 
-  public removeConnectionConfig(connectionId: string) {
+  public removeConnectionConfig(connectionId: string): void {
     delete this._connectionConfigs[connectionId];
     this._storageController.removeConnection(connectionId);
 
@@ -328,33 +328,33 @@ export default class ConnectionController {
     return Object.keys(this._connectionConfigs);
   }
 
-  public getActiveConnectionInstanceId(): any {
+  public getActiveConnectionInstanceId(): string | null {
     return this._currentConnectionInstanceId;
   }
 
   public addEventListener(
     eventType: DataServiceEventTypes,
     listener: () => void
-  ): any {
+  ): void {
     this.eventEmitter.addListener(eventType, listener);
   }
 
   public removeEventListener(
     eventType: DataServiceEventTypes,
     listener: () => void
-  ): any {
+  ): void {
     this.eventEmitter.removeListener(eventType, listener);
   }
 
-  public isConnnecting(): any {
+  public isConnnecting(): boolean {
     return this._connecting;
   }
 
-  public isDisconnecting(): any {
+  public isDisconnecting(): boolean {
     return this._disconnecting;
   }
 
-  public getConnectingInstanceId(): any {
+  public getConnectingInstanceId(): string | null {
     return this._connectingInstanceId;
   }
 
@@ -368,16 +368,16 @@ export default class ConnectionController {
   public getActiveConnectionConfig(): any {
     return this._currentConnectionConfig;
   }
-  public setActiveConnection(newActiveConnection: any): any {
+  public setActiveConnection(newActiveConnection: any): void {
     this._currentConnection = newActiveConnection;
   }
-  public setConnnecting(connecting: boolean): any {
+  public setConnnecting(connecting: boolean): void {
     this._connecting = connecting;
   }
-  public setConnnectingInstanceId(connectingInstanceId: string): any {
+  public setConnnectingInstanceId(connectingInstanceId: string): void {
     this._connectingInstanceId = connectingInstanceId;
   }
-  public setDisconnecting(disconnecting: boolean): any {
+  public setDisconnecting(disconnecting: boolean): void {
     this._disconnecting = disconnecting;
   }
 }

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -58,15 +58,17 @@ export default class ConnectionController {
 
   activate(): void {
     // Load saved connections from storage.
-    const existingGlobalConnectionStrings = this._storageController.get(StorageVariables.GLOBAL_CONNECTION_STRINGS) || {};
-    if (existingGlobalConnectionStrings && Object.keys(existingGlobalConnectionStrings).length > 0) {
+    const existingGlobalConnectionStrings = this._storageController.get(
+      StorageVariables.GLOBAL_CONNECTION_STRINGS
+    ) || {};
+    if (Object.keys(existingGlobalConnectionStrings).length > 0) {
       // Try to pull in the previous connections. We are open to failing here
       // in case the old connection has been corrupted or is no longer supported.
       Object.keys(existingGlobalConnectionStrings).forEach(connectionId => {
         Connection.from(existingGlobalConnectionStrings[connectionId], (err, loadedGlobalConnectionConfig) => {
           if (err) {
-            // Here we silently fail.
-            // This may mean a connection has been corrupted or is no longer supported.
+            // This may indicate a connection has been corrupted or is no longer supported.
+            return;
           }
 
           // Override the default connection `appname`.
@@ -77,15 +79,18 @@ export default class ConnectionController {
       });
     }
 
-    const existingWorkspaceConnectionStrings = this._storageController.get(StorageVariables.WORKSPACE_CONNECTION_STRINGS, StorageScope.WORKSPACE) || {};
-    if (existingWorkspaceConnectionStrings && Object.keys(existingWorkspaceConnectionStrings).length > 0) {
+    const existingWorkspaceConnectionStrings = this._storageController.get(
+      StorageVariables.WORKSPACE_CONNECTION_STRINGS,
+      StorageScope.WORKSPACE
+    ) || {};
+    if (Object.keys(existingWorkspaceConnectionStrings).length > 0) {
       // Try to pull in the previous connections. We are open to failing here
       // in case the old connection has been corrupted or is no longer supported.
       Object.keys(existingWorkspaceConnectionStrings).forEach(connectionId => {
         Connection.from(existingWorkspaceConnectionStrings[connectionId], (err, loadedWorkspaceConnectionConfig) => {
           if (err) {
-            // Here we silently fail.
-            // This may mean a connection has been corrupted or is no longer supported.
+            // This may indicate a connection has been corrupted or is no longer supported.
+            return;
           }
 
           // Override the default connection `appname`.

--- a/src/explorer/mdbConnectionsTreeItem.ts
+++ b/src/explorer/mdbConnectionsTreeItem.ts
@@ -75,7 +75,9 @@ export default class ExplorerRootTreeItem extends vscode.TreeItem
     });
 
     if (this._connectionController.isConnnecting()
-      && !this._connectionController.getConnectionInstanceIds().includes(this._connectionController.getConnectingInstanceId())
+      && !this._connectionController.getConnectionInstanceIds().includes(
+        this._connectionController.getConnectingInstanceId()
+      )
     ) {
       const notYetEstablishConnectionTreeItem = new vscode.TreeItem(
         this._connectionController.getConnectingInstanceId()

--- a/src/explorer/mdbConnectionsTreeItem.ts
+++ b/src/explorer/mdbConnectionsTreeItem.ts
@@ -7,7 +7,7 @@ import TreeItemParent from './treeItemParentInterface';
 const rootLabel = 'Connections';
 const rootTooltip = 'Your MongoDB connections';
 
-export default class ExplorerRootTreeItem extends vscode.TreeItem
+export default class MDBConnectionsTreeItem extends vscode.TreeItem
   implements TreeItemParent, vscode.TreeDataProvider<vscode.TreeItem> {
   private _connectionController: ConnectionController;
   private _connectionTreeItems: { [key: string]: any } = {};

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,12 +15,12 @@ const log = createLogger('commands');
 export function activate(context: vscode.ExtensionContext) {
   log.info('activate extension called');
 
-  mdbExtension = new MDBExtensionController();
+  mdbExtension = new MDBExtensionController(context);
 
   // Add our extension to a list of disposables for when we are deactivated.
   context.subscriptions.push(mdbExtension);
 
-  mdbExtension.activate(context);
+  mdbExtension.activate();
 
   log.info('extension activated');
 }

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -1,0 +1,6 @@
+import StorageController, { StorageVariables } from './storageController';
+
+export {
+  StorageController,
+  StorageVariables
+};

--- a/src/storage/storageController.ts
+++ b/src/storage/storageController.ts
@@ -76,7 +76,11 @@ export default class StorageController {
     connectionStrings[newConnectionId] = connectionString;
 
     // Update the store.
-    this.update(StorageVariables.WORKSPACE_CONNECTION_STRINGS, connectionStrings, StorageScope.WORKSPACE);
+    this.update(
+      StorageVariables.WORKSPACE_CONNECTION_STRINGS,
+      connectionStrings,
+      StorageScope.WORKSPACE
+    );
   }
 
   public storeNewConnection(connectionString: string, newConnectionId: string): Thenable<void> {

--- a/src/storage/storageController.ts
+++ b/src/storage/storageController.ts
@@ -1,10 +1,21 @@
 import * as vscode from 'vscode';
 
-const STORAGE_PREFIX = 'mongoDB-ext-';
+// Exported for testing.
+export const STORAGE_PREFIX = 'mongoDB-ext-';
 
 export enum StorageVariables {
-  USE_WORKSPACE_STATE_FOR_STORING_CONNECTIONS = 'USE_WORKSPACE_STATE_FOR_STORING_CONNECTIONS',
-  CONNECTION_MODELS = 'CONNECTION_MODELS'
+  // TODO: I think these should be stored as configuration option in extension settings.
+  HIDE_OPTION_TO_CHOOSE_CONNECTION_STORING_SCOPE = 'HIDE_OPTION_TO_CHOOSE_CONNECTION_STORING_SCOPE',
+  STORAGE_SCOPE_FOR_STORING_CONNECTIONS = 'STORAGE_SCOPE_FOR_STORING_CONNECTIONS',
+  GLOBAL_CONNECTION_MODELS = 'GLOBAL_CONNECTION_MODELS',
+  WORKSPACE_CONNECTION_MODELS = 'WORKSPACE_CONNECTION_MODELS'
+  // CONNECTION_MODELS = 'CONNECTION_MODELS' // This exists both on workspace state and global state.
+}
+
+// Typically variables default to 'GLOBAL' scope.
+export enum StorageScope {
+  GLOBAL = 'GLOBAL',
+  WORKSPACE = 'WORKSPACE'
 }
 
 export default class StorageController {
@@ -17,22 +28,105 @@ export default class StorageController {
   }
 
   public get(variableName: StorageVariables): any {
-    if (variableName === StorageVariables.CONNECTION_MODELS
-      && this._globalState.get(`${STORAGE_PREFIX}${StorageVariables.USE_WORKSPACE_STATE_FOR_STORING_CONNECTIONS}`) === false
-    ) {
-      return this._workspaceState.get(`${STORAGE_PREFIX}${variableName}`);
-    }
-
     return this._globalState.get(`${STORAGE_PREFIX}${variableName}`);
   }
 
+  // Update something in the storage. Defaults to global storage (not workspace).
   public update(variableName: StorageVariables, value: any): Thenable<void> {
-    if (variableName === StorageVariables.CONNECTION_MODELS
-      && this._globalState.get(`${STORAGE_PREFIX}${StorageVariables.USE_WORKSPACE_STATE_FOR_STORING_CONNECTIONS}`) === false
-    ) {
-      return this._workspaceState.update(`${STORAGE_PREFIX}${variableName}`, value);
+    return this._globalState.update(`${STORAGE_PREFIX}${variableName}`, value);
+  }
+
+  private addNewConnectionToGlobalStore(newConnectionConfig: any, newConnectionId: string): Thenable<void> {
+    // Get the current save connections.
+    let connectionConfigs: { [key: string]: any } | undefined = this._workspaceState.get(
+      `${STORAGE_PREFIX}${StorageVariables.GLOBAL_CONNECTION_MODELS}`
+    );
+    if (!connectionConfigs) {
+      connectionConfigs = {};
     }
 
-    return this._globalState.update(`${STORAGE_PREFIX}${variableName}`, value);
+    // Add the new connection.
+    connectionConfigs[newConnectionId] = newConnectionConfig;
+    // TODO: Is this read only???? ^^^ Maybe deconstruct needed.
+
+    // Update the store.
+    return this._workspaceState.update(
+      `${STORAGE_PREFIX}${StorageVariables.GLOBAL_CONNECTION_MODELS}`,
+      connectionConfigs
+    );
+  }
+
+  private addNewConnectionToWorkspaceStore(newConnectionConfig: any, newConnectionId: string): Thenable<void> {
+    // Get the current save connections.
+    let connectionConfigs: { [key: string]: any } | undefined = this._workspaceState.get(
+      `${STORAGE_PREFIX}${StorageVariables.WORKSPACE_CONNECTION_MODELS}`
+    );
+    if (!connectionConfigs) {
+      connectionConfigs = {};
+    }
+
+    // Add the new connection.
+    connectionConfigs[newConnectionId] = newConnectionConfig;
+    // TODO: Is this read only???? ^^^ Maybe deconstruct needed.
+
+    // Update the store.
+    return this._workspaceState.update(
+      `${STORAGE_PREFIX}${StorageVariables.WORKSPACE_CONNECTION_MODELS}`,
+      connectionConfigs
+    );
+  }
+
+
+  public storeNewConnection(newConnectionConfig: any, newConnectionId: string): Thenable<void> {
+    console.log('hideOption for choosing connecting storing scope:', this._globalState.get(
+      `${STORAGE_PREFIX}${StorageVariables.HIDE_OPTION_TO_CHOOSE_CONNECTION_STORING_SCOPE}`
+    ));
+
+    if (this._globalState.get(
+      `${STORAGE_PREFIX}${StorageVariables.HIDE_OPTION_TO_CHOOSE_CONNECTION_STORING_SCOPE}`
+    ) === true
+    ) {
+      // The user has chosen not to show the message on where to save the connection.
+      // Save the connection in their default preference.
+      const preferedStorageScope = this._globalState.get(
+        `${STORAGE_PREFIX}${StorageVariables.STORAGE_SCOPE_FOR_STORING_CONNECTIONS}`
+      );
+      if (preferedStorageScope === StorageScope.WORKSPACE) {
+        return this.addNewConnectionToWorkspaceStore(newConnectionConfig, newConnectionId);
+      } else if (preferedStorageScope === StorageScope.GLOBAL) {
+        return this.addNewConnectionToGlobalStore(newConnectionConfig, newConnectionId);
+      }
+
+      // The user prefers for the connections not to be saved.
+      return Promise.resolve();
+    }
+
+    return new Promise(resolve => {
+      const storeOnWorkspace = 'Save on workspace';
+      const storeGlobally = 'Save globally on vscode';
+      // Prompt the user where they want to save the new connection.
+      vscode.window.showInformationMessage(
+        'Would you like to save this new connection ?\'Cancel\' will make this connection only last in this session. (This message can be disabled in the extension settings.)',
+        { modal: true },
+        storeOnWorkspace,
+        storeGlobally
+      ).then(saveConnectionScope => {
+        console.log('saveConnectionScope', saveConnectionScope);
+
+        if (!saveConnectionScope || saveConnectionScope === 'Don\'t save past this session') {
+          console.log('not storing connection');
+          // Don't store the connection.
+          return resolve();
+        }
+
+        if (saveConnectionScope === storeOnWorkspace) {
+          console.log('storing on workspace');
+          return resolve(this.addNewConnectionToWorkspaceStore(newConnectionConfig, newConnectionId));
+        }
+
+        console.log('storing globally');
+        return resolve(this.addNewConnectionToGlobalStore(newConnectionConfig, newConnectionId));
+      });
+    });
   }
 }

--- a/src/storage/storageController.ts
+++ b/src/storage/storageController.ts
@@ -114,17 +114,13 @@ export default class StorageController {
       vscode.window.showInformationMessage(
         'Would you like to save this new connection ?\'Cancel\' will make this connection only last in this session. (This message can be disabled in the extension settings.)',
         { modal: true },
+        'Cancel',
         storeOnWorkspace,
         storeGlobally
       ).then(saveConnectionScope => {
-        if (!saveConnectionScope || saveConnectionScope === 'Don\'t save past this session') {
-          // Don't store the connection.
-          return resolve();
-        }
-
         if (saveConnectionScope === storeOnWorkspace) {
           this.addNewConnectionToWorkspaceStore(newConnectionConfig, newConnectionId);
-        } else {
+        } else if (saveConnectionScope === storeGlobally) {
           this.addNewConnectionToGlobalStore(newConnectionConfig, newConnectionId);
         }
 

--- a/src/storage/storageController.ts
+++ b/src/storage/storageController.ts
@@ -148,7 +148,8 @@ export default class StorageController {
       delete workspaceStoredConnections[connectionId];
       this.update(
         StorageVariables.WORKSPACE_CONNECTION_STRINGS,
-        workspaceStoredConnections
+        workspaceStoredConnections,
+        StorageScope.WORKSPACE
       );
     }
   }

--- a/src/storage/storageController.ts
+++ b/src/storage/storageController.ts
@@ -1,8 +1,8 @@
 import * as vscode from 'vscode';
 
 export enum StorageVariables {
-  GLOBAL_CONNECTION_MODELS = 'GLOBAL_CONNECTION_MODELS', // Only exists on globalState.
-  WORKSPACE_CONNECTION_MODELS = 'WORKSPACE_CONNECTION_MODELS' // Only exists on workspaceState.
+  GLOBAL_CONNECTION_STRINGS = 'GLOBAL_CONNECTION_STRINGS', // Only exists on globalState.
+  WORKSPACE_CONNECTION_STRINGS = 'WORKSPACE_CONNECTION_STRINGS' // Only exists on workspaceState.
 }
 
 // Typically variables default to 'GLOBAL' scope.
@@ -45,41 +45,41 @@ export default class StorageController {
     this._globalState.update(variableName, value);
   }
 
-  public addNewConnectionToGlobalStore(newConnectionConfig: any, newConnectionId: string): void {
+  public addNewConnectionToGlobalStore(connectionString: any, newConnectionId: string): void {
     // Get the current save connections.
-    let connectionConfigs: { [key: string]: any } | undefined = this.get(
-      StorageVariables.GLOBAL_CONNECTION_MODELS
+    let connectionStrings: { [key: string]: any } | undefined = this.get(
+      StorageVariables.GLOBAL_CONNECTION_STRINGS
     );
 
-    if (!connectionConfigs) {
-      connectionConfigs = {};
+    if (!connectionStrings) {
+      connectionStrings = {};
     }
 
     // Add the new connection.
-    connectionConfigs[newConnectionId] = newConnectionConfig;
+    connectionStrings[newConnectionId] = connectionString;
 
     // Update the store.
-    this.update(StorageVariables.GLOBAL_CONNECTION_MODELS, connectionConfigs);
+    this.update(StorageVariables.GLOBAL_CONNECTION_STRINGS, connectionStrings);
   }
 
-  public addNewConnectionToWorkspaceStore(newConnectionConfig: any, newConnectionId: string): void {
+  public addNewConnectionToWorkspaceStore(connectionString: string, newConnectionId: string): void {
     // Get the current save connections.
-    let connectionConfigs: { [key: string]: any } | undefined = this.get(
-      StorageVariables.WORKSPACE_CONNECTION_MODELS,
+    let connectionStrings: { [key: string]: any } | undefined = this.get(
+      StorageVariables.WORKSPACE_CONNECTION_STRINGS,
       StorageScope.WORKSPACE
     );
-    if (!connectionConfigs) {
-      connectionConfigs = {};
+    if (!connectionStrings) {
+      connectionStrings = {};
     }
 
     // Add the new connection.
-    connectionConfigs[newConnectionId] = newConnectionConfig;
+    connectionStrings[newConnectionId] = connectionString;
 
     // Update the store.
-    this.update(StorageVariables.WORKSPACE_CONNECTION_MODELS, connectionConfigs, StorageScope.WORKSPACE);
+    this.update(StorageVariables.WORKSPACE_CONNECTION_STRINGS, connectionStrings, StorageScope.WORKSPACE);
   }
 
-  public storeNewConnection(newConnectionConfig: any, newConnectionId: string): Thenable<void> {
+  public storeNewConnection(connectionString: string, newConnectionId: string): Thenable<void> {
     const dontShowSaveLocationPrompt = vscode.workspace.getConfiguration(
       'mdb.connectionSaving'
     ).get('hideOptionToChooseWhereToSaveNewConnections');
@@ -92,9 +92,9 @@ export default class StorageController {
       ).get('defaultConnectionSavingLocation');
 
       if (preferedStorageScope === DefaultSavingLocations.Workspace) {
-        this.addNewConnectionToWorkspaceStore(newConnectionConfig, newConnectionId);
+        this.addNewConnectionToWorkspaceStore(connectionString, newConnectionId);
       } else if (preferedStorageScope === DefaultSavingLocations.Global) {
-        this.addNewConnectionToGlobalStore(newConnectionConfig, newConnectionId);
+        this.addNewConnectionToGlobalStore(connectionString, newConnectionId);
       }
 
       // The user prefers for the connections not to be saved.
@@ -116,9 +116,9 @@ export default class StorageController {
         }
       ).then(saveConnectionScope => {
         if (saveConnectionScope === storeOnWorkspace) {
-          this.addNewConnectionToWorkspaceStore(newConnectionConfig, newConnectionId);
+          this.addNewConnectionToWorkspaceStore(connectionString, newConnectionId);
         } else if (saveConnectionScope === storeGlobally) {
-          this.addNewConnectionToGlobalStore(newConnectionConfig, newConnectionId);
+          this.addNewConnectionToGlobalStore(connectionString, newConnectionId);
         }
 
         return resolve();
@@ -129,26 +129,26 @@ export default class StorageController {
   public removeConnection(connectionId: string): void {
     // See if the connection exists in the saved global or workspace connections
     // and remove it if it is.
-    const globalConnectionConfigs: { [key: string]: any } | undefined = this.get(
-      StorageVariables.GLOBAL_CONNECTION_MODELS
+    const globalStoredConnections: { [key: string]: any } | undefined = this.get(
+      StorageVariables.GLOBAL_CONNECTION_STRINGS
     );
-    if (globalConnectionConfigs && globalConnectionConfigs[connectionId]) {
-      delete globalConnectionConfigs[connectionId];
+    if (globalStoredConnections && globalStoredConnections[connectionId]) {
+      delete globalStoredConnections[connectionId];
       this.update(
-        StorageVariables.GLOBAL_CONNECTION_MODELS,
-        globalConnectionConfigs
+        StorageVariables.GLOBAL_CONNECTION_STRINGS,
+        globalStoredConnections
       );
     }
 
-    const workspaceConnectionConfigs: { [key: string]: any } | undefined = this.get(
-      StorageVariables.WORKSPACE_CONNECTION_MODELS,
+    const workspaceStoredConnections: { [key: string]: any } | undefined = this.get(
+      StorageVariables.WORKSPACE_CONNECTION_STRINGS,
       StorageScope.WORKSPACE
     );
-    if (workspaceConnectionConfigs && workspaceConnectionConfigs[connectionId]) {
-      delete workspaceConnectionConfigs[connectionId];
+    if (workspaceStoredConnections && workspaceStoredConnections[connectionId]) {
+      delete workspaceStoredConnections[connectionId];
       this.update(
-        StorageVariables.WORKSPACE_CONNECTION_MODELS,
-        workspaceConnectionConfigs
+        StorageVariables.WORKSPACE_CONNECTION_STRINGS,
+        workspaceStoredConnections
       );
     }
   }

--- a/src/storage/storageController.ts
+++ b/src/storage/storageController.ts
@@ -1,0 +1,38 @@
+import * as vscode from 'vscode';
+
+const STORAGE_PREFIX = 'mongoDB-ext-';
+
+export enum StorageVariables {
+  USE_WORKSPACE_STATE_FOR_STORING_CONNECTIONS = 'USE_WORKSPACE_STATE_FOR_STORING_CONNECTIONS',
+  CONNECTION_MODELS = 'CONNECTION_MODELS'
+}
+
+export default class StorageController {
+  _globalState: vscode.Memento;
+  _workspaceState: vscode.Memento;
+
+  constructor(context: vscode.ExtensionContext) {
+    this._globalState = context.globalState;
+    this._workspaceState = context.workspaceState;
+  }
+
+  public get(variableName: StorageVariables): any {
+    if (variableName === StorageVariables.CONNECTION_MODELS
+      && this._globalState.get(`${STORAGE_PREFIX}${StorageVariables.USE_WORKSPACE_STATE_FOR_STORING_CONNECTIONS}`) === false
+    ) {
+      return this._workspaceState.get(`${STORAGE_PREFIX}${variableName}`);
+    }
+
+    return this._globalState.get(`${STORAGE_PREFIX}${variableName}`);
+  }
+
+  public update(variableName: StorageVariables, value: any): Thenable<void> {
+    if (variableName === StorageVariables.CONNECTION_MODELS
+      && this._globalState.get(`${STORAGE_PREFIX}${StorageVariables.USE_WORKSPACE_STATE_FOR_STORING_CONNECTIONS}`) === false
+    ) {
+      return this._workspaceState.update(`${STORAGE_PREFIX}${variableName}`, value);
+    }
+
+    return this._globalState.update(`${STORAGE_PREFIX}${variableName}`, value);
+  }
+}

--- a/src/storage/storageController.ts
+++ b/src/storage/storageController.ts
@@ -102,15 +102,18 @@ export default class StorageController {
     }
 
     return new Promise(resolve => {
-      const storeOnWorkspace = 'Save on workspace';
-      const storeGlobally = 'Save globally on vscode';
+      const storeOnWorkspace = 'Save the connection on this workspace';
+      const storeGlobally = 'Save the connection globally on vscode';
       // Prompt the user where they want to save the new connection.
-      vscode.window.showInformationMessage(
-        'Would you like to save this new connection ?\'Cancel\' will make this connection only last in this session. (This message can be disabled in the extension settings.)',
-        { modal: true },
-        'Cancel',
-        storeOnWorkspace,
-        storeGlobally
+      vscode.window.showQuickPick(
+        [
+          storeOnWorkspace,
+          storeGlobally,
+          'Don\'t save this connection (it will be lost when the session is closed)'
+        ],
+        {
+          placeHolder: 'Where would you like to save this new connection? (This message can be disabled in the extension settings.)'
+        }
       ).then(saveConnectionScope => {
         if (saveConnectionScope === storeOnWorkspace) {
           this.addNewConnectionToWorkspaceStore(newConnectionConfig, newConnectionId);

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -2,6 +2,8 @@ import * as path from 'path';
 
 import { runTests } from 'vscode-test';
 
+// More information on vscode specific tests: https://github.com/microsoft/vscode-test
+
 async function main(): Promise<any> {
   try {
     // The folder containing the Extension Manifest package.json
@@ -12,8 +14,15 @@ async function main(): Promise<any> {
     // Passed to --extensionTestsPath
     const extensionTestsPath = path.resolve(__dirname, './suite/index');
 
+    // This is the workspace we open in our tests.
+    const testWorkspace = path.resolve(__dirname, '../../out/test');
+
     // Download VS Code, unzip it and run the integration test
-    await runTests({ extensionDevelopmentPath, extensionTestsPath });
+    await runTests({
+      extensionDevelopmentPath,
+      extensionTestsPath,
+      launchArgs: [testWorkspace]
+    });
   } catch (err) {
     console.error('Failed to run tests');
     process.exit(1);

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -352,17 +352,17 @@ suite('Connection Controller Test Suite', () => {
     const testExtensionContext = new TestExtensionContext();
     // Set existing connections.
     testExtensionContext.globalState.update(
-      StorageVariables.GLOBAL_CONNECTION_MODELS,
+      StorageVariables.GLOBAL_CONNECTION_STRINGS,
       {
-        'testGlobalConnectionModel': {},
-        'testGlobalConnectionModel2': {},
+        'testGlobalConnectionModel': 'testGlobalConnectionModelDriverUrl',
+        'testGlobalConnectionModel2': 'testGlobalConnectionModel2DriverUrl'
       }
     );
     testExtensionContext.workspaceState.update(
-      StorageVariables.WORKSPACE_CONNECTION_MODELS,
+      StorageVariables.WORKSPACE_CONNECTION_STRINGS,
       {
-        'testWorkspaceConnectionModel': {},
-        'testWorkspaceConnectionModel2': {},
+        'testWorkspaceConnectionModel': 'testWorkspaceConnectionModel1DriverUrl',
+        'testWorkspaceConnectionModel2': 'testWorkspaceConnectionModel2DriverUrl'
       }
     );
     const testStorageController = new StorageController(testExtensionContext);
@@ -386,6 +386,10 @@ suite('Connection Controller Test Suite', () => {
     assert(
       Object.keys(connections).includes('testWorkspaceConnectionModel2') === true,
       'Expected connection configurations to include \'testWorkspaceConnectionModel2\''
+    );
+    assert(
+      connections.testGlobalConnectionModel2.hostname === 'testglobalconnectionmodel2driverurl',
+      'Expected connection configuration to include hostname \'testglobalconnectionmodel2driverurl\''
     );
   });
 
@@ -412,7 +416,7 @@ suite('Connection Controller Test Suite', () => {
             'defaultConnectionSavingLocation',
             DefaultSavingLocations['Session Only']
           ).then(() => {
-            const globalStoreConnections = testStorageController.get(StorageVariables.GLOBAL_CONNECTION_MODELS);
+            const globalStoreConnections = testStorageController.get(StorageVariables.GLOBAL_CONNECTION_STRINGS);
             assert(
               Object.keys(globalStoreConnections).length === 1,
               `Expected global store connections to have 1 connection found ${Object.keys(globalStoreConnections).length}`
@@ -422,7 +426,7 @@ suite('Connection Controller Test Suite', () => {
               `Expected global store connections to have the new connection '${testDatabaseInstanceId}' found ${Object.keys(globalStoreConnections)}`
             );
 
-            const workspaceStoreConnections = testStorageController.get(StorageVariables.WORKSPACE_CONNECTION_MODELS);
+            const workspaceStoreConnections = testStorageController.get(StorageVariables.WORKSPACE_CONNECTION_STRINGS);
             assert(
               workspaceStoreConnections === undefined,
               `Expected workspace store connections to be 'undefined' found ${workspaceStoreConnections}`
@@ -451,7 +455,7 @@ suite('Connection Controller Test Suite', () => {
         .addNewConnectionAndConnect(testDatabaseURI)
         .then(() => {
           const workspaceStoreConnections = testStorageController.get(
-            StorageVariables.WORKSPACE_CONNECTION_MODELS,
+            StorageVariables.WORKSPACE_CONNECTION_STRINGS,
             StorageScope.WORKSPACE
           );
 
@@ -464,7 +468,7 @@ suite('Connection Controller Test Suite', () => {
             `Expected workspace store connections to have the new connection '${testDatabaseInstanceId}' found ${Object.keys(workspaceStoreConnections)}`
           );
 
-          const globalStoreConnections = testStorageController.get(StorageVariables.GLOBAL_CONNECTION_MODELS);
+          const globalStoreConnections = testStorageController.get(StorageVariables.GLOBAL_CONNECTION_STRINGS);
           assert(
             globalStoreConnections === undefined,
             `Expected global store connections to be 'undefined' found ${globalStoreConnections}`
@@ -492,7 +496,7 @@ suite('Connection Controller Test Suite', () => {
         .addNewConnectionAndConnect(testDatabaseURI)
         .then(() => {
           const workspaceStoreConnections = testStorageController.get(
-            StorageVariables.WORKSPACE_CONNECTION_MODELS,
+            StorageVariables.WORKSPACE_CONNECTION_STRINGS,
             StorageScope.WORKSPACE
           );
           assert(
@@ -517,9 +521,12 @@ suite('Connection Controller Test Suite', () => {
             testConnectionController
               .connectWithInstanceId(testDatabaseInstanceId)
               .then(() => {
+                const { instanceId } = testConnectionController.getActiveConnectionConfig().getAttributes({
+                  derived: true
+                });
                 assert(
-                  testConnectionController.getActiveConnectionInstanceId() === testDatabaseURI,
-                  `Expected the active connection to be ${testDatabaseURI}, found ${testConnectionController.getActiveConnectionInstanceId()}.`
+                  instanceId === 'localhost:27018',
+                  `Expected the active connection to be 'localhost:27018', found ${instanceId}.`
                 );
               }).then(done, done);
           });
@@ -547,7 +554,7 @@ suite('Connection Controller Test Suite', () => {
         .then(() => {
           const objectString = JSON.stringify(undefined);
           const globalStoreConnections = testStorageController.get(
-            StorageVariables.GLOBAL_CONNECTION_MODELS
+            StorageVariables.GLOBAL_CONNECTION_STRINGS
           );
           assert(
             JSON.stringify(globalStoreConnections) === objectString,
@@ -555,7 +562,7 @@ suite('Connection Controller Test Suite', () => {
           );
 
           const workspaceStoreConnections = testStorageController.get(
-            StorageVariables.WORKSPACE_CONNECTION_MODELS,
+            StorageVariables.WORKSPACE_CONNECTION_STRINGS,
             StorageScope.WORKSPACE
           );
           assert(
@@ -585,7 +592,7 @@ suite('Connection Controller Test Suite', () => {
         .addNewConnectionAndConnect(testDatabaseURI)
         .then(() => {
           const workspaceStoreConnections = testStorageController.get(
-            StorageVariables.WORKSPACE_CONNECTION_MODELS,
+            StorageVariables.WORKSPACE_CONNECTION_STRINGS,
             StorageScope.WORKSPACE
           );
 
@@ -597,7 +604,7 @@ suite('Connection Controller Test Suite', () => {
           testConnectionController.removeConnectionConfig(testDatabaseInstanceId);
 
           const postWorkspaceStoreConnections = testStorageController.get(
-            StorageVariables.WORKSPACE_CONNECTION_MODELS,
+            StorageVariables.WORKSPACE_CONNECTION_STRINGS,
             StorageScope.WORKSPACE
           );
           assert(
@@ -627,7 +634,7 @@ suite('Connection Controller Test Suite', () => {
         .addNewConnectionAndConnect(testDatabaseURI)
         .then(() => {
           const globalStoreConnections = testStorageController.get(
-            StorageVariables.GLOBAL_CONNECTION_MODELS
+            StorageVariables.GLOBAL_CONNECTION_STRINGS
           );
 
           assert(
@@ -638,7 +645,7 @@ suite('Connection Controller Test Suite', () => {
           testConnectionController.removeConnectionConfig(testDatabaseInstanceId);
 
           const postGlobalStoreConnections = testStorageController.get(
-            StorageVariables.GLOBAL_CONNECTION_MODELS
+            StorageVariables.GLOBAL_CONNECTION_STRINGS
           );
           assert(
             Object.keys(postGlobalStoreConnections).length === 0,

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -6,12 +6,13 @@ import ConnectionController, {
   DataServiceEventTypes
 } from '../../connectionController';
 import { StorageController, StorageVariables } from '../../storage';
-import { STORAGE_PREFIX } from '../../storage/storageController';
+import { STORAGE_PREFIX, StorageScope } from '../../storage/storageController';
 import { StatusView } from '../../views';
 
 import { TestExtensionContext } from './stubs';
 
 const testDatabaseURI = 'mongodb://localhost';
+const testDatabaseInstanceId = 'localhost:27017';
 const testDatabaseURI2WithTimeout =
   'mongodb://shouldfail?connectTimeoutMS=1000&serverSelectionTimeoutMS=1000';
 
@@ -311,41 +312,172 @@ suite('Connection Controller Test Suite', () => {
       });
   });
 
-  // test('when there are no existing connections in the store and the connection controller is activated', function () {
-  //   const testExtensionContext = new TestExtensionContext();
-  //   const testStorageController = new StorageController(testExtensionContext);
+  test('when there are no existing connections in the store and the connection controller is activated', function () {
+    const testExtensionContext = new TestExtensionContext();
+    const testStorageController = new StorageController(testExtensionContext);
 
-  //   const testConnectionController = new ConnectionController(
-  //     new StatusView(),
-  //     testStorageController
-  //   );
+    const testConnectionController = new ConnectionController(
+      new StatusView(),
+      testStorageController
+    );
 
-  //   testConnectionController.activate();
-  //   assert(
-  //     testConnectionController.getConnections() === {},
-  //     `Expected connections to be '{}' found ${testConnectionController.getConnections()}`
-  //   );
-  //   assert(
-  //     Object.keys(testConnectionController.getConnections()).length === 0,
-  //     `Expected 0 connection configurations found ${Object.keys(testConnectionController.getConnections()).length}`
-  //   );
-  // });
+    testConnectionController.activate();
+    assert(
+      Object.keys(testConnectionController.getConnections()).length === 0,
+      `Expected connections to be 0 found ${Object.keys(testConnectionController.getConnections()).length}`
+    );
+  });
 
-  // test('When activated, the connection model loads both global and workspace stored connection models', function () {
-  //   const testExtensionContext = new TestExtensionContext();
-  //   // Set existing connections.
-  //   testExtensionContext.globalState.update(
-  //     `${STORAGE_PREFIX}${StorageVariables.GLOBAL_CONNECTION_MODELS}`,
-  //     {
-  //       'testGlobalConnectionModel': {},
-  //       'testGlobalConnectionModel2': {},
-  //     }
-  //   );
-  //   const testStorageController = new StorageController(testExtensionContext);
+  test('When activated, the connection model loads both global and workspace stored connection models', function () {
+    const testExtensionContext = new TestExtensionContext();
+    // Set existing connections.
+    testExtensionContext.globalState.update(
+      `${STORAGE_PREFIX}${StorageVariables.GLOBAL_CONNECTION_MODELS}`,
+      {
+        'testGlobalConnectionModel': {},
+        'testGlobalConnectionModel2': {},
+      }
+    );
+    testExtensionContext.workspaceState.update(
+      `${STORAGE_PREFIX}${StorageVariables.WORKSPACE_CONNECTION_MODELS}`,
+      {
+        'testWorkspaceConnectionModel': {},
+        'testWorkspaceConnectionModel2': {},
+      }
+    );
+    const testStorageController = new StorageController(testExtensionContext);
 
-  //   const testConnectionController = new ConnectionController(
-  //     new StatusView(),
-  //     testStorageController
-  //   );
-  // });
+    const testConnectionController = new ConnectionController(
+      new StatusView(),
+      testStorageController
+    );
+
+    testConnectionController.activate();
+
+    const connections = testConnectionController.getConnections();
+    assert(
+      Object.keys(connections).length === 4,
+      `Expected 4 connection configurations found ${Object.keys(testConnectionController.getConnections()).length}`
+    );
+    assert(
+      Object.keys(connections).includes('testGlobalConnectionModel2') === true,
+      'Expected connection configurations to include \'testGlobalConnectionModel2\''
+    );
+    assert(
+      Object.keys(connections).includes('testWorkspaceConnectionModel2') === true,
+      'Expected connection configurations to include \'testWorkspaceConnectionModel2\''
+    );
+  });
+
+  test('When a connection is added it is saved to the global store', function (done) {
+    const testExtensionContext = new TestExtensionContext();
+    testExtensionContext.globalState.update(
+      `${STORAGE_PREFIX}${StorageVariables.HIDE_OPTION_TO_CHOOSE_CONNECTION_STORING_SCOPE}`,
+      true
+    );
+    testExtensionContext.globalState.update(
+      `${STORAGE_PREFIX}${StorageVariables.STORAGE_SCOPE_FOR_STORING_CONNECTIONS}`,
+      StorageScope.GLOBAL
+    );
+    const testStorageController = new StorageController(testExtensionContext);
+
+    const testConnectionController = new ConnectionController(
+      new StatusView(),
+      testStorageController
+    );
+
+    testConnectionController.activate();
+
+    testConnectionController
+      .addNewConnectionAndConnect(testDatabaseURI)
+      .then(() => {
+        const globalStoreConnections = testStorageController.get(StorageVariables.GLOBAL_CONNECTION_MODELS);
+        assert(
+          Object.keys(globalStoreConnections).length === 1,
+          `Expected global store connections to have 1 connection found ${Object.keys(globalStoreConnections).length}`
+        );
+        assert(
+          Object.keys(globalStoreConnections).includes(testDatabaseInstanceId),
+          `Expected global store connections to have the new connection '${testDatabaseInstanceId}' found ${Object.keys(globalStoreConnections)}`
+        );
+
+        const workspaceStoreConnections = testStorageController.get(StorageVariables.WORKSPACE_CONNECTION_MODELS);
+        assert(
+          workspaceStoreConnections === undefined,
+          `Expected workspace store connections to be 'undefined' found ${workspaceStoreConnections}`
+        );
+      }).then(done).catch(done);
+  });
+
+  test('When a connection is added it is saved to the workspace store', function (done) {
+    const testExtensionContext = new TestExtensionContext();
+    testExtensionContext.globalState.update(
+      `${STORAGE_PREFIX}${StorageVariables.HIDE_OPTION_TO_CHOOSE_CONNECTION_STORING_SCOPE}`,
+      true
+    );
+    testExtensionContext.globalState.update(
+      `${STORAGE_PREFIX}${StorageVariables.STORAGE_SCOPE_FOR_STORING_CONNECTIONS}`,
+      StorageScope.WORKSPACE
+    );
+    const testStorageController = new StorageController(testExtensionContext);
+
+    const testConnectionController = new ConnectionController(
+      new StatusView(),
+      testStorageController
+    );
+
+    testConnectionController.activate();
+
+    testConnectionController
+      .addNewConnectionAndConnect(testDatabaseURI)
+      .then(() => {
+        const workspaceStoreConnections = testStorageController.get(StorageVariables.WORKSPACE_CONNECTION_MODELS, StorageScope.WORKSPACE);
+        assert(
+          Object.keys(workspaceStoreConnections).length === 1,
+          `Expected global store connections to have 1 connection found ${Object.keys(workspaceStoreConnections).length}`
+        );
+        assert(
+          Object.keys(workspaceStoreConnections).includes(testDatabaseInstanceId),
+          `Expected global store connections to have the new connection '${testDatabaseInstanceId}' found ${Object.keys(workspaceStoreConnections)}`
+        );
+
+        const globalStoreConnections = testStorageController.get(StorageVariables.GLOBAL_CONNECTION_MODELS);
+        assert(
+          globalStoreConnections === undefined,
+          `Expected workspace store connections to be 'undefined' found ${globalStoreConnections}`
+        );
+      }).then(done).catch(done);
+  });
+
+  test('When a connection is added and the user has set it to not save on default it is not saved', function (done) {
+    const testExtensionContext = new TestExtensionContext();
+    testExtensionContext.globalState.update(
+      `${STORAGE_PREFIX}${StorageVariables.HIDE_OPTION_TO_CHOOSE_CONNECTION_STORING_SCOPE}`,
+      true
+    );
+    const testStorageController = new StorageController(testExtensionContext);
+
+    const testConnectionController = new ConnectionController(
+      new StatusView(),
+      testStorageController
+    );
+
+    testConnectionController.activate();
+
+    testConnectionController
+      .addNewConnectionAndConnect(testDatabaseURI)
+      .then(() => {
+        const globalStoreConnections = testStorageController.get(StorageVariables.GLOBAL_CONNECTION_MODELS);
+        assert(
+          globalStoreConnections === undefined,
+          `Expected global store connections to be 'undefined' found ${globalStoreConnections}`
+        );
+
+        const workspaceStoreConnections = testStorageController.get(StorageVariables.WORKSPACE_CONNECTION_MODELS, StorageScope.WORKSPACE);
+        assert(
+          workspaceStoreConnections === undefined,
+          `Expected workspace store connections to be 'undefined' found ${workspaceStoreConnections}`
+        );
+      }).then(done).catch(done);
+  });
 });

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -12,7 +12,7 @@ import { StatusView } from '../../views';
 import { TestExtensionContext } from './stubs';
 
 const testDatabaseURI = 'mongodb://localhost';
-const testDatabaseInstanceId = 'localhost:27017';
+const testDatabaseInstanceId = 'localhost:27018';
 const testDatabaseURI2WithTimeout =
   'mongodb://shouldfail?connectTimeoutMS=1000&serverSelectionTimeoutMS=1000';
 
@@ -50,8 +50,8 @@ suite('Connection Controller Test Suite', () => {
         );
         const instanceId = testConnectionController.getActiveConnectionInstanceId();
         assert(
-          instanceId === 'localhost:27017',
-          `Expected active connection to be 'localhost:27017' found ${instanceId}`
+          instanceId === 'localhost:27018',
+          `Expected active connection to be 'localhost:27018' found ${instanceId}`
         );
       })
       .then(done, done);

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -5,7 +5,10 @@ import { before, after } from 'mocha';
 import ConnectionController, {
   DataServiceEventTypes
 } from '../../connectionController';
+import { StorageController } from '../../storage';
 import { StatusView } from '../../views';
+
+import { TestExtensionContext } from './stubs';
 
 const testDatabaseURI = 'mongodb://localhost';
 const testDatabaseURI2WithTimeout =
@@ -17,8 +20,14 @@ suite('Connection Controller Test Suite', () => {
   before(require('mongodb-runner/mocha/before'));
   after(require('mongodb-runner/mocha/after'));
 
+  const mockExtensionContext = new TestExtensionContext();
+  const mockStorageController = new StorageController(mockExtensionContext);
+
   test('it connects to mongodb', function (done) {
-    const testConnectionController = new ConnectionController(new StatusView());
+    const testConnectionController = new ConnectionController(
+      new StatusView(),
+      mockStorageController
+    );
     this.timeout(2000);
 
     testConnectionController
@@ -42,7 +51,10 @@ suite('Connection Controller Test Suite', () => {
   });
 
   test('"disconnect()" disconnects from the active connection', function (done) {
-    const testConnectionController = new ConnectionController(new StatusView());
+    const testConnectionController = new ConnectionController(
+      new StatusView(),
+      mockStorageController
+    );
     this.timeout(2000);
 
     testConnectionController
@@ -79,7 +91,10 @@ suite('Connection Controller Test Suite', () => {
   });
 
   test('"removeMongoDBConnection()" returns a reject promise when there is no active connection', done => {
-    const testConnectionController = new ConnectionController(new StatusView());
+    const testConnectionController = new ConnectionController(
+      new StatusView(),
+      mockStorageController
+    );
 
     testConnectionController
       .removeMongoDBConnection()
@@ -90,7 +105,10 @@ suite('Connection Controller Test Suite', () => {
   });
 
   test('"disconnect()" fails when there is no active connection', done => {
-    const testConnectionController = new ConnectionController(new StatusView());
+    const testConnectionController = new ConnectionController(
+      new StatusView(),
+      mockStorageController
+    );
 
     testConnectionController
       .disconnect()
@@ -101,7 +119,10 @@ suite('Connection Controller Test Suite', () => {
   });
 
   test('when adding a new connection it disconnects from the current connection', function (done) {
-    const testConnectionController = new ConnectionController(new StatusView());
+    const testConnectionController = new ConnectionController(
+      new StatusView(),
+      mockStorageController
+    );
     this.timeout(2000);
 
     testConnectionController
@@ -130,7 +151,10 @@ suite('Connection Controller Test Suite', () => {
   });
 
   test('when adding a new connection it disconnects from the current connection', function (done) {
-    const testConnectionController = new ConnectionController(new StatusView());
+    const testConnectionController = new ConnectionController(
+      new StatusView(),
+      mockStorageController
+    );
     this.timeout(2000);
 
     testConnectionController
@@ -159,7 +183,10 @@ suite('Connection Controller Test Suite', () => {
   });
 
   test('"connect()" failed when we are currently connecting', function (done) {
-    const testConnectionController = new ConnectionController(new StatusView());
+    const testConnectionController = new ConnectionController(
+      new StatusView(),
+      mockStorageController
+    );
 
     testConnectionController.setConnnecting(true);
 
@@ -172,7 +199,10 @@ suite('Connection Controller Test Suite', () => {
   });
 
   test('"connect()" failed when we are currently disconnecting', function (done) {
-    const testConnectionController = new ConnectionController(new StatusView());
+    const testConnectionController = new ConnectionController(
+      new StatusView(),
+      mockStorageController
+    );
 
     testConnectionController.setDisconnecting(true);
 
@@ -185,7 +215,10 @@ suite('Connection Controller Test Suite', () => {
   });
 
   test('"disconnect()" fails when we are currently connecting', function (done) {
-    const testConnectionController = new ConnectionController(new StatusView());
+    const testConnectionController = new ConnectionController(
+      new StatusView(),
+      mockStorageController
+    );
 
     testConnectionController.setConnnecting(true);
 
@@ -198,7 +231,10 @@ suite('Connection Controller Test Suite', () => {
   });
 
   test('"disconnect()" fails when we are currently disconnecting', function (done) {
-    const testConnectionController = new ConnectionController(new StatusView());
+    const testConnectionController = new ConnectionController(
+      new StatusView(),
+      mockStorageController
+    );
 
     testConnectionController.setDisconnecting(true);
 
@@ -211,7 +247,10 @@ suite('Connection Controller Test Suite', () => {
   });
 
   test('"connect()" should fire a CONNECTIONS_DID_CHANGE event', function (done) {
-    const testConnectionController = new ConnectionController(new StatusView());
+    const testConnectionController = new ConnectionController(
+      new StatusView(),
+      mockStorageController
+    );
 
     let didFireConnectionEvent = false;
 
@@ -237,7 +276,10 @@ suite('Connection Controller Test Suite', () => {
 
   const expectedTimesToFire = 3;
   test(`"connect()" then "disconnect()" should fire the connections did change event ${expectedTimesToFire} times`, function (done) {
-    const testConnectionController = new ConnectionController(new StatusView());
+    const testConnectionController = new ConnectionController(
+      new StatusView(),
+      mockStorageController
+    );
 
     let connectionEventFiredCount = 0;
 

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -23,7 +23,6 @@ suite('Connection Controller Test Suite', () => {
   const mockStorageController = new StorageController(mockExtensionContext);
 
   before(async () => {
-    require('mongodb-runner/mocha/before');
     // Disable the dialogue for prompting the user where to store the connection.
     await vscode.workspace.getConfiguration('mdb.connectionSaving').update(
       'hideOptionToChooseWhereToSaveNewConnections',
@@ -36,7 +35,6 @@ suite('Connection Controller Test Suite', () => {
     );
   });
   after(async () => {
-    require('mongodb-runner/mocha/after');
     // Unset the variable we set in `before`.
     await vscode.workspace.getConfiguration('mdb.connectionSaving').update(
       'hideOptionToChooseWhereToSaveNewConnections',

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -5,7 +5,8 @@ import { before, after } from 'mocha';
 import ConnectionController, {
   DataServiceEventTypes
 } from '../../connectionController';
-import { StorageController } from '../../storage';
+import { StorageController, StorageVariables } from '../../storage';
+import { STORAGE_PREFIX } from '../../storage/storageController';
 import { StatusView } from '../../views';
 
 import { TestExtensionContext } from './stubs';
@@ -21,6 +22,11 @@ suite('Connection Controller Test Suite', () => {
   after(require('mongodb-runner/mocha/after'));
 
   const mockExtensionContext = new TestExtensionContext();
+  // Disable the dialogue for prompting the user where to store the connection.
+  mockExtensionContext.globalState.update(
+    `${STORAGE_PREFIX}${StorageVariables.HIDE_OPTION_TO_CHOOSE_CONNECTION_STORING_SCOPE}`,
+    true
+  );
   const mockStorageController = new StorageController(mockExtensionContext);
 
   test('it connects to mongodb', function (done) {
@@ -304,4 +310,42 @@ suite('Connection Controller Test Suite', () => {
         });
       });
   });
+
+  // test('when there are no existing connections in the store and the connection controller is activated', function () {
+  //   const testExtensionContext = new TestExtensionContext();
+  //   const testStorageController = new StorageController(testExtensionContext);
+
+  //   const testConnectionController = new ConnectionController(
+  //     new StatusView(),
+  //     testStorageController
+  //   );
+
+  //   testConnectionController.activate();
+  //   assert(
+  //     testConnectionController.getConnections() === {},
+  //     `Expected connections to be '{}' found ${testConnectionController.getConnections()}`
+  //   );
+  //   assert(
+  //     Object.keys(testConnectionController.getConnections()).length === 0,
+  //     `Expected 0 connection configurations found ${Object.keys(testConnectionController.getConnections()).length}`
+  //   );
+  // });
+
+  // test('When activated, the connection model loads both global and workspace stored connection models', function () {
+  //   const testExtensionContext = new TestExtensionContext();
+  //   // Set existing connections.
+  //   testExtensionContext.globalState.update(
+  //     `${STORAGE_PREFIX}${StorageVariables.GLOBAL_CONNECTION_MODELS}`,
+  //     {
+  //       'testGlobalConnectionModel': {},
+  //       'testGlobalConnectionModel2': {},
+  //     }
+  //   );
+  //   const testStorageController = new StorageController(testExtensionContext);
+
+  //   const testConnectionController = new ConnectionController(
+  //     new StatusView(),
+  //     testStorageController
+  //   );
+  // });
 });

--- a/src/test/suite/explorer/explorerController.test.ts
+++ b/src/test/suite/explorer/explorerController.test.ts
@@ -5,6 +5,8 @@ import { before, after } from 'mocha';
 import ConnectionController from '../../../connectionController';
 import { ExplorerController } from '../../../explorer';
 import { StatusView } from '../../../views';
+import { TestExtensionContext } from '../stubs';
+import { StorageController } from '../../../storage';
 
 const testDatabaseURI = 'mongodb://localhost';
 const testDatabaseURI2WithTimeout =
@@ -16,8 +18,14 @@ suite('Explorer Controller Test Suite', function () {
   before(require('mongodb-runner/mocha/before'));
   after(require('mongodb-runner/mocha/after'));
 
+  const mockExtensionContext = new TestExtensionContext();
+  const mockStorageController = new StorageController(mockExtensionContext);
+
   test('when activated it creates a tree with a connections root', function (done) {
-    const testConnectionController = new ConnectionController(new StatusView());
+    const testConnectionController = new ConnectionController(
+      new StatusView(),
+      mockStorageController
+    );
 
     const testExplorerController = new ExplorerController();
 
@@ -46,7 +54,8 @@ suite('Explorer Controller Test Suite', function () {
 
   test('it updates the connections to account for a change in the connection controller', function (done) {
     const testConnectionController = new ConnectionController(
-      new StatusView()
+      new StatusView(),
+      mockStorageController
     );
 
     const testExplorerController = new ExplorerController();
@@ -85,7 +94,10 @@ suite('Explorer Controller Test Suite', function () {
   });
 
   test('when a connection is added and connected it is added to the tree and expanded', function (done) {
-    const testConnectionController = new ConnectionController(new StatusView());
+    const testConnectionController = new ConnectionController(
+      new StatusView(),
+      mockStorageController
+    );
 
     const testExplorerController = new ExplorerController();
 
@@ -144,7 +156,10 @@ suite('Explorer Controller Test Suite', function () {
   });
 
   test('only the active connection is displayed as connected in the tree', function (done) {
-    const testConnectionController = new ConnectionController(new StatusView());
+    const testConnectionController = new ConnectionController(
+      new StatusView(),
+      mockStorageController
+    );
 
     const testExplorerController = new ExplorerController();
 
@@ -208,7 +223,10 @@ suite('Explorer Controller Test Suite', function () {
   });
 
   test('shows the databases of connected connection in tree', function (done) {
-    const testConnectionController = new ConnectionController(new StatusView());
+    const testConnectionController = new ConnectionController(
+      new StatusView(),
+      mockStorageController
+    );
     const testExplorerController = new ExplorerController();
 
     testExplorerController.activate(testConnectionController);

--- a/src/test/suite/explorer/explorerController.test.ts
+++ b/src/test/suite/explorer/explorerController.test.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 import { before, after } from 'mocha';
 
 import ConnectionController from '../../../connectionController';
+import { STORAGE_PREFIX, StorageVariables } from '../../../storage/storageController';
 import { ExplorerController } from '../../../explorer';
 import { StatusView } from '../../../views';
 import { TestExtensionContext } from '../stubs';
@@ -19,6 +20,11 @@ suite('Explorer Controller Test Suite', function () {
   after(require('mongodb-runner/mocha/after'));
 
   const mockExtensionContext = new TestExtensionContext();
+  // Disable the dialogue for prompting the user where to store the connection.
+  mockExtensionContext.globalState.update(
+    `${STORAGE_PREFIX}${StorageVariables.HIDE_OPTION_TO_CHOOSE_CONNECTION_STORING_SCOPE}`,
+    true
+  );
   const mockStorageController = new StorageController(mockExtensionContext);
 
   test('when activated it creates a tree with a connections root', function (done) {

--- a/src/test/suite/explorer/explorerController.test.ts
+++ b/src/test/suite/explorer/explorerController.test.ts
@@ -238,7 +238,7 @@ suite('Explorer Controller Test Suite', function () {
                   'Expected the first connection to have no description.'
                 );
                 assert(
-                  connectionsItems[0].getIsExpanded() === false,
+                  connectionsItems[0].isExpanded === false,
                   'Expected the first connection tree item to not be expanded'
                 );
                 assert(

--- a/src/test/suite/explorer/explorerController.test.ts
+++ b/src/test/suite/explorer/explorerController.test.ts
@@ -129,8 +129,8 @@ suite('Explorer Controller Test Suite', function () {
         );
         const instanceId = testConnectionController.getActiveConnectionInstanceId();
         assert(
-          instanceId === 'localhost:27017',
-          `Expected active connection to be 'localhost:27017' found ${instanceId}`
+          instanceId === 'localhost:27018',
+          `Expected active connection to be 'localhost:27018' found ${instanceId}`
         );
 
         treeController.getChildren().then(treeControllerChildren => {
@@ -142,8 +142,8 @@ suite('Explorer Controller Test Suite', function () {
                 `Expected there be 1 connection tree item, found ${connectionsItems.length}`
               );
               assert(
-                connectionsItems[0].label === 'localhost:27017',
-                'There should be a connection tree item with the label "localhost:27017"'
+                connectionsItems[0].label === 'localhost:27018',
+                'There should be a connection tree item with the label "localhost:27018"'
               );
               assert(
                 connectionsItems[0].description === 'connected',
@@ -180,52 +180,63 @@ suite('Explorer Controller Test Suite', function () {
 
     this.timeout(1500);
 
-    testConnectionController.addNewConnectionAndConnect(testDatabaseURI).then(succesfullyConnected => {
-      assert(succesfullyConnected === true, 'Expected a successful connection response.');
-      assert(
-        Object.keys(testConnectionController.getConnections()).length === 1,
-        'Expected there to be 1 connection in the connection list.'
-      );
-      const instanceId = testConnectionController.getActiveConnectionInstanceId();
-      assert(
-        instanceId === 'localhost:27017',
-        `Expected active connection to be 'localhost:27017' found ${instanceId}`
-      );
+    testConnectionController
+      .addNewConnectionAndConnect(testDatabaseURI)
+      .then(succesfullyConnected => {
+        assert(
+          succesfullyConnected === true,
+          'Expected a successful connection response.'
+        );
+        assert(
+          Object.keys(testConnectionController.getConnections()).length === 1,
+          'Expected there to be 1 connection in the connection list.'
+        );
+        const instanceId = testConnectionController.getActiveConnectionInstanceId();
+        assert(
+          instanceId === 'localhost:27018',
+          `Expected active connection to be 'localhost:27018' found ${instanceId}`
+        );
 
-      // This will timeout in 1s, which is enough time for us to just check.
-      testConnectionController.addNewConnectionAndConnect(testDatabaseURI2WithTimeout);
+        // This will timeout in 1s, which is enough time for us to just check.
+        testConnectionController.addNewConnectionAndConnect(
+          testDatabaseURI2WithTimeout
+        ).then(() => { }, () => { } /* Silent fail (should fail) */);
 
-      treeController.getChildren().then(treeControllerChildren => {
-        treeControllerChildren[0].getChildren().then(connectionsItems => {
-          assert(
-            connectionsItems.length === 2,
-            `Expected there be 2 connection tree item, found ${connectionsItems.length}`
-          );
-          assert(
-            connectionsItems[0].label === 'localhost:27017',
-            `First connection tree item should have label "localhost:27017" found ${connectionsItems[0].label}`
-          );
-          assert(
-            connectionsItems[0].description === '',
-            'Expected the first connection to have no description.'
-          );
-          assert(
-            connectionsItems[0].isExpanded === false,
-            'Expected the first connection tree item to not be expanded'
-          );
-          assert(
-            connectionsItems[1].label === 'shouldfail:27017',
-            'Second connection tree item should have label "shouldfail:27017"'
-          );
-          assert(
-            connectionsItems[1].description === 'connecting...',
-            'The second connection should have a connecting description.'
-          );
+        setTimeout(() => {
+          treeController.getChildren().then(treeControllerChildren => {
+            treeControllerChildren[0]
+              .getChildren()
+              .then(connectionsItems => {
+                assert(
+                  connectionsItems.length === 2,
+                  `Expected there be 2 connection tree item, found ${connectionsItems.length}`
+                );
+                assert(
+                  connectionsItems[0].label === 'localhost:27018',
+                  `First connection tree item should have label "localhost:27018" found ${connectionsItems[0].label}`
+                );
+                assert(
+                  connectionsItems[0].description === '',
+                  'Expected the first connection to have no description.'
+                );
+                assert(
+                  connectionsItems[0].getIsExpanded() === false,
+                  'Expected the first connection tree item to not be expanded'
+                );
+                assert(
+                  connectionsItems[1].label === 'shouldfail:27018',
+                  'Second connection tree item should have label "shouldfail:27018"'
+                );
+                assert(
+                  connectionsItems[1].description === 'connecting...',
+                  'The second connection should have a connecting description.'
+                );
 
-          testExplorerController.deactivate();
-        }).then(done, done);
+                testExplorerController.deactivate();
+              }).then(done, done);
+          });
+        }, 100);
       });
-    });
   });
 
   test('shows the databases of connected connection in tree', function (done) {
@@ -273,7 +284,10 @@ suite('Explorer Controller Test Suite', function () {
   });
 
   test('caches the expanded state of databases in the tree when a connection is expanded or collapsed', function (done) {
-    const testConnectionController = new ConnectionController(new StatusView());
+    const testConnectionController = new ConnectionController(
+      new StatusView(),
+      mockStorageController
+    );
 
     const testExplorerController = new ExplorerController();
 

--- a/src/test/suite/explorer/explorerController.test.ts
+++ b/src/test/suite/explorer/explorerController.test.ts
@@ -17,7 +17,6 @@ suite('Explorer Controller Test Suite', function () {
   vscode.window.showInformationMessage('Starting tests...');
 
   before(async () => {
-    require('mongodb-runner/mocha/before');
     // Disable the dialogue for prompting the user where to store the connection.
     await vscode.workspace.getConfiguration('mdb.connectionSaving').update(
       'hideOptionToChooseWhereToSaveNewConnections',
@@ -30,7 +29,6 @@ suite('Explorer Controller Test Suite', function () {
     );
   });
   after(async () => {
-    require('mongodb-runner/mocha/after');
     // Unset the variable we set in `before`.
     await vscode.workspace.getConfiguration('mdb.connectionSaving').update(
       'hideOptionToChooseWhereToSaveNewConnections',

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -9,7 +9,7 @@ import { StatusView } from '../../views';
 
 import { TestExtensionContext } from './stubs';
 
-const testDatabaseURI = 'mongodb://localhost';
+const testDatabaseURI = 'mongodb://localhost:27018';
 
 suite('Extension Test Suite', () => {
   vscode.window.showInformationMessage('Starting tests...');

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -4,7 +4,7 @@ import { before, after } from 'mocha';
 
 import ConnectionController from '../../connectionController';
 import MDBExtensionController from '../../mdbExtensionController';
-
+import { StorageController } from '../../storage';
 import { StatusView } from '../../views';
 
 import { TestExtensionContext } from './stubs';
@@ -24,10 +24,10 @@ suite('Extension Test Suite', () => {
   test('commands are registered in vscode', done => {
     const mockExtensionContext = new TestExtensionContext();
 
-    const mockMDBExtension = new MDBExtensionController();
+    const mockMDBExtension = new MDBExtensionController(mockExtensionContext);
     disposables.push(mockMDBExtension);
 
-    mockMDBExtension.activate(mockExtensionContext);
+    mockMDBExtension.activate();
 
     vscode.commands
       .getCommands()
@@ -58,8 +58,9 @@ suite('Extension Test Suite', () => {
 
   test('launchMongoShell should open a terminal', done => {
     disposables.push(vscode.window.onDidOpenTerminal(() => done()));
+    const mockExtensionContext = new TestExtensionContext();
 
-    const mockMDBExtension = new MDBExtensionController();
+    const mockMDBExtension = new MDBExtensionController(mockExtensionContext);
 
     mockMDBExtension.openMongoDBShell();
   });
@@ -69,15 +70,20 @@ suite('Extension Test Suite', () => {
     after(require('mongodb-runner/mocha/after'));
 
     test('when the extension is deactivated, the active connection is disconnected', (done) => {
-      const testConnectionController = new ConnectionController(new StatusView());
+      const mockExtensionContext = new TestExtensionContext();
+      const mockStorageController = new StorageController(mockExtensionContext);
+      const testConnectionController = new ConnectionController(
+        new StatusView(),
+        mockStorageController
+      );
 
       const mockMDBExtension = new MDBExtensionController(
+        mockExtensionContext,
         testConnectionController
       );
       disposables.push(mockMDBExtension);
 
-      const mockExtensionContext = new TestExtensionContext();
-      mockMDBExtension.activate(mockExtensionContext);
+      mockMDBExtension.activate();
 
       testConnectionController
         .addNewConnectionAndConnect(testDatabaseURI)

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -66,9 +66,6 @@ suite('Extension Test Suite', () => {
   });
 
   test('extension connections', () => {
-    before(require('mongodb-runner/mocha/before'));
-    after(require('mongodb-runner/mocha/after'));
-
     test('when the extension is deactivated, the active connection is disconnected', (done) => {
       const mockExtensionContext = new TestExtensionContext();
       const mockStorageController = new StorageController(mockExtensionContext);

--- a/src/test/suite/storage/storageController.test.ts
+++ b/src/test/suite/storage/storageController.test.ts
@@ -1,0 +1,78 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+import StorageController, { StorageVariables, StorageScope } from '../../../storage/storageController';
+
+import { TestExtensionContext } from '../stubs';
+
+suite('Storage Controller Test Suite', () => {
+  vscode.window.showInformationMessage('Starting tests...');
+
+  test('getting a variable gets it from the global context store', function () {
+    const testExtensionContext = new TestExtensionContext();
+    testExtensionContext._globalState = {
+      [StorageVariables.GLOBAL_CONNECTION_MODELS]: 'expectedValue'
+    };
+    const testStorageController = new StorageController(testExtensionContext);
+    const testVal = testStorageController.get(
+      StorageVariables.GLOBAL_CONNECTION_MODELS
+    );
+    assert(
+      testVal === 'expectedValue',
+      `Expected ${testVal} from global state to equal 'expectedValue'.`
+    );
+  });
+
+  test('getting a variable from the workspace state gets it from the workspace context store', function () {
+    const testExtensionContext = new TestExtensionContext();
+    testExtensionContext._workspaceState = {
+      [StorageVariables.WORKSPACE_CONNECTION_MODELS]: 'expectedValue'
+    };
+    const testStorageController = new StorageController(testExtensionContext);
+    const testVal = testStorageController.get(
+      StorageVariables.WORKSPACE_CONNECTION_MODELS,
+      StorageScope.WORKSPACE
+    );
+    assert(
+      testVal === 'expectedValue',
+      `Expected ${testVal} from workspace state to equal 'expectedValue'.`
+    );
+  });
+
+  test('addNewConnectionToGlobalStore adds the connection to preexisting connections on the global store', function () {
+    const testExtensionContext = new TestExtensionContext();
+    testExtensionContext._globalState = {
+      [StorageVariables.GLOBAL_CONNECTION_MODELS]: {
+        'conn_1': 'someData'
+      }
+    };
+    const testStorageController = new StorageController(testExtensionContext);
+    testStorageController.addNewConnectionToGlobalStore('someMoreData', 'new_conn');
+
+    const updatedGlobalModels = testStorageController.get(
+      StorageVariables.GLOBAL_CONNECTION_MODELS
+    );
+    assert(Object.keys(updatedGlobalModels).length === 2, `Expected 2 connections, found ${Object.keys(updatedGlobalModels).length}.`);
+    assert(updatedGlobalModels.conn_1 === 'someData', 'Expected connection data to persist.');
+    assert(updatedGlobalModels.new_conn === 'someMoreData', 'Expected new connection data to exist.');
+  });
+
+  test('addNewConnectionToWorkspaceStore adds the connection to preexisting connections on the workspace store', function () {
+    const testExtensionContext = new TestExtensionContext();
+    testExtensionContext._workspaceState = {
+      [StorageVariables.WORKSPACE_CONNECTION_MODELS]: {
+        'conn_1': 'someData'
+      }
+    };
+    const testStorageController = new StorageController(testExtensionContext);
+    testStorageController.addNewConnectionToWorkspaceStore('someMoreData', 'new_conn');
+
+    const updatedWorkspaceModels = testStorageController.get(
+      StorageVariables.WORKSPACE_CONNECTION_MODELS,
+      StorageScope.WORKSPACE
+    );
+    assert(Object.keys(updatedWorkspaceModels).length === 2, `Expected 2 connections, found ${Object.keys(updatedWorkspaceModels).length}.`);
+    assert(updatedWorkspaceModels.conn_1 === 'someData', 'Expected connection data to persist.');
+    assert(updatedWorkspaceModels.new_conn === 'someMoreData', 'Expected new connection data to exist.');
+  });
+});

--- a/src/test/suite/storage/storageController.test.ts
+++ b/src/test/suite/storage/storageController.test.ts
@@ -11,68 +11,74 @@ suite('Storage Controller Test Suite', () => {
   test('getting a variable gets it from the global context store', function () {
     const testExtensionContext = new TestExtensionContext();
     testExtensionContext._globalState = {
-      [StorageVariables.GLOBAL_CONNECTION_MODELS]: 'expectedValue'
+      [StorageVariables.GLOBAL_CONNECTION_STRINGS]: 'this_gonna_get_saved'
     };
     const testStorageController = new StorageController(testExtensionContext);
     const testVal = testStorageController.get(
-      StorageVariables.GLOBAL_CONNECTION_MODELS
+      StorageVariables.GLOBAL_CONNECTION_STRINGS
     );
     assert(
-      testVal === 'expectedValue',
-      `Expected ${testVal} from global state to equal 'expectedValue'.`
+      testVal === 'this_gonna_get_saved',
+      `Expected ${testVal} from global state to equal 'this_gonna_get_saved'.`
     );
   });
 
   test('getting a variable from the workspace state gets it from the workspace context store', function () {
     const testExtensionContext = new TestExtensionContext();
     testExtensionContext._workspaceState = {
-      [StorageVariables.WORKSPACE_CONNECTION_MODELS]: 'expectedValue'
+      [StorageVariables.WORKSPACE_CONNECTION_STRINGS]: 'i_cant_believe_its_gonna_save_this'
     };
     const testStorageController = new StorageController(testExtensionContext);
     const testVal = testStorageController.get(
-      StorageVariables.WORKSPACE_CONNECTION_MODELS,
+      StorageVariables.WORKSPACE_CONNECTION_STRINGS,
       StorageScope.WORKSPACE
     );
     assert(
-      testVal === 'expectedValue',
-      `Expected ${testVal} from workspace state to equal 'expectedValue'.`
+      testVal === 'i_cant_believe_its_gonna_save_this',
+      `Expected ${testVal} from workspace state to equal 'i_cant_believe_its_gonna_save_this'.`
     );
   });
 
   test('addNewConnectionToGlobalStore adds the connection to preexisting connections on the global store', function () {
     const testExtensionContext = new TestExtensionContext();
     testExtensionContext._globalState = {
-      [StorageVariables.GLOBAL_CONNECTION_MODELS]: {
-        'conn_1': 'someData'
+      [StorageVariables.GLOBAL_CONNECTION_STRINGS]: {
+        'conn_1': 'url_that_is_very_saved'
       }
     };
     const testStorageController = new StorageController(testExtensionContext);
-    testStorageController.addNewConnectionToGlobalStore('someMoreData', 'new_conn');
+    testStorageController.addNewConnectionToGlobalStore(
+      'another_url_that_is_so_saved',
+      'new_conn'
+    );
 
     const updatedGlobalModels = testStorageController.get(
-      StorageVariables.GLOBAL_CONNECTION_MODELS
+      StorageVariables.GLOBAL_CONNECTION_STRINGS
     );
     assert(Object.keys(updatedGlobalModels).length === 2, `Expected 2 connections, found ${Object.keys(updatedGlobalModels).length}.`);
-    assert(updatedGlobalModels.conn_1 === 'someData', 'Expected connection data to persist.');
-    assert(updatedGlobalModels.new_conn === 'someMoreData', 'Expected new connection data to exist.');
+    assert(updatedGlobalModels.conn_1 === 'url_that_is_very_saved', 'Expected connection data to persist.');
+    assert(updatedGlobalModels.new_conn === 'another_url_that_is_so_saved', 'Expected new connection data to exist.');
   });
 
   test('addNewConnectionToWorkspaceStore adds the connection to preexisting connections on the workspace store', function () {
     const testExtensionContext = new TestExtensionContext();
     testExtensionContext._workspaceState = {
-      [StorageVariables.WORKSPACE_CONNECTION_MODELS]: {
-        'conn_1': 'someData'
+      [StorageVariables.WORKSPACE_CONNECTION_STRINGS]: {
+        'conn_1': 'very_saved_connection_url'
       }
     };
     const testStorageController = new StorageController(testExtensionContext);
-    testStorageController.addNewConnectionToWorkspaceStore('someMoreData', 'new_conn');
+    testStorageController.addNewConnectionToWorkspaceStore(
+      'this_has_been_saved',
+      'new_conn'
+    );
 
     const updatedWorkspaceModels = testStorageController.get(
-      StorageVariables.WORKSPACE_CONNECTION_MODELS,
+      StorageVariables.WORKSPACE_CONNECTION_STRINGS,
       StorageScope.WORKSPACE
     );
     assert(Object.keys(updatedWorkspaceModels).length === 2, `Expected 2 connections, found ${Object.keys(updatedWorkspaceModels).length}.`);
-    assert(updatedWorkspaceModels.conn_1 === 'someData', 'Expected connection data to persist.');
-    assert(updatedWorkspaceModels.new_conn === 'someMoreData', 'Expected new connection data to exist.');
+    assert(updatedWorkspaceModels.conn_1 === 'very_saved_connection_url', 'Expected connection data to persist.');
+    assert(updatedWorkspaceModels.new_conn === 'this_has_been_saved', 'Expected new connection data to exist.');
   });
 });

--- a/src/test/suite/stubs.ts
+++ b/src/test/suite/stubs.ts
@@ -6,7 +6,9 @@ class TestExtensionContext implements vscode.ExtensionContext {
   logPath: string;
   subscriptions: { dispose(): any }[];
   workspaceState: vscode.Memento;
+  _workspaceState = {};
   globalState: vscode.Memento;
+  _globalState = {};
   extensionPath: string;
   storagePath: string;
 
@@ -19,15 +21,19 @@ class TestExtensionContext implements vscode.ExtensionContext {
     this.logPath = '';
     this.subscriptions = [];
     this.workspaceState = {
-      get: (): void => {},
-      update: (key: string, value: any) => {
-        return new Promise<void>(() => {});
+      get: (key: string): any => {
+        return this._workspaceState[key];
+      },
+      update: (key: string, value: any): Thenable<void> => {
+        return new Promise<void>(() => { this._workspaceState[key] = value; });
       }
     };
     this.globalState = {
-      get: () => {},
-      update: (key: string, value: any) => {
-        return new Promise<void>(() => {});
+      get: (key: string): any => {
+        return this._globalState[key];
+      },
+      update: (key: string, value: any): Thenable<void> => {
+        return new Promise<void>(() => { this._globalState[key] = value; });
       }
     };
     this.extensionPath = '';


### PR DESCRIPTION
https://jira.mongodb.org/browse/VSCODE-34

This PR makes it so that after a new connection is added, it can be saved into either the vscode workspace, globally in vscode, or just kept on the current session. There's a setting that can disable the prompt that asks for where to save the connection in settings. There's an additional setting which dictates when the prompt is disabled, where new connections should be saved (`Global`, `Workspace`, or `Session Only`).

Currently we're storing the entire connection's driverUrl in storage. In the future we'll want to not store the password (or maybe give the option to store it). 

Another thing we could do is expose these connections as settings in the extension settings (an array or object of connections that the user can even add to or configure there in tandem with command palette commands). I'm still thinking on if that's the move, I don't think it would require too much work, and may be something that could be useful to users - open to thoughts on that one. @mmarcon 

It might be nice to display a message on the bottom right reflecting the action that the user took when saving. When ya'll try it does it feel like it needs that?

Here's the prompt after a user adds a new connection (Cancelling with escape makes the connection just exist on the session.):
<img width="613" alt="Screen Shot 2020-02-20 at 10 34 17 AM" src="https://user-images.githubusercontent.com/1791149/74920509-90714e80-53cc-11ea-8d9c-a0db365bb43a.png">
I wanted to use an information message prompt with a few options for this, but their API is fairly restrictive with showing multiple input options, a `Cancel` option is *always* shown as the 2nd to the right option...
<img width="998" alt="Screen Shot 2020-02-20 at 12 44 29 AM" src="https://user-images.githubusercontent.com/1791149/74920658-cdd5dc00-53cc-11ea-8c3a-a20d4d60df45.png">
So I think we're using the best UI we can for this.

Extension connection saving settings:
<img width="769" alt="Screen Shot 2020-02-20 at 10 38 41 AM" src="https://user-images.githubusercontent.com/1791149/74921081-86038480-53cd-11ea-999b-2c294383eea9.png">

Default saving location setting dropdown:
<img width="769" alt="Screen Shot 2020-02-20 at 10 38 58 AM" src="https://user-images.githubusercontent.com/1791149/74921092-8ac83880-53cd-11ea-984b-cf71477d8dbf.png">
