### PR TITLE
VSCODE-28: View collection in editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -197,6 +197,52 @@
         "fastq": "^1.6.0"
       }
     },
+    "@sinonjs/commons": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.1.tgz",
+      "integrity": "sha512-Debi3Baff1Qu1Unc3mjJ96MgpbwTn43S1+9yJ0llWygPwDNu2aaWBD6yc9y/Z8XDRNhx7U+u2UDg2OGQXkclUQ==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.0.tgz",
+      "integrity": "sha512-atR1J/jRXvQAb47gfzSK8zavXy7BcpnYq21ALon0U99etu99vsir0trzIO3wpeLtW+LLVY6X7EkfVTbjGSH8Ww==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
+      "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^5.0.2"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.0.2.tgz",
+      "integrity": "sha512-p3yrEVB5F/1wI+835n+X8llOGRgV8+jw5BHQ/cJoLBUXXZ5U8Tr5ApwPc4L4av/vjla48kVPoN0t6dykQm+Rvg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "@sinonjs/formatio": "^5.0.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "@types/chai": {
       "version": "4.2.9",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.9.tgz",
@@ -3578,6 +3624,12 @@
         "object.assign": "^4.1.0"
       }
     },
+    "just-extend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
+      "dev": true
+    },
     "kerberos": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/kerberos/-/kerberos-1.1.3.tgz",
@@ -4122,6 +4174,12 @@
         "lodash._bindcallback": "^3.0.0",
         "lodash.keys": "^3.0.0"
       }
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
     },
     "lodash.groupby": {
       "version": "3.1.1",
@@ -5970,6 +6028,20 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "nise": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.2.tgz",
+      "integrity": "sha512-ALDnm0pTTyeGdbg5FCpWGd58Nmp3qO8d8x+dU2Fw8lApeJTEBSjkBZZM4S8t6GpKh+czxkfM/TKxpRMroZzwOg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/formatio": "^5.0.1",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
     "node-abi": {
       "version": "2.13.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.13.0.tgz",
@@ -6287,6 +6359,23 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
     },
     "path-type": {
       "version": "4.0.0",
@@ -6857,6 +6946,44 @@
         "decompress-response": "^4.2.0",
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
+      }
+    },
+    "sinon": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.0.tgz",
+      "integrity": "sha512-c4bREcvuK5VuEGyMW/Oim9I3Rq49Vzb0aMdxouFaA44QCFpilc5LJOugrX+mkrvikbqCimxuK+4cnHVNnLR41g==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/formatio": "^5.0.0",
+        "@sinonjs/samsam": "^5.0.1",
+        "diff": "^4.0.2",
+        "nise": "^4.0.1",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "slash": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -846,9 +846,13 @@
       "dev": true
     },
     "bson": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.3.tgz",
-      "integrity": "sha512-TdiJxMVnodVS7r0BdL42y/pqC9cL2iKynVwA0Ho3qbsQYr428veL3l7BQyuqiw+Q5SqqoT0m4srSY/BlZ9AxXg=="
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.0.3.tgz",
+      "integrity": "sha512-7uBjjxwOSuGLmoqGI1UXWpDGc0K2WjR7dC6iaOg4iriNZo6M2EEBb8co4dEPJ5ArYCebPMie0ecgX0TWF+ZUrQ==",
+      "requires": {
+        "buffer": "^5.1.0",
+        "long": "^4.0.0"
+      }
     },
     "buffer": {
       "version": "5.4.3",
@@ -4951,6 +4955,13 @@
         "require_optional": "^1.0.1",
         "safe-buffer": "^5.1.2",
         "saslprep": "^1.0.0"
+      },
+      "dependencies": {
+        "bson": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.3.tgz",
+          "integrity": "sha512-TdiJxMVnodVS7r0BdL42y/pqC9cL2iKynVwA0Ho3qbsQYr428veL3l7BQyuqiw+Q5SqqoT0m4srSY/BlZ9AxXg=="
+        }
       }
     },
     "mongodb-ace-autocompleter": {
@@ -5190,6 +5201,14 @@
         "require_optional": "^1.0.1",
         "safe-buffer": "^5.1.2",
         "saslprep": "^1.0.0"
+      },
+      "dependencies": {
+        "bson": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.3.tgz",
+          "integrity": "sha512-TdiJxMVnodVS7r0BdL42y/pqC9cL2iKynVwA0Ho3qbsQYr428veL3l7BQyuqiw+Q5SqqoT0m4srSY/BlZ9AxXg==",
+          "dev": true
+        }
       }
     },
     "mongodb-data-service": {

--- a/package.json
+++ b/package.json
@@ -83,8 +83,16 @@
       {
         "command": "mdb.openMongoDBShell",
         "title": "MongoDB: Launch Mongo Shell"
+      },
+      {
+        "command": "mdb.viewCollectionDocuments",
+        "title": "View Documents"
       }
     ],
+    "view/item/context": {
+      "command": "mdb.viewCollectionDocuments",
+      "when": "view == mongoDB && viewItem == collectionTreeItem"
+    },
     "configuration": {
       "title": "MongoDB",
       "properties": {

--- a/package.json
+++ b/package.json
@@ -89,9 +89,13 @@
         "title": "View Documents"
       }
     ],
-    "view/item/context": {
-      "command": "mdb.viewCollectionDocuments",
-      "when": "view == mongoDB && viewItem == collectionTreeItem"
+    "menus": {
+      "view/item/context": [
+        {
+          "command": "mdb.viewCollectionDocuments",
+          "when": "view == mongoDB && viewItem == collectionTreeItem"
+        }
+      ]
     },
     "configuration": {
       "title": "MongoDB",
@@ -176,6 +180,7 @@
     "mongodb-ace-autocompleter": "^0.4.1",
     "mongodb-js-precommit": "^2.2.1",
     "mongodb-runner": "^4.8.0",
+    "sinon": "^9.0.0",
     "ts-node": "^8.6.2",
     "typescript": "^3.7.5",
     "vscode-test": "^1.3.0"

--- a/package.json
+++ b/package.json
@@ -186,6 +186,7 @@
     "vscode-test": "^1.3.0"
   },
   "dependencies": {
+    "bson": "^4.0.3",
     "mongodb-connection-model": "^14.5.0",
     "mongodb-data-service": "^16.5.1",
     "ts-log": "^2.1.4"

--- a/src/editors/collectionDocumentsProvider.ts
+++ b/src/editors/collectionDocumentsProvider.ts
@@ -1,0 +1,42 @@
+import * as vscode from 'vscode';
+
+import ConnectionController from '../connectionController';
+
+export const NAMESPACE_URI_IDENTIFIER = 'namespace';
+export const VIEW_COLLECTION_SCHEME = 'VIEW_COLLECTION_SCHEME';
+export const DOCUMENTS_LIMIT = 10;
+
+export default class CollectionViewProvider implements vscode.TextDocumentContentProvider {
+  _connectionController: ConnectionController;
+
+  constructor(connectionController: ConnectionController) {
+    this._connectionController = connectionController;
+  }
+
+  onDidChangeEmitter = new vscode.EventEmitter<vscode.Uri>();
+  onDidChange = this.onDidChangeEmitter.event;
+
+  provideTextDocumentContent(uri: vscode.Uri): Promise<string> {
+    return new Promise(resolve => {
+      const dataservice = this._connectionController.getActiveConnection();
+
+      // Remove the `namespace=` attribute from the uri query.
+      const namespace = uri.query.slice(NAMESPACE_URI_IDENTIFIER.length + 1);
+      dataservice.find(
+        namespace,
+        {}, // No filter.
+        {
+          limit: DOCUMENTS_LIMIT
+        },
+        (err: Error, documents: []) => {
+          if (err) {
+            vscode.window.showErrorMessage(`Unable to list documents: ${err}`);
+            return resolve(`Unable to list documents: ${err}`);
+          }
+
+          return resolve(JSON.stringify(documents, null, 2));
+        }
+      );
+    });
+  }
+}

--- a/src/editors/collectionDocumentsProvider.ts
+++ b/src/editors/collectionDocumentsProvider.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { EJSON } from 'bson';
 
 import ConnectionController from '../connectionController';
 
@@ -34,7 +35,7 @@ export default class CollectionViewProvider implements vscode.TextDocumentConten
             return resolve(`Unable to list documents: ${err}`);
           }
 
-          return resolve(JSON.stringify(documents, null, 2));
+          return resolve(EJSON.stringify(documents, null, 2));
         }
       );
     });

--- a/src/editors/editorsController.ts
+++ b/src/editors/editorsController.ts
@@ -1,0 +1,45 @@
+import * as vscode from 'vscode';
+
+import ConnectionController from '../connectionController';
+import CollectionDocumentsProvider, {
+  NAMESPACE_URI_IDENTIFIER,
+  VIEW_COLLECTION_SCHEME
+} from './collectionDocumentsProvider';
+import { createLogger } from '../logging';
+
+const log = createLogger('editors controller');
+
+/**
+ * This controller manages when our extension needs to open
+ * new editors and the data they need. It also manages active editors.
+ */
+export default class EditorsController {
+  activate(connectionController: ConnectionController): void {
+    log.info('activating...');
+    const collectionViewProvider = new CollectionDocumentsProvider(connectionController);
+
+    vscode.workspace.registerTextDocumentContentProvider(
+      VIEW_COLLECTION_SCHEME, collectionViewProvider
+    );
+
+    log.info('activated.');
+  }
+
+  onViewCollectionDocuments(namespace): Thenable<void> {
+    const uriQuery = `?${NAMESPACE_URI_IDENTIFIER}=${namespace}`;
+    // We attach the current time to ensure a new editor window is opened on
+    // each query and maybe help the user know when the query started.
+    // The part of the URI after the scheme and before the query is the file name.
+    const uri = vscode.Uri.parse(
+      `${VIEW_COLLECTION_SCHEME}:Results: ${namespace} ${Date.now()}.json${uriQuery}`
+    );
+    return new Promise((resolve, reject) => {
+      vscode.workspace.openTextDocument(uri).then((doc) => {
+        vscode.window.showTextDocument(doc, { preview: false }).then(
+          () => resolve(),
+          reject
+        );
+      }, reject);
+    });
+  }
+}

--- a/src/editors/index.ts
+++ b/src/editors/index.ts
@@ -1,0 +1,5 @@
+import EditorsController from './editorsController';
+
+export {
+  EditorsController
+};

--- a/src/explorer/collectionTreeItem.ts
+++ b/src/explorer/collectionTreeItem.ts
@@ -35,6 +35,8 @@ export default class CollectionTreeItem extends vscode.TreeItem
   private _childrenCache: vscode.TreeItem[] = [];
   private _childrenCacheIsUpToDate = false;
 
+  contextValue = 'collectionTreeItem';
+
   // We fetch 1 more than this in order to see if there are more to fetch.
   private _maxDocumentsToShow: number;
 

--- a/src/explorer/collectionTreeItem.ts
+++ b/src/explorer/collectionTreeItem.ts
@@ -40,8 +40,9 @@ export default class CollectionTreeItem extends vscode.TreeItem
   // We fetch 1 more than this in order to see if there are more to fetch.
   private _maxDocumentsToShow: number;
 
-  private _collectionName: string;
-  private _databaseName: string;
+  public collectionName: string;
+  public databaseName: string;
+
   private _dataService: any;
   private _type: CollectionTypes;
 
@@ -57,9 +58,10 @@ export default class CollectionTreeItem extends vscode.TreeItem
   ) {
     super(collection.name, isExpanded ? vscode.TreeItemCollapsibleState.Expanded : vscode.TreeItemCollapsibleState.Collapsed);
 
-    this._collectionName = collection.name;
+    this.collectionName = collection.name;
+    this.databaseName = databaseName;
+
     this._type = collection.type; // Type can be `collection` or `view`.
-    this._databaseName = databaseName;
     this._dataService = dataService;
 
     this.isExpanded = isExpanded;
@@ -70,7 +72,7 @@ export default class CollectionTreeItem extends vscode.TreeItem
   get tooltip(): string {
     return this._type === CollectionTypes.view
       ? 'Read only view'
-      : this._collectionName;
+      : this.collectionName;
   }
 
   getTreeItem(element: CollectionTreeItem): CollectionTreeItem {
@@ -87,7 +89,7 @@ export default class CollectionTreeItem extends vscode.TreeItem
     }
 
     return new Promise((resolve, reject) => {
-      const namespace = `${this._databaseName}.${this._collectionName}`;
+      const namespace = `${this.databaseName}.${this.collectionName}`;
 
       this._dataService.find(
         namespace,

--- a/src/explorer/index.ts
+++ b/src/explorer/index.ts
@@ -1,4 +1,8 @@
 
+import CollectionTreeItem from './collectionTreeItem';
 import ExplorerController from './explorerController';
 
-export { ExplorerController };
+export {
+  CollectionTreeItem,
+  ExplorerController
+};

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -51,6 +51,10 @@ export default class MDBExtensionController implements vscode.Disposable {
     vscode.commands.registerCommand('mdb.refresh', () => this._explorerController.refresh());
     vscode.commands.registerCommand('mdb.reload', () => this._explorerController.refresh());
 
+    vscode.commands.registerCommand('mdb.viewCollectionDocuments', () => {
+      console.log('heererererere');
+    });
+
     log.info('Registered commands.');
   }
 

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -609,7 +609,7 @@ suite('Connection Controller Test Suite', () => {
             Object.keys(postWorkspaceStoreConnections).length === 0,
             `Expected workspace store connections to have 0 connections found ${Object.keys(postWorkspaceStoreConnections).length}`
           );
-        }).then(done).catch(done);
+        }).then(done, done);
     });
   });
 

--- a/src/test/suite/editors/collectionDocumentsProvider.test.ts
+++ b/src/test/suite/editors/collectionDocumentsProvider.test.ts
@@ -1,0 +1,47 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+import CollectionDocumentsProvider from '../../../editors/collectionDocumentsProvider';
+import ConnectionController from '../../../connectionController';
+import { StatusView } from '../../../views';
+import { TestExtensionContext } from '../stubs';
+import { StorageController } from '../../../storage';
+
+suite('Collection Documents Provider Test Suite', () => {
+  test('expected provideTextDocumentContent to parse uri and return documents in the form of a string from a find call', (done) => {
+    const mockActiveConnection = {
+      find: (namespace, filter, options, callback): void => {
+        assert(
+          namespace === 'my-favorite-fruit-is.pineapple',
+          `Expected find namespace to be 'my-favorite-fruit-is.pineapple' found ${namespace}`
+        );
+
+        assert(
+          options.limit === 10,
+          `Expected find limit to be 10, found ${options.limit}`
+        );
+
+        return callback(null, ['Declaration of Independence']);
+      }
+    };
+
+    const mockExtensionContext = new TestExtensionContext();
+    const mockStorageController = new StorageController(mockExtensionContext);
+    const mockConnectionController = new ConnectionController(new StatusView(), mockStorageController);
+    mockConnectionController.setActiveConnection(mockActiveConnection);
+
+    const testCollectionViewProvider = new CollectionDocumentsProvider(mockConnectionController);
+
+    const uri = vscode.Uri.parse(
+      'scheme:Results: filename.json?namespace=my-favorite-fruit-is.pineapple'
+    );
+
+    testCollectionViewProvider.provideTextDocumentContent(uri).then(documents => {
+      assert(
+        documents.includes('Declaration of Independence'),
+        `Expected provideTextDocumentContent to return documents string, found ${documents}`
+      );
+      done();
+    }).catch(done);
+  });
+});

--- a/src/test/suite/editors/collectionDocumentsProvider.test.ts
+++ b/src/test/suite/editors/collectionDocumentsProvider.test.ts
@@ -7,6 +7,17 @@ import { StatusView } from '../../../views';
 import { TestExtensionContext } from '../stubs';
 import { StorageController } from '../../../storage';
 
+const mockDocumentsAsJsonString = `[
+  {
+    "_id": "first_id",
+    "field1": "first_field"
+  },
+  {
+    "_id": "first_id",
+    "field1": "first_field"
+  }
+]`;
+
 suite('Collection Documents Provider Test Suite', () => {
   test('expected provideTextDocumentContent to parse uri and return documents in the form of a string from a find call', (done) => {
     const mockActiveConnection = {
@@ -40,6 +51,41 @@ suite('Collection Documents Provider Test Suite', () => {
       assert(
         documents.includes('Declaration of Independence'),
         `Expected provideTextDocumentContent to return documents string, found ${documents}`
+      );
+      done();
+    }).catch(done);
+  });
+
+  test('expected provideTextDocumentContent to return a ejson.stringify string', (done) => {
+    const mockDocuments = [{
+      _id: 'first_id',
+      field1: 'first_field'
+    }, {
+      _id: 'first_id',
+      field1: 'first_field'
+    }];
+
+    const mockActiveConnection = {
+      find: (namespace, filter, options, callback): void => {
+        return callback(null, mockDocuments);
+      }
+    };
+
+    const mockExtensionContext = new TestExtensionContext();
+    const mockStorageController = new StorageController(mockExtensionContext);
+    const mockConnectionController = new ConnectionController(new StatusView(), mockStorageController);
+    mockConnectionController.setActiveConnection(mockActiveConnection);
+
+    const testCollectionViewProvider = new CollectionDocumentsProvider(mockConnectionController);
+
+    const uri = vscode.Uri.parse(
+      'scheme:Results: filename.json?namespace=test.test'
+    );
+
+    testCollectionViewProvider.provideTextDocumentContent(uri).then(documents => {
+      assert(
+        documents === mockDocumentsAsJsonString,
+        `Expected provideTextDocumentContent to return ejson stringified string, found ${documents}`
       );
       done();
     }).catch(done);

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1,6 +1,5 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
-import { before, after } from 'mocha';
 
 import ConnectionController from '../../connectionController';
 import MDBExtensionController from '../../mdbExtensionController';
@@ -37,7 +36,8 @@ suite('Extension Test Suite', () => {
           'mdb.connectWithURI',
           'mdb.disconnect',
           'mdb.removeConnection',
-          'mdb.openMongoDBShell'
+          'mdb.openMongoDBShell',
+          'mdb.viewCollectionDocuments'
         ];
 
         for (let i = 0; i < expectedCommands.length; i++) {

--- a/src/test/suite/mdbExtensionController.test.ts
+++ b/src/test/suite/mdbExtensionController.test.ts
@@ -1,0 +1,44 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { after } from 'mocha';
+const sinon = require('sinon');
+
+import { CollectionTreeItem } from '../../explorer';
+import { VIEW_COLLECTION_SCHEME } from '../../editors/collectionDocumentsProvider';
+
+suite('MDBExtensionController Test Suite', () => {
+  after(function () {
+    sinon.restore();
+  });
+
+  test('mdb.viewCollectionDocuments command should call onViewCollectionDocuments on the editor controller with the collection namespace', (done) => {
+    const mockOpenTextDocument = sinon.fake.resolves('magna carta');
+    sinon.replace(vscode.workspace, 'openTextDocument', mockOpenTextDocument);
+
+    const mockShowTextDocument = sinon.fake.resolves();
+    sinon.replace(vscode.window, 'showTextDocument', mockShowTextDocument);
+
+    const textCollectionTree = new CollectionTreeItem(
+      {
+        name: 'testColName'
+      },
+      'testDbName',
+      {},
+      false,
+      [],
+      10
+    );
+
+    vscode.commands.executeCommand('mdb.viewCollectionDocuments', textCollectionTree).then(() => {
+      assert(mockOpenTextDocument.firstArg.path.indexOf('Results: testDbName.testColName') === 0);
+      assert(mockOpenTextDocument.firstArg.path.includes('.json'));
+      assert(mockOpenTextDocument.firstArg.scheme === VIEW_COLLECTION_SCHEME);
+      assert(mockOpenTextDocument.firstArg.query === 'namespace=testDbName.testColName');
+
+      assert(
+        mockShowTextDocument.firstArg === 'magna carta',
+        'Expected it to call vscode to show the returned documents from the provider'
+      );
+    }).then(done, done);
+  });
+});


### PR DESCRIPTION
https://jira.mongodb.org/browse/VSCODE-34

This PR adds the right click option `View Documents` to collections in the tree view. It currently shows the first `10` documents resulting from a `find` operation on the collection in a `read-only` `.json` file. In future work we're looking into code lenses to provide an option to show more documents. That work is in here: https://jira.mongodb.org/browse/VSCODE-36 I think once I add something with code lenses I'll also add in a status bar item for while we're performing the request to find the documents.

![Feb-23-2020 21-14-07](https://user-images.githubusercontent.com/1791149/75119305-e589ba80-5681-11ea-8168-e518bc1aae0e.gif)

If there's an error, like internet is disconnected, an error message is displayed in the bottom right and a document like this is opened:
<img width="978" alt="Screen Shot 2020-02-23 at 9 15 16 PM" src="https://user-images.githubusercontent.com/1791149/75119313-018d5c00-5682-11ea-8d85-3776f817126f.png">
