### PR TITLE
VSCODE-43: Show status bar item while fetching documents & creating collections

### DIFF
--- a/src/editors/editorsController.ts
+++ b/src/editors/editorsController.ts
@@ -10,6 +10,7 @@ import CollectionDocumentsProvider, {
 } from './collectionDocumentsProvider';
 import ConnectionController from '../connectionController';
 import { createLogger } from '../logging';
+import { StatusView } from '../views';
 
 const log = createLogger('editors controller');
 
@@ -27,7 +28,8 @@ export default class EditorsController {
     log.info('activating...');
     const collectionViewProvider = new CollectionDocumentsProvider(
       connectionController,
-      this._collectionDocumentsOperationsStore
+      this._collectionDocumentsOperationsStore,
+      new StatusView(context)
     );
 
     this._connectionController = connectionController;

--- a/src/explorer/connectionTreeItem.ts
+++ b/src/explorer/connectionTreeItem.ts
@@ -5,6 +5,7 @@ const path = require('path');
 import DatabaseTreeItem from './databaseTreeItem';
 import ConnectionController from '../connectionController';
 import TreeItemParent from './treeItemParentInterface';
+import { StatusView } from '../views';
 
 export default class ConnectionTreeItem extends vscode.TreeItem
   implements TreeItemParent, vscode.TreeDataProvider<ConnectionTreeItem> {
@@ -169,7 +170,7 @@ export default class ConnectionTreeItem extends vscode.TreeItem
     return this._childrenCache;
   }
 
-  async onAddDatabaseClicked(): Promise<boolean> {
+  async onAddDatabaseClicked(context: vscode.ExtensionContext): Promise<boolean> {
     let databaseName;
     try {
       databaseName = await vscode.window.showInputBox({
@@ -230,11 +231,16 @@ export default class ConnectionTreeItem extends vscode.TreeItem
       return Promise.resolve(false);
     }
 
+    const statusView = new StatusView(context);
+    statusView.showMessage('Creating new database and collection...');
+
     return new Promise((resolve, reject) => {
       this._connectionController.getActiveConnection().createCollection(
         `${databaseName}.${collectionName}`,
         {}, // No options.
         (err) => {
+          statusView.hideMessage();
+
           if (err) {
             return reject(new Error(`Create collection failed: ${err.message}`));
           }

--- a/src/explorer/databaseTreeItem.ts
+++ b/src/explorer/databaseTreeItem.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 const ns = require('mongodb-ns');
 const path = require('path');
+import { StatusView } from '../views';
 
 import CollectionTreeItem, { MAX_DOCUMENTS_VISIBLE } from './collectionTreeItem';
 import TreeItemParent from './treeItemParentInterface';
@@ -127,7 +128,7 @@ export default class DatabaseTreeItem extends vscode.TreeItem
     return this._childrenCache;
   }
 
-  async onAddCollectionClicked(): Promise<boolean> {
+  async onAddCollectionClicked(context: vscode.ExtensionContext): Promise<boolean> {
     const databaseName = this.databaseName;
 
     let collectionName;
@@ -161,11 +162,16 @@ export default class DatabaseTreeItem extends vscode.TreeItem
       return Promise.resolve(false);
     }
 
+    const statusBarItem = new StatusView(context);
+    statusBarItem.showMessage('Creating new collection...');
+
     return new Promise((resolve, reject) => {
       this._dataService.createCollection(
         `${databaseName}.${collectionName}`,
         {}, // No options.
         (err) => {
+          statusBarItem.hideMessage();
+
           if (err) {
             return reject(new Error(`Create collection failed: ${err.message}`));
           }

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -29,7 +29,7 @@ export default class MDBExtensionController implements vscode.Disposable {
     context: vscode.ExtensionContext,
     connectionController?: ConnectionController
   ) {
-    this._statusView = new StatusView();
+    this._statusView = new StatusView(context);
     const storageController = new StorageController(context);
 
     if (connectionController) {
@@ -92,7 +92,7 @@ export default class MDBExtensionController implements vscode.Disposable {
     );
 
     this.registerEditorCommands();
-    this.registerTreeViewCommands();
+    this.registerTreeViewCommands(context);
 
     log.info('Registered commands.');
   }
@@ -111,7 +111,7 @@ export default class MDBExtensionController implements vscode.Disposable {
     });
   }
 
-  registerTreeViewCommands(): void {
+  registerTreeViewCommands(context: vscode.ExtensionContext): void {
     this.registerCommand(
       'mdb.addConnection',
       () => this._connectionController.addMongoDBConnection()
@@ -178,7 +178,7 @@ export default class MDBExtensionController implements vscode.Disposable {
         }
 
         return new Promise((resolve, reject) => {
-          element.onAddDatabaseClicked().then(successfullyAddedDatabase => {
+          element.onAddDatabaseClicked(context).then(successfullyAddedDatabase => {
             if (successfullyAddedDatabase) {
               vscode.window.showInformationMessage('Database and collection successfully created.');
 
@@ -217,7 +217,7 @@ export default class MDBExtensionController implements vscode.Disposable {
         }
 
         return new Promise((resolve, reject) => {
-          element.onAddCollectionClicked().then(successfullyAddedCollection => {
+          element.onAddCollectionClicked(context).then(successfullyAddedCollection => {
             if (successfullyAddedCollection) {
               vscode.window.showInformationMessage('Collection successfully created.');
 

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -31,7 +31,7 @@ suite('Connection Controller Test Suite', () => {
 
   test('it connects to mongodb', function (done) {
     const testConnectionController = new ConnectionController(
-      new StatusView(),
+      new StatusView(mockExtensionContext),
       mockStorageController
     );
 
@@ -57,7 +57,7 @@ suite('Connection Controller Test Suite', () => {
 
   test('"disconnect()" disconnects from the active connection', function (done) {
     const testConnectionController = new ConnectionController(
-      new StatusView(),
+      new StatusView(mockExtensionContext),
       mockStorageController
     );
     this.timeout(2000);
@@ -97,7 +97,7 @@ suite('Connection Controller Test Suite', () => {
 
   test('when the extension is deactivated, the active connection is disconnected', function (done) {
     const testConnectionController = new ConnectionController(
-      new StatusView(),
+      new StatusView(mockExtensionContext),
       mockStorageController
     );
 
@@ -129,7 +129,7 @@ suite('Connection Controller Test Suite', () => {
 
   test('"removeMongoDBConnection()" returns a reject promise when there is no active connection', done => {
     const testConnectionController = new ConnectionController(
-      new StatusView(),
+      new StatusView(mockExtensionContext),
       mockStorageController
     );
 
@@ -143,7 +143,7 @@ suite('Connection Controller Test Suite', () => {
 
   test('"disconnect()" fails when there is no active connection', done => {
     const testConnectionController = new ConnectionController(
-      new StatusView(),
+      new StatusView(mockExtensionContext),
       mockStorageController
     );
 
@@ -157,7 +157,7 @@ suite('Connection Controller Test Suite', () => {
 
   test('when adding a new connection it disconnects from the current connection', function (done) {
     const testConnectionController = new ConnectionController(
-      new StatusView(),
+      new StatusView(mockExtensionContext),
       mockStorageController
     );
     this.timeout(2000);
@@ -189,7 +189,7 @@ suite('Connection Controller Test Suite', () => {
 
   test('when adding a new connection it disconnects from the current connection', function (done) {
     const testConnectionController = new ConnectionController(
-      new StatusView(),
+      new StatusView(mockExtensionContext),
       mockStorageController
     );
     this.timeout(2000);
@@ -221,7 +221,7 @@ suite('Connection Controller Test Suite', () => {
 
   test('"connect()" failed when we are currently connecting', function (done) {
     const testConnectionController = new ConnectionController(
-      new StatusView(),
+      new StatusView(mockExtensionContext),
       mockStorageController
     );
 
@@ -237,7 +237,7 @@ suite('Connection Controller Test Suite', () => {
 
   test('"connect()" failed when we are currently disconnecting', function (done) {
     const testConnectionController = new ConnectionController(
-      new StatusView(),
+      new StatusView(mockExtensionContext),
       mockStorageController
     );
 
@@ -253,7 +253,7 @@ suite('Connection Controller Test Suite', () => {
 
   test('"disconnect()" fails when we are currently connecting', function (done) {
     const testConnectionController = new ConnectionController(
-      new StatusView(),
+      new StatusView(mockExtensionContext),
       mockStorageController
     );
 
@@ -269,7 +269,7 @@ suite('Connection Controller Test Suite', () => {
 
   test('"disconnect()" fails when we are currently disconnecting', function (done) {
     const testConnectionController = new ConnectionController(
-      new StatusView(),
+      new StatusView(mockExtensionContext),
       mockStorageController
     );
 
@@ -285,7 +285,7 @@ suite('Connection Controller Test Suite', () => {
 
   test('"connect()" should fire a CONNECTIONS_DID_CHANGE event', function (done) {
     const testConnectionController = new ConnectionController(
-      new StatusView(),
+      new StatusView(mockExtensionContext),
       mockStorageController
     );
 
@@ -314,7 +314,7 @@ suite('Connection Controller Test Suite', () => {
   const expectedTimesToFire = 3;
   test(`"connect()" then "disconnect()" should fire the connections did change event ${expectedTimesToFire} times`, function (done) {
     const testConnectionController = new ConnectionController(
-      new StatusView(),
+      new StatusView(mockExtensionContext),
       mockStorageController
     );
 
@@ -347,7 +347,7 @@ suite('Connection Controller Test Suite', () => {
     const testStorageController = new StorageController(testExtensionContext);
 
     const testConnectionController = new ConnectionController(
-      new StatusView(),
+      new StatusView(mockExtensionContext),
       testStorageController
     );
 
@@ -378,7 +378,7 @@ suite('Connection Controller Test Suite', () => {
     const testStorageController = new StorageController(testExtensionContext);
 
     const testConnectionController = new ConnectionController(
-      new StatusView(),
+      new StatusView(mockExtensionContext),
       testStorageController
     );
 
@@ -408,7 +408,7 @@ suite('Connection Controller Test Suite', () => {
     const testStorageController = new StorageController(testExtensionContext);
 
     const testConnectionController = new ConnectionController(
-      new StatusView(),
+      new StatusView(mockExtensionContext),
       testStorageController
     );
 
@@ -443,7 +443,7 @@ suite('Connection Controller Test Suite', () => {
     const testStorageController = new StorageController(testExtensionContext);
 
     const testConnectionController = new ConnectionController(
-      new StatusView(),
+      new StatusView(mockExtensionContext),
       testStorageController
     );
 
@@ -482,7 +482,7 @@ suite('Connection Controller Test Suite', () => {
     const testStorageController = new StorageController(testExtensionContext);
 
     const testConnectionController = new ConnectionController(
-      new StatusView(),
+      new StatusView(mockExtensionContext),
       testStorageController
     );
 
@@ -539,7 +539,7 @@ suite('Connection Controller Test Suite', () => {
     const testStorageController = new StorageController(testExtensionContext);
 
     const testConnectionController = new ConnectionController(
-      new StatusView(),
+      new StatusView(mockExtensionContext),
       testStorageController
     );
 
@@ -564,7 +564,7 @@ suite('Connection Controller Test Suite', () => {
     const testStorageController = new StorageController(testExtensionContext);
 
     const testConnectionController = new ConnectionController(
-      new StatusView(),
+      new StatusView(mockExtensionContext),
       testStorageController
     );
 
@@ -603,7 +603,7 @@ suite('Connection Controller Test Suite', () => {
     const testStorageController = new StorageController(testExtensionContext);
 
     const testConnectionController = new ConnectionController(
-      new StatusView(),
+      new StatusView(mockExtensionContext),
       testStorageController
     );
 
@@ -645,7 +645,7 @@ suite('Connection Controller Test Suite', () => {
     const testStorageController = new StorageController(testExtensionContext);
 
     const testConnectionController = new ConnectionController(
-      new StatusView(),
+      new StatusView(mockExtensionContext),
       testStorageController
     );
 

--- a/src/test/suite/explorer/explorerController.test.ts
+++ b/src/test/suite/explorer/explorerController.test.ts
@@ -36,7 +36,7 @@ suite('Explorer Controller Test Suite', function () {
 
   test('when activated it creates a tree with a connections root', function (done) {
     const testConnectionController = new ConnectionController(
-      new StatusView(),
+      new StatusView(mockExtensionContext),
       mockStorageController
     );
 
@@ -67,7 +67,7 @@ suite('Explorer Controller Test Suite', function () {
 
   test('it updates the connections to account for a change in the connection controller', function (done) {
     const testConnectionController = new ConnectionController(
-      new StatusView(),
+      new StatusView(mockExtensionContext),
       mockStorageController
     );
 
@@ -108,7 +108,7 @@ suite('Explorer Controller Test Suite', function () {
 
   test('when a connection is added and connected it is added to the tree and expanded', function (done) {
     const testConnectionController = new ConnectionController(
-      new StatusView(),
+      new StatusView(mockExtensionContext),
       mockStorageController
     );
 
@@ -170,7 +170,7 @@ suite('Explorer Controller Test Suite', function () {
 
   test('only the active connection is displayed as connected in the tree', function (done) {
     const testConnectionController = new ConnectionController(
-      new StatusView(),
+      new StatusView(mockExtensionContext),
       mockStorageController
     );
 
@@ -248,7 +248,7 @@ suite('Explorer Controller Test Suite', function () {
 
   test('shows the databases of connected connection in tree', function (done) {
     const testConnectionController = new ConnectionController(
-      new StatusView(),
+      new StatusView(mockExtensionContext),
       mockStorageController
     );
     const testExplorerController = new ExplorerController();
@@ -292,7 +292,7 @@ suite('Explorer Controller Test Suite', function () {
 
   test('caches the expanded state of databases in the tree when a connection is expanded or collapsed', function (done) {
     const testConnectionController = new ConnectionController(
-      new StatusView(),
+      new StatusView(mockExtensionContext),
       mockStorageController
     );
 

--- a/src/views/statusView.ts
+++ b/src/views/statusView.ts
@@ -3,16 +3,20 @@ import * as vscode from 'vscode';
 export default class StatusView {
   _statusBarItem: vscode.StatusBarItem;
 
-  constructor() {
+  constructor(context: vscode.ExtensionContext) {
     this._statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 0);
+
+    context.subscriptions.push(
+      this._statusBarItem
+    );
   }
 
-  public showMessage(message: string) {
+  public showMessage(message: string): void {
     this._statusBarItem.text = message;
     this._statusBarItem.show();
   }
 
-  public hideMessage() {
+  public hideMessage(): void {
     this._statusBarItem.hide();
   }
 }


### PR DESCRIPTION
https://jira.mongodb.org/browse/VSCODE-53

This PR adds showing a status bar item message when we're fetching collection documents (view documents and `show more` code lens) and when we're creating a collection (create database and create collection in the tree view). Easy way to test is to disable your internet when you run one of the commands. Hopefully this will feel like some decent feedback that the operation is running when things are taking some time.

I added context to the status view parameters so when the extension is disposed it cleans up a bit better. Going to read up on how vscode prefers disposal. ah just saw https://code.visualstudio.com/api/references/icons-in-labels might incorporate...

![stataus bar](https://user-images.githubusercontent.com/1791149/75833725-34d69600-5dba-11ea-9cb5-99f48c2655c4.gif)
