### PR TITLE
VSCODE-52: Add connect disconnect and drop database collection explorer actions

### DIFF
--- a/images/mongodb-original.svg
+++ b/images/mongodb-original.svg
@@ -2,7 +2,7 @@
   id="Layer_1"
   data-name="Layer 1"
   xmlns="http://www.w3.org/2000/svg"
-  viewBox="-111.92375 -250 1119.2375 2500"
+  viewBox="0 0 895.39 2000"
 >
   <defs>
     <style>.cls-1{fill:#c2bfbf;}.cls-2{fill:#599636;}.cls-3{fill:#69b240;}</style>

--- a/images/mongodb.svg
+++ b/images/mongodb.svg
@@ -2,7 +2,7 @@
   id="Layer_1"
   data-name="Layer 1"
   xmlns="http://www.w3.org/2000/svg"
-  viewBox="-111.92375 -250 1119.2375 2500"
+  viewBox="-179.078 -400 1253.546 2800"
 >
   <defs>
     <style>.cls-1{fill:#c2bfbf;}.cls-2{fill:#599636;}.cls-3{fill:#69b240;}</style>

--- a/package.json
+++ b/package.json
@@ -159,6 +159,10 @@
         "title": "Copy Database Name"
       },
       {
+        "command": "mdb.dropDatabase",
+        "title": "Drop Database..."
+      },
+      {
         "command": "mdb.refreshDatabase",
         "title": "Refresh"
       },
@@ -177,6 +181,10 @@
       {
         "command": "mdb.copyCollectionName",
         "title": "Copy Collection Name"
+      },
+      {
+        "command": "mdb.dropCollection",
+        "title": "Drop Collection..."
       },
       {
         "command": "mdb.refreshCollection",
@@ -237,6 +245,10 @@
           "when": "view == mongoDB && viewItem == databaseTreeItem"
         },
         {
+          "command": "mdb.dropDatabase",
+          "when": "view == mongoDB && viewItem == databaseTreeItem"
+        },
+        {
           "command": "mdb.copyDatabaseName",
           "when": "view == mongoDB && viewItem == databaseTreeItem"
         },
@@ -246,6 +258,10 @@
         },
         {
           "command": "mdb.viewCollectionDocuments",
+          "when": "view == mongoDB && viewItem == collectionTreeItem"
+        },
+        {
+          "command": "mdb.dropCollection",
           "when": "view == mongoDB && viewItem == collectionTreeItem"
         },
         {

--- a/package.json
+++ b/package.json
@@ -216,11 +216,19 @@
         },
         {
           "command": "mdb.treeItemRemoveConnection",
-          "when": "view == mongoDB && (viewItem == connectedConnectionTreeItem || viewItem == disconnectedConnectionTreeItem)"
+          "when": "view == mongoDB && viewItem == disconnectedConnectionTreeItem"
+        },
+        {
+          "command": "mdb.treeItemRemoveConnection",
+          "when": "view == mongoDB && viewItem == connectedConnectionTreeItem"
         },
         {
           "command": "mdb.copyConnectionString",
-          "when": "view == mongoDB && (viewItem == connectedConnectionTreeItem || viewItem == disconnectedConnectionTreeItem)"
+          "when": "view == mongoDB && viewItem == disconnectedConnectionTreeItem"
+        },
+        {
+          "command": "mdb.copyConnectionString",
+          "when": "view == mongoDB && viewItem == connectedConnectionTreeItem"
         },
         {
           "command": "mdb.refreshConnection",

--- a/package.json
+++ b/package.json
@@ -143,6 +143,14 @@
         }
       },
       {
+        "command": "mdb.connectToConnectionTreeItem",
+        "title": "Connect"
+      },
+      {
+        "command": "mdb.disconnectFromConnectionTreeItem",
+        "title": "Disconnect"
+      },
+      {
         "command": "mdb.refreshConnection",
         "title": "Refresh"
       },
@@ -191,25 +199,33 @@
           "when": "view == mongoDB && viewItem == mdbConnectionsTreeItem"
         },
         {
+          "command": "mdb.connectToConnectionTreeItem",
+          "when": "view == mongoDB && viewItem == disconnectedConnectionTreeItem"
+        },
+        {
+          "command": "mdb.disconnectFromConnectionTreeItem",
+          "when": "view == mongoDB && viewItem == connectedConnectionTreeItem"
+        },
+        {
           "command": "mdb.treeItemRemoveConnection",
-          "when": "view == mongoDB && viewItem == connectionTreeItem"
+          "when": "view == mongoDB && (viewItem == connectedConnectionTreeItem || viewItem == disconnectedConnectionTreeItem)"
         },
         {
           "command": "mdb.copyConnectionString",
-          "when": "view == mongoDB && viewItem == connectionTreeItem"
+          "when": "view == mongoDB && (viewItem == connectedConnectionTreeItem || viewItem == disconnectedConnectionTreeItem)"
         },
         {
           "command": "mdb.refreshConnection",
-          "when": "view == mongoDB && viewItem == connectionTreeItem"
+          "when": "view == mongoDB && viewItem == connectedConnectionTreeItem"
         },
         {
           "command": "mdb.addDatabase",
-          "when": "view == mongoDB && viewItem == connectionTreeItem",
+          "when": "view == mongoDB && viewItem == connectedConnectionTreeItem",
           "group": "inline"
         },
         {
           "command": "mdb.addDatabase",
-          "when": "view == mongoDB && viewItem == connectionTreeItem"
+          "when": "view == mongoDB && viewItem == connectedConnectionTreeItem"
         },
         {
           "command": "mdb.addCollection",

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -314,8 +314,6 @@ export default class ConnectionController {
     });
   }
 
-  // TODO: Shrink size of the leaf on the left view.
-
   public removeConnectionConfig(connectionId: string): void {
     delete this._connectionConfigs[connectionId];
     this._storageController.removeConnection(connectionId);

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -57,7 +57,7 @@ export default class ConnectionController {
     this._storageController = storageController;
   }
 
-  activate(): void {
+  loadSavedConnections(): void {
     // Load saved connections from storage.
     const existingGlobalConnectionStrings = this._storageController.get(
       StorageVariables.GLOBAL_CONNECTION_STRINGS

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -250,7 +250,7 @@ export default class ConnectionController {
     });
   }
 
-  public async connectWithInstanceId(connectionId: string): Promise<any> {
+  public async connectWithInstanceId(connectionId: string): Promise<boolean> {
     if (this._connectionConfigs[connectionId]) {
       return this.connect(this._connectionConfigs[connectionId]);
     }
@@ -265,9 +265,15 @@ export default class ConnectionController {
     );
 
     if (this._disconnecting) {
-      // TODO: The desired UX here may be for the connection to be interrupted.
       return Promise.reject(
         new Error('Unable to disconnect: already disconnecting from an instance.')
+      );
+    }
+
+    if (this._connecting) {
+      // TODO: The desired UX here may be for the connection to be interrupted.
+      return Promise.reject(
+        new Error('Unable to disconnect: currently connecting to an instance.')
       );
     }
 

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -455,8 +455,14 @@ export default class ConnectionController {
   public getActiveConnectionConfig(): any {
     return this._currentConnectionConfig;
   }
-  public clearConnectionConfigs(): void {
+  public clearAllConnections(): void {
     this._connectionConfigs = {};
+    this._currentConnectionConfig = null;
+    this._currentConnectionInstanceId = null;
+    this._currentConnection = null;
+    this._connecting = false;
+    this._disconnecting = false;
+    this._connectingInstanceId = '';
   }
   public setActiveConnection(newActiveConnection: any): void {
     this._currentConnection = newActiveConnection;

--- a/src/editors/collectionDocumentsCodeLensProvider.ts
+++ b/src/editors/collectionDocumentsCodeLensProvider.ts
@@ -8,12 +8,16 @@ import {
   OPERATION_ID_URI_IDENTIFIER
 } from './collectionDocumentsProvider';
 
-export default class CollectionDocumentsCodeLensProvider implements vscode.CodeLensProvider {
+export default class CollectionDocumentsCodeLensProvider
+  implements vscode.CodeLensProvider {
   private _codeLenses: vscode.CodeLens[] = [];
   private _activeOperationsStore: CollectionDocumentsOperationStore;
   private uri: vscode.Uri = vscode.Uri.parse('');
-  private _onDidChangeCodeLenses: vscode.EventEmitter<void> = new vscode.EventEmitter<void>();
-  public readonly onDidChangeCodeLenses: vscode.Event<void> = this._onDidChangeCodeLenses.event;
+  private _onDidChangeCodeLenses: vscode.EventEmitter<
+    void
+  > = new vscode.EventEmitter<void>();
+  public readonly onDidChangeCodeLenses: vscode.Event<void> = this
+    ._onDidChangeCodeLenses.event;
 
   constructor(operationsStore: CollectionDocumentsOperationStore) {
     this._activeOperationsStore = operationsStore;
@@ -23,38 +27,37 @@ export default class CollectionDocumentsCodeLensProvider implements vscode.CodeL
     });
   }
 
-  public provideCodeLenses(
-    document: vscode.TextDocument
-  ): vscode.CodeLens[] {
+  public provideCodeLenses(document: vscode.TextDocument): vscode.CodeLens[] {
     const uriParams = new URLSearchParams(document.uri.query);
     const operationId = uriParams.get(OPERATION_ID_URI_IDENTIFIER);
     if (!operationId) {
       return [];
     }
 
-    if (!this._activeOperationsStore.operations[operationId].hasMoreDocumentsToShow) {
+    if (
+      !this._activeOperationsStore.operations[operationId]
+        .hasMoreDocumentsToShow
+    ) {
       return [];
     }
 
     // Create a codelens at the second to last line. This should be before
     // the closing ']'.
-    this._codeLenses = [new vscode.CodeLens(new vscode.Range(
-      new vscode.Position(
-        document.lineCount - 1, 0
-      ),
-      new vscode.Position(
-        document.lineCount, 0
-      ),
-    ))];
+    this._codeLenses = [
+      new vscode.CodeLens(
+        new vscode.Range(
+          new vscode.Position(document.lineCount - 1, 0),
+          new vscode.Position(document.lineCount, 0)
+        )
+      )
+    ];
 
     this.uri = document.uri;
 
     return this._codeLenses;
   }
 
-  public resolveCodeLens?(
-    codeLens: vscode.CodeLens
-  ): vscode.CodeLens {
+  public resolveCodeLens?(codeLens: vscode.CodeLens): vscode.CodeLens {
     const uriParams = new URLSearchParams(this.uri.query);
 
     const namespace = uriParams.get(NAMESPACE_URI_IDENTIFIER);
@@ -72,11 +75,12 @@ export default class CollectionDocumentsCodeLensProvider implements vscode.CodeL
     let commandTooltip;
     if (operation.isCurrentlyFetchingMoreDocuments) {
       commandTitle = `... Fetching ${amountOfDocs} documents...`;
-      commandTooltip = 'Currently fetching more documents. The amount of documents fetched can be adjusted in the extension settings.';
+      commandTooltip =
+        'Currently fetching more documents. The amount of documents fetched can be adjusted in the extension settings.';
     } else {
-      const additionalDocumentsToFetch = vscode.workspace.getConfiguration(
-        'mdb'
-      ).get('defaultLimit');
+      const additionalDocumentsToFetch = vscode.workspace
+        .getConfiguration('mdb')
+        .get('defaultLimit');
 
       commandTitle = `... Showing ${amountOfDocs} documents. Click to open ${additionalDocumentsToFetch} more documents.`;
       commandTooltip = `Click to open ${additionalDocumentsToFetch} more documents, this amount can be changed in the extension settings.`;

--- a/src/editors/collectionDocumentsCodeLensProvider.ts
+++ b/src/editors/collectionDocumentsCodeLensProvider.ts
@@ -8,8 +8,7 @@ import {
   OPERATION_ID_URI_IDENTIFIER
 } from './collectionDocumentsProvider';
 
-export default class CollectionDocumentsCodeLensProvider
-  implements vscode.CodeLensProvider {
+export default class CollectionDocumentsCodeLensProvider implements vscode.CodeLensProvider {
   private _codeLenses: vscode.CodeLens[] = [];
   private _activeOperationsStore: CollectionDocumentsOperationStore;
   private uri: vscode.Uri = vscode.Uri.parse('');

--- a/src/editors/collectionDocumentsOperationsStore.ts
+++ b/src/editors/collectionDocumentsOperationsStore.ts
@@ -22,10 +22,12 @@ export default class CollectionDocumentsOperationsStore {
   createNewOperation(): string {
     const operationId = uuidv4();
 
-    const initialDocumentsLimit = vscode.workspace.getConfiguration(
-      'mdb'
-    ).get(DEFAULT_LIMIT_CONFIG_NAME);
-    this.operations[operationId] = new CollectionDocumentsOperation(Number(initialDocumentsLimit));
+    const initialDocumentsLimit = vscode.workspace
+      .getConfiguration('mdb')
+      .get(DEFAULT_LIMIT_CONFIG_NAME);
+    this.operations[operationId] = new CollectionDocumentsOperation(
+      Number(initialDocumentsLimit)
+    );
 
     return operationId;
   }
@@ -33,9 +35,11 @@ export default class CollectionDocumentsOperationsStore {
   increaseOperationDocumentLimit(operationId: string): void {
     this.operations[operationId].isCurrentlyFetchingMoreDocuments = false;
 
-    const additionalDocumentsToFetch = vscode.workspace.getConfiguration(
-      'mdb'
-    ).get(DEFAULT_LIMIT_CONFIG_NAME);
-    this.operations[operationId].currentLimit += Number(additionalDocumentsToFetch);
+    const additionalDocumentsToFetch = vscode.workspace
+      .getConfiguration('mdb')
+      .get(DEFAULT_LIMIT_CONFIG_NAME);
+    this.operations[operationId].currentLimit += Number(
+      additionalDocumentsToFetch
+    );
   }
 }

--- a/src/editors/collectionDocumentsProvider.ts
+++ b/src/editors/collectionDocumentsProvider.ts
@@ -12,8 +12,7 @@ export const CONNECTION_ID_URI_IDENTIFIER = 'connectionId';
 
 export const VIEW_COLLECTION_SCHEME = 'VIEW_COLLECTION_SCHEME';
 
-export default class CollectionViewProvider
-  implements vscode.TextDocumentContentProvider {
+export default class CollectionViewProvider implements vscode.TextDocumentContentProvider {
   _connectionController: ConnectionController;
   _operationsStore: CollectionDocumentsOperationsStore;
   _statusView: StatusView;

--- a/src/editors/collectionDocumentsProvider.ts
+++ b/src/editors/collectionDocumentsProvider.ts
@@ -12,7 +12,8 @@ export const CONNECTION_ID_URI_IDENTIFIER = 'connectionId';
 
 export const VIEW_COLLECTION_SCHEME = 'VIEW_COLLECTION_SCHEME';
 
-export default class CollectionViewProvider implements vscode.TextDocumentContentProvider {
+export default class CollectionViewProvider
+  implements vscode.TextDocumentContentProvider {
   _connectionController: ConnectionController;
   _operationsStore: CollectionDocumentsOperationsStore;
   _statusView: StatusView;
@@ -38,7 +39,9 @@ export default class CollectionViewProvider implements vscode.TextDocumentConten
       const operationId = uriParams.get(OPERATION_ID_URI_IDENTIFIER);
 
       if (!operationId) {
-        vscode.window.showErrorMessage('Unable to list documents: invalid operation');
+        vscode.window.showErrorMessage(
+          'Unable to list documents: invalid operation'
+        );
         return reject(new Error('Unable to list documents: invalid operation'));
       }
 
@@ -46,10 +49,19 @@ export default class CollectionViewProvider implements vscode.TextDocumentConten
       const documentLimit = operation.currentLimit;
 
       // Ensure we're still connected to the correct connection.
-      if (connectionInstanceId !== this._connectionController.getActiveConnectionInstanceId()) {
+      if (
+        connectionInstanceId !==
+        this._connectionController.getActiveConnectionInstanceId()
+      ) {
         operation.isCurrentlyFetchingMoreDocuments = false;
-        vscode.window.showErrorMessage(`Unable to list documents: no longer connected to ${connectionInstanceId}`);
-        return reject(new Error(`Unable to list documents: no longer connected to ${connectionInstanceId}`));
+        vscode.window.showErrorMessage(
+          `Unable to list documents: no longer connected to ${connectionInstanceId}`
+        );
+        return reject(
+          new Error(
+            `Unable to list documents: no longer connected to ${connectionInstanceId}`
+          )
+        );
       }
 
       this._statusView.showMessage('Fetching documents...');
@@ -66,8 +78,12 @@ export default class CollectionViewProvider implements vscode.TextDocumentConten
           this._statusView.hideMessage();
 
           if (err) {
-            vscode.window.showErrorMessage(`Unable to list documents: ${err.message}`);
-            return reject(new Error(`Unable to list documents: ${err.message}`));
+            vscode.window.showErrorMessage(
+              `Unable to list documents: ${err.message}`
+            );
+            return reject(
+              new Error(`Unable to list documents: ${err.message}`)
+            );
           }
 
           if (documents.length !== documentLimit) {

--- a/src/editors/editorsController.ts
+++ b/src/editors/editorsController.ts
@@ -93,19 +93,19 @@ export default class EditorsController {
   onViewMoreCollectionDocuments(operationId: string, connectionId: string, namespace: string): Promise<boolean> {
     log.info('view more collection documents');
 
+    // A user might click to fetch more documents multiple times,
+    // this ensures it only performs one fetch at a time.
     if (this._collectionDocumentsOperationsStore.operations[operationId].isCurrentlyFetchingMoreDocuments) {
-      // A user might click to fetch more documents multiple times,
-      // this ensures it only performs one fetch at a time.
-      return Promise.reject(new Error('Already fetching more documents...'));
+      vscode.window.showErrorMessage('Already fetching more documents...');
+      return Promise.resolve(false);
     }
 
     // Ensure we're still connected to the correct connection.
     if (!this._connectionController
       || connectionId !== this._connectionController.getActiveConnectionInstanceId()
     ) {
-      return Promise.reject(new Error(
-        `Unable to view more documents: no longer connected to ${connectionId}`
-      ));
+      vscode.window.showErrorMessage(`Unable to view more documents: no longer connected to ${connectionId}`);
+      return Promise.resolve(false);
     }
 
     if (!this._collectionViewProvider) {

--- a/src/editors/editorsController.ts
+++ b/src/editors/editorsController.ts
@@ -24,15 +24,15 @@ export default class EditorsController {
 
   _collectionViewProvider?: CollectionDocumentsProvider;
 
-  activate(context: vscode.ExtensionContext, connectionController: ConnectionController): void {
+  constructor(context: vscode.ExtensionContext, connectionController: ConnectionController) {
     log.info('activating...');
+    this._connectionController = connectionController;
+
     const collectionViewProvider = new CollectionDocumentsProvider(
       connectionController,
       this._collectionDocumentsOperationsStore,
       new StatusView(context)
     );
-
-    this._connectionController = connectionController;
 
     context.subscriptions.push(
       vscode.workspace.registerTextDocumentContentProvider(
@@ -52,7 +52,7 @@ export default class EditorsController {
     log.info('activated.');
   }
 
-  getViewCollectionDocumentsUri(operationId, namespace, connectionId): vscode.Uri {
+  static getViewCollectionDocumentsUri(operationId, namespace, connectionId): vscode.Uri {
     // We attach a unique id to the query so that it creates a new file in
     // the editor and so that we can virtually manage the amount of docs shown.
     const operationIdUriQuery = `${OPERATION_ID_URI_IDENTIFIER}=${operationId}`;
@@ -75,7 +75,7 @@ export default class EditorsController {
 
     const operationId = this._collectionDocumentsOperationsStore.createNewOperation();
 
-    const uri = this.getViewCollectionDocumentsUri(
+    const uri = EditorsController.getViewCollectionDocumentsUri(
       operationId,
       namespace,
       this._connectionController.getActiveConnectionInstanceId()
@@ -112,7 +112,7 @@ export default class EditorsController {
       return Promise.reject(new Error('No registered collection view provider.'));
     }
 
-    const uri = this.getViewCollectionDocumentsUri(
+    const uri = EditorsController.getViewCollectionDocumentsUri(
       operationId,
       namespace,
       connectionId

--- a/src/explorer/collectionTreeItem.ts
+++ b/src/explorer/collectionTreeItem.ts
@@ -56,7 +56,12 @@ export default class CollectionTreeItem extends vscode.TreeItem
     existingChildrenCache: vscode.TreeItem[],
     maxDocumentsToShow: number
   ) {
-    super(collection.name, isExpanded ? vscode.TreeItemCollapsibleState.Expanded : vscode.TreeItemCollapsibleState.Collapsed);
+    super(
+      collection.name,
+      isExpanded
+        ? vscode.TreeItemCollapsibleState.Expanded
+        : vscode.TreeItemCollapsibleState.Collapsed
+    );
 
     this.collectionName = collection.name;
     this.databaseName = databaseName;
@@ -93,7 +98,9 @@ export default class CollectionTreeItem extends vscode.TreeItem
 
       this._dataService.find(
         namespace,
-        { /* No filter */ },
+        {
+          /* No filter */
+        },
         {
           // We fetch 1 more than the max documents to show to see if
           // there are more documents we aren't showing.
@@ -107,19 +114,17 @@ export default class CollectionTreeItem extends vscode.TreeItem
           this._childrenCacheIsUpToDate = true;
 
           if (documents) {
-            this._childrenCache = documents.map(
-              (document, index) => {
-                if (index === this._maxDocumentsToShow) {
-                  return new ShowMoreDocumentsTreeItem(
-                    namespace,
-                    () => this.onShowMoreClicked(),
-                    this._maxDocumentsToShow
-                  );
-                }
-
-                return new DocumentTreeItem(document, index);
+            this._childrenCache = documents.map((document, index) => {
+              if (index === this._maxDocumentsToShow) {
+                return new ShowMoreDocumentsTreeItem(
+                  namespace,
+                  () => this.onShowMoreClicked(),
+                  this._maxDocumentsToShow
+                );
               }
-            );
+
+              return new DocumentTreeItem(document, index);
+            });
           } else {
             this._childrenCache = [];
           }
@@ -130,16 +135,32 @@ export default class CollectionTreeItem extends vscode.TreeItem
     });
   }
 
-  get iconPath(): string | vscode.Uri | { light: string | vscode.Uri; dark: string | vscode.Uri } {
-    return this._type === CollectionTypes.collection
-      ? {
-        light: path.join(__filename, '..', '..', '..', 'resources', 'light', 'collection.svg'),
-        dark: path.join(__filename, '..', '..', '..', 'resources', 'dark', 'collection.svg')
-      }
-      : {
-        light: path.join(__filename, '..', '..', '..', 'resources', 'light', 'view.svg'),
-        dark: path.join(__filename, '..', '..', '..', 'resources', 'dark', 'view.svg')
-      };
+  get iconPath():
+    | string
+    | vscode.Uri
+    | { light: string | vscode.Uri; dark: string | vscode.Uri } {
+    const iconName =
+      this._type === CollectionTypes.collection ? 'collection' : 'view';
+    return {
+      light: path.join(
+        __filename,
+        '..',
+        '..',
+        '..',
+        'resources',
+        'light',
+        `${iconName}.svg`
+      ),
+      dark: path.join(
+        __filename,
+        '..',
+        '..',
+        '..',
+        'resources',
+        'dark',
+        `${iconName}.svg`
+      )
+    };
   }
 
   onShowMoreClicked(): void {
@@ -180,11 +201,13 @@ export default class CollectionTreeItem extends vscode.TreeItem
     try {
       inputtedCollectionName = await vscode.window.showInputBox({
         value: '',
-        placeHolder:
-          'e.g. myNewCollection',
+        placeHolder: 'e.g. myNewCollection',
         prompt: `Are you sure you wish to drop this collection? Enter the collection name '${collectionName}' to confirm.`,
         validateInput: (inputCollectionName: any) => {
-          if (inputCollectionName && !collectionName.startsWith(inputCollectionName)) {
+          if (
+            inputCollectionName &&
+            !collectionName.startsWith(inputCollectionName)
+          ) {
             return 'Collection name does not match';
           }
 
@@ -201,11 +224,14 @@ export default class CollectionTreeItem extends vscode.TreeItem
       return Promise.resolve(false);
     }
 
-    return new Promise(resolve => {
-      this._dataService.dropCollection(`${this.databaseName}.${collectionName}`,
+    return new Promise((resolve) => {
+      this._dataService.dropCollection(
+        `${this.databaseName}.${collectionName}`,
         (err, successfullyDroppedCollection) => {
           if (err) {
-            vscode.window.showErrorMessage(`Drop collection failed: ${err.message}`);
+            vscode.window.showErrorMessage(
+              `Drop collection failed: ${err.message}`
+            );
             return resolve(false);
           }
 

--- a/src/explorer/collectionTreeItem.ts
+++ b/src/explorer/collectionTreeItem.ts
@@ -192,22 +192,25 @@ export default class CollectionTreeItem extends vscode.TreeItem
         }
       });
     } catch (e) {
-      return Promise.reject(`An error occured parsing the collection name: ${e}`);
+      return Promise.reject(
+        new Error(`An error occured parsing the collection name: ${e}`)
+      );
     }
 
     if (!inputtedCollectionName || collectionName !== inputtedCollectionName) {
       return Promise.resolve(false);
     }
 
-    return new Promise((resolve, reject) => {
+    return new Promise(resolve => {
       this._dataService.dropCollection(`${this.databaseName}.${collectionName}`,
-        (err) => {
+        (err, successfullyDroppedCollection) => {
           if (err) {
-            return reject(new Error(`Drop collection failed: ${err.message}`));
+            vscode.window.showErrorMessage(`Drop collection failed: ${err.message}`);
+            return resolve(false);
           }
 
           this._childrenCacheIsUpToDate = false;
-          return resolve(true);
+          return resolve(successfullyDroppedCollection);
         }
       );
     });

--- a/src/explorer/connectionTreeItem.ts
+++ b/src/explorer/connectionTreeItem.ts
@@ -7,9 +7,14 @@ import ConnectionController from '../connectionController';
 import TreeItemParent from './treeItemParentInterface';
 import { StatusView } from '../views';
 
+enum ConnectionItemContextValues {
+  disconnected = 'disconnectedConnectionTreeItem',
+  connected = 'connectedConnectionTreeItem'
+}
+
 export default class ConnectionTreeItem extends vscode.TreeItem
   implements TreeItemParent, vscode.TreeDataProvider<ConnectionTreeItem> {
-  contextValue = 'connectionTreeItem';
+  contextValue = 'disconnectedConnectionTreeItem';
 
   private _childrenCache: { [key: string]: DatabaseTreeItem };
   _childrenCacheIsUpToDate = false;
@@ -30,6 +35,15 @@ export default class ConnectionTreeItem extends vscode.TreeItem
       connectionInstanceId,
       collapsibleState
     );
+
+    if (
+      connectionController.getActiveConnectionInstanceId() === connectionInstanceId
+      && !connectionController.isDisconnecting()
+      && !connectionController.isConnecting()
+    ) {
+      this.contextValue = ConnectionItemContextValues.connected;
+    }
+
 
     this.connectionInstanceId = connectionInstanceId;
     this._connectionController = connectionController;

--- a/src/explorer/connectionTreeItem.ts
+++ b/src/explorer/connectionTreeItem.ts
@@ -35,7 +35,7 @@ export default class ConnectionTreeItem extends vscode.TreeItem
 
     if (
       connectionController.getActiveConnectionInstanceId() ===
-        connectionInstanceId &&
+      connectionInstanceId &&
       !connectionController.isDisconnecting() &&
       !connectionController.isConnecting()
     ) {
@@ -71,7 +71,7 @@ export default class ConnectionTreeItem extends vscode.TreeItem
     if (
       this._connectionController.isConnecting() &&
       this._connectionController.getConnectingInstanceId() ===
-        this.connectionInstanceId
+      this.connectionInstanceId
     ) {
       return 'connecting...';
     }
@@ -143,7 +143,7 @@ export default class ConnectionTreeItem extends vscode.TreeItem
     | { light: string | vscode.Uri; dark: string | vscode.Uri } {
     const iconName =
       this._connectionController.getActiveConnectionInstanceId() ===
-      this.connectionInstanceId
+        this.connectionInstanceId
         ? 'active-connection'
         : 'inactive-connection';
     return {

--- a/src/explorer/connectionTreeItem.ts
+++ b/src/explorer/connectionTreeItem.ts
@@ -205,7 +205,9 @@ export default class ConnectionTreeItem extends vscode.TreeItem
         }
       });
     } catch (e) {
-      return Promise.reject(new Error(`An error occured parsing the database name: ${e}`));
+      return Promise.reject(
+        new Error(`An error occured parsing the database name: ${e}`)
+      );
     }
 
     if (!databaseName) {
@@ -248,7 +250,7 @@ export default class ConnectionTreeItem extends vscode.TreeItem
     const statusView = new StatusView(context);
     statusView.showMessage('Creating new database and collection...');
 
-    return new Promise((resolve, reject) => {
+    return new Promise(resolve => {
       this._connectionController.getActiveConnection().createCollection(
         `${databaseName}.${collectionName}`,
         {}, // No options.
@@ -256,7 +258,8 @@ export default class ConnectionTreeItem extends vscode.TreeItem
           statusView.hideMessage();
 
           if (err) {
-            return reject(new Error(`Create collection failed: ${err.message}`));
+            vscode.window.showErrorMessage(`Create collection failed: ${err.message}`);
+            return resolve(false);
           }
 
           this._childrenCacheIsUpToDate = false;

--- a/src/explorer/connectionTreeItem.ts
+++ b/src/explorer/connectionTreeItem.ts
@@ -31,15 +31,13 @@ export default class ConnectionTreeItem extends vscode.TreeItem
     connectionController: ConnectionController,
     existingChildrenCache: { [key: string]: DatabaseTreeItem }
   ) {
-    super(
-      connectionInstanceId,
-      collapsibleState
-    );
+    super(connectionInstanceId, collapsibleState);
 
     if (
-      connectionController.getActiveConnectionInstanceId() === connectionInstanceId
-      && !connectionController.isDisconnecting()
-      && !connectionController.isConnecting()
+      connectionController.getActiveConnectionInstanceId() ===
+        connectionInstanceId &&
+      !connectionController.isDisconnecting() &&
+      !connectionController.isConnecting()
     ) {
       this.contextValue = ConnectionItemContextValues.connected;
     }
@@ -70,8 +68,10 @@ export default class ConnectionTreeItem extends vscode.TreeItem
       return 'connected';
     }
 
-    if (this._connectionController.isConnecting()
-      && this._connectionController.getConnectingInstanceId() === this.connectionInstanceId
+    if (
+      this._connectionController.isConnecting() &&
+      this._connectionController.getConnectingInstanceId() ===
+        this.connectionInstanceId
     ) {
       return 'connecting...';
     }
@@ -84,9 +84,10 @@ export default class ConnectionTreeItem extends vscode.TreeItem
   }
 
   getChildren(): Thenable<any[]> {
-    if (!this.isExpanded
-      || this._connectionController.isDisconnecting()
-      || this._connectionController.isConnecting()
+    if (
+      !this.isExpanded ||
+      this._connectionController.isDisconnecting() ||
+      this._connectionController.isConnecting()
     ) {
       return Promise.resolve([]);
     }
@@ -136,16 +137,35 @@ export default class ConnectionTreeItem extends vscode.TreeItem
     });
   }
 
-  get iconPath(): string | vscode.Uri | { light: string | vscode.Uri; dark: string | vscode.Uri } {
-    return this._connectionController.getActiveConnectionInstanceId() === this.connectionInstanceId
-      ? {
-        light: path.join(__filename, '..', '..', '..', 'resources', 'light', 'active-connection.svg'),
-        dark: path.join(__filename, '..', '..', '..', 'resources', 'dark', 'active-connection.svg')
-      }
-      : {
-        light: path.join(__filename, '..', '..', '..', 'resources', 'light', 'inactive-connection.svg'),
-        dark: path.join(__filename, '..', '..', '..', 'resources', 'dark', 'inactive-connection.svg')
-      };
+  get iconPath():
+    | string
+    | vscode.Uri
+    | { light: string | vscode.Uri; dark: string | vscode.Uri } {
+    const iconName =
+      this._connectionController.getActiveConnectionInstanceId() ===
+      this.connectionInstanceId
+        ? 'active-connection'
+        : 'inactive-connection';
+    return {
+      light: path.join(
+        __filename,
+        '..',
+        '..',
+        '..',
+        'resources',
+        'light',
+        `${iconName}.svg`
+      ),
+      dark: path.join(
+        __filename,
+        '..',
+        '..',
+        '..',
+        'resources',
+        'dark',
+        `${iconName}.svg`
+      )
+    };
   }
 
   onDidCollapse(): void {
@@ -157,20 +177,25 @@ export default class ConnectionTreeItem extends vscode.TreeItem
     this._childrenCacheIsUpToDate = false;
     this.isExpanded = true;
 
-    if (this._connectionController.getActiveConnectionInstanceId() === this.connectionInstanceId) {
+    if (
+      this._connectionController.getActiveConnectionInstanceId() ===
+      this.connectionInstanceId
+    ) {
       return Promise.resolve(true);
     }
 
     // If we aren't the active connection, we reconnect.
-    return new Promise(resolve => {
-      this._connectionController.connectWithInstanceId(this.connectionInstanceId).then(
-        () => resolve(true),
-        err => {
-          this.isExpanded = false;
-          vscode.window.showErrorMessage(err);
-          resolve(false);
-        }
-      );
+    return new Promise((resolve) => {
+      this._connectionController
+        .connectWithInstanceId(this.connectionInstanceId)
+        .then(
+          () => resolve(true),
+          (err) => {
+            this.isExpanded = false;
+            vscode.window.showErrorMessage(err);
+            resolve(false);
+          }
+        );
     });
   }
 
@@ -183,19 +208,20 @@ export default class ConnectionTreeItem extends vscode.TreeItem
     return this._childrenCache;
   }
 
-  async onAddDatabaseClicked(context: vscode.ExtensionContext): Promise<boolean> {
+  async onAddDatabaseClicked(
+    context: vscode.ExtensionContext
+  ): Promise<boolean> {
     let databaseName;
     try {
       databaseName = await vscode.window.showInputBox({
         value: '',
-        placeHolder:
-          'e.g. myNewDB',
+        placeHolder: 'e.g. myNewDB',
         prompt: 'Enter the new database name.',
         validateInput: (inputDatabaseName: any) => {
           if (
-            inputDatabaseName
-            && inputDatabaseName.length > 0
-            && !ns(inputDatabaseName).validDatabaseName
+            inputDatabaseName &&
+            inputDatabaseName.length > 0 &&
+            !ns(inputDatabaseName).validDatabaseName
           ) {
             return 'MongoDB database names cannot contain `/\\. "$` or the null character, and must be fewer than 64 characters';
           }
@@ -217,15 +243,17 @@ export default class ConnectionTreeItem extends vscode.TreeItem
     try {
       collectionName = await vscode.window.showInputBox({
         value: '',
-        placeHolder:
-          'e.g. myNewCollection',
-        prompt: 'Enter the new collection name. (A database must have a collection to be created.)',
+        placeHolder: 'e.g. myNewCollection',
+        prompt:
+          'Enter the new collection name. (A database must have a collection to be created.)',
         validateInput: (inputCollectionName: any) => {
           if (!inputCollectionName) {
             return null;
           }
 
-          if (!ns(`${databaseName}.${inputCollectionName}`).validCollectionName) {
+          if (
+            !ns(`${databaseName}.${inputCollectionName}`).validCollectionName
+          ) {
             return 'MongoDB collection names cannot contain `/\\. "$` or the null character, and must be fewer than 64 characters';
           }
 
@@ -237,9 +265,9 @@ export default class ConnectionTreeItem extends vscode.TreeItem
         }
       });
     } catch (e) {
-      return Promise.reject(new Error(
-        `An error occured parsing the collection name: ${e}`
-      ));
+      return Promise.reject(
+        new Error(`An error occured parsing the collection name: ${e}`)
+      );
     }
 
     if (!collectionName) {
@@ -249,7 +277,7 @@ export default class ConnectionTreeItem extends vscode.TreeItem
     const statusView = new StatusView(context);
     statusView.showMessage('Creating new database and collection...');
 
-    return new Promise(resolve => {
+    return new Promise((resolve) => {
       this._connectionController.getActiveConnection().createCollection(
         `${databaseName}.${collectionName}`,
         {}, // No options.
@@ -257,7 +285,9 @@ export default class ConnectionTreeItem extends vscode.TreeItem
           statusView.hideMessage();
 
           if (err) {
-            vscode.window.showErrorMessage(`Create collection failed: ${err.message}`);
+            vscode.window.showErrorMessage(
+              `Create collection failed: ${err.message}`
+            );
             return resolve(false);
           }
 

--- a/src/explorer/connectionTreeItem.ts
+++ b/src/explorer/connectionTreeItem.ts
@@ -14,7 +14,7 @@ enum ConnectionItemContextValues {
 
 export default class ConnectionTreeItem extends vscode.TreeItem
   implements TreeItemParent, vscode.TreeDataProvider<ConnectionTreeItem> {
-  contextValue = 'disconnectedConnectionTreeItem';
+  contextValue = ConnectionItemContextValues.disconnected;
 
   private _childrenCache: { [key: string]: DatabaseTreeItem };
   _childrenCacheIsUpToDate = false;
@@ -43,7 +43,6 @@ export default class ConnectionTreeItem extends vscode.TreeItem
     ) {
       this.contextValue = ConnectionItemContextValues.connected;
     }
-
 
     this.connectionInstanceId = connectionInstanceId;
     this._connectionController = connectionController;

--- a/src/explorer/databaseTreeItem.ts
+++ b/src/explorer/databaseTreeItem.ts
@@ -3,7 +3,9 @@ const ns = require('mongodb-ns');
 const path = require('path');
 import { StatusView } from '../views';
 
-import CollectionTreeItem, { MAX_DOCUMENTS_VISIBLE } from './collectionTreeItem';
+import CollectionTreeItem, {
+  MAX_DOCUMENTS_VISIBLE
+} from './collectionTreeItem';
 import TreeItemParent from './treeItemParentInterface';
 
 export default class DatabaseTreeItem extends vscode.TreeItem
@@ -61,7 +63,9 @@ export default class DatabaseTreeItem extends vscode.TreeItem
         {}, // No filter.
         (err: any, collections: string[]) => {
           if (err) {
-            return reject(new Error(`Unable to list collections: ${err.message}`));
+            return reject(
+              new Error(`Unable to list collections: ${err.message}`)
+            );
           }
 
           this._childrenCacheIsUpToDate = true;
@@ -97,14 +101,34 @@ export default class DatabaseTreeItem extends vscode.TreeItem
           }
 
           return resolve(Object.values(this._childrenCache));
-        });
+        }
+      );
     });
   }
 
-  get iconPath(): string | vscode.Uri | { light: string | vscode.Uri; dark: string | vscode.Uri } {
+  get iconPath():
+    | string
+    | vscode.Uri
+    | { light: string | vscode.Uri; dark: string | vscode.Uri } {
     return {
-      light: path.join(__filename, '..', '..', '..', 'resources', 'light', 'database.svg'),
-      dark: path.join(__filename, '..', '..', '..', 'resources', 'dark', 'database.svg')
+      light: path.join(
+        __filename,
+        '..',
+        '..',
+        '..',
+        'resources',
+        'light',
+        'database.svg'
+      ),
+      dark: path.join(
+        __filename,
+        '..',
+        '..',
+        '..',
+        'resources',
+        'dark',
+        'database.svg'
+      )
     };
   }
 
@@ -128,22 +152,25 @@ export default class DatabaseTreeItem extends vscode.TreeItem
     return this._childrenCache;
   }
 
-  async onAddCollectionClicked(context: vscode.ExtensionContext): Promise<boolean> {
+  async onAddCollectionClicked(
+    context: vscode.ExtensionContext
+  ): Promise<boolean> {
     const databaseName = this.databaseName;
 
     let collectionName;
     try {
       collectionName = await vscode.window.showInputBox({
         value: '',
-        placeHolder:
-          'e.g. myNewCollection',
+        placeHolder: 'e.g. myNewCollection',
         prompt: 'Enter the new collection name.',
         validateInput: (inputCollectionName: any) => {
           if (!inputCollectionName) {
             return null;
           }
 
-          if (!ns(`${databaseName}.${inputCollectionName}`).validCollectionName) {
+          if (
+            !ns(`${databaseName}.${inputCollectionName}`).validCollectionName
+          ) {
             return 'MongoDB collection names cannot contain `/\\. "$` or the null character, and must be fewer than 64 characters';
           }
 
@@ -167,7 +194,7 @@ export default class DatabaseTreeItem extends vscode.TreeItem
     const statusBarItem = new StatusView(context);
     statusBarItem.showMessage('Creating new collection...');
 
-    return new Promise(resolve => {
+    return new Promise((resolve) => {
       this._dataService.createCollection(
         `${databaseName}.${collectionName}`,
         {}, // No options.
@@ -175,7 +202,9 @@ export default class DatabaseTreeItem extends vscode.TreeItem
           statusBarItem.hideMessage();
 
           if (err) {
-            vscode.window.showErrorMessage(`Create collection failed: ${err.message}`);
+            vscode.window.showErrorMessage(
+              `Create collection failed: ${err.message}`
+            );
             return resolve(false);
           }
 
@@ -194,11 +223,13 @@ export default class DatabaseTreeItem extends vscode.TreeItem
     try {
       inputtedDatabaseName = await vscode.window.showInputBox({
         value: '',
-        placeHolder:
-          'e.g. myNewCollection',
+        placeHolder: 'e.g. myNewCollection',
         prompt: `Are you sure you wish to drop this database? Enter the database name '${databaseName}' to confirm.`,
         validateInput: (inputDatabaseName: any) => {
-          if (inputDatabaseName && !databaseName.startsWith(inputDatabaseName)) {
+          if (
+            inputDatabaseName &&
+            !databaseName.startsWith(inputDatabaseName)
+          ) {
             return 'Database name does not match';
           }
 
@@ -215,18 +246,18 @@ export default class DatabaseTreeItem extends vscode.TreeItem
       return Promise.resolve(false);
     }
 
-    return new Promise(resolve => {
-      this._dataService.dropDatabase(databaseName,
-        (err) => {
-          if (err) {
-            vscode.window.showErrorMessage(`Drop database failed: ${err.message}`);
-            return resolve(false);
-          }
-
-          this._childrenCacheIsUpToDate = false;
-          return resolve(true);
+    return new Promise((resolve) => {
+      this._dataService.dropDatabase(databaseName, (err) => {
+        if (err) {
+          vscode.window.showErrorMessage(
+            `Drop database failed: ${err.message}`
+          );
+          return resolve(false);
         }
-      );
+
+        this._childrenCacheIsUpToDate = false;
+        return resolve(true);
+      });
     });
   }
 }

--- a/src/explorer/databaseTreeItem.ts
+++ b/src/explorer/databaseTreeItem.ts
@@ -155,7 +155,9 @@ export default class DatabaseTreeItem extends vscode.TreeItem
         }
       });
     } catch (e) {
-      return Promise.reject(`An error occured parsing the collection name: ${e}`);
+      return Promise.reject(
+        new Error(`An error occured parsing the collection name: ${e}`)
+      );
     }
 
     if (!collectionName) {
@@ -165,7 +167,7 @@ export default class DatabaseTreeItem extends vscode.TreeItem
     const statusBarItem = new StatusView(context);
     statusBarItem.showMessage('Creating new collection...');
 
-    return new Promise((resolve, reject) => {
+    return new Promise(resolve => {
       this._dataService.createCollection(
         `${databaseName}.${collectionName}`,
         {}, // No options.
@@ -173,7 +175,8 @@ export default class DatabaseTreeItem extends vscode.TreeItem
           statusBarItem.hideMessage();
 
           if (err) {
-            return reject(new Error(`Create collection failed: ${err.message}`));
+            vscode.window.showErrorMessage(`Create collection failed: ${err.message}`);
+            return resolve(false);
           }
 
           this._childrenCacheIsUpToDate = false;
@@ -203,18 +206,21 @@ export default class DatabaseTreeItem extends vscode.TreeItem
         }
       });
     } catch (e) {
-      return Promise.reject(`An error occured parsing the collection name: ${e}`);
+      return Promise.reject(
+        new Error(`An error occured parsing the collection name: ${e}`)
+      );
     }
 
     if (!inputtedDatabaseName || databaseName !== inputtedDatabaseName) {
       return Promise.resolve(false);
     }
 
-    return new Promise((resolve, reject) => {
+    return new Promise(resolve => {
       this._dataService.dropDatabase(databaseName,
         (err) => {
           if (err) {
-            return reject(new Error(`Drop database failed: ${err.message}`));
+            vscode.window.showErrorMessage(`Drop database failed: ${err.message}`);
+            return resolve(false);
           }
 
           this._childrenCacheIsUpToDate = false;

--- a/src/explorer/documentTreeItem.ts
+++ b/src/explorer/documentTreeItem.ts
@@ -1,12 +1,10 @@
 import * as vscode from 'vscode';
 
-export default class MongoDBDocumentTreeItem extends vscode.TreeItem implements vscode.TreeDataProvider<MongoDBDocumentTreeItem> {
+export default class MongoDBDocumentTreeItem extends vscode.TreeItem
+  implements vscode.TreeDataProvider<MongoDBDocumentTreeItem> {
   private _documentLabel: string;
 
-  constructor(
-    document: any,
-    documentIndexInTree: number
-  ) {
+  constructor(document: any, documentIndexInTree: number) {
     // A document can not have a `_id` when it is in a view. In this instance
     // we just show the document's index in the tree.
     super(

--- a/src/explorer/explorerController.ts
+++ b/src/explorer/explorerController.ts
@@ -8,14 +8,16 @@ import { createLogger } from '../logging';
 const log = createLogger('explorer controller');
 
 export default class ExplorerController {
-  private _treeController?: ExplorerTreeController;
+  private _treeController: ExplorerTreeController;
   private _treeView?: vscode.TreeView<vscode.TreeItem>;
 
-  activate(connectionController: ConnectionController): void {
+  constructor(connectionController: ConnectionController) {
     log.info('activate explorer controller');
 
     this._treeController = new ExplorerTreeController(connectionController);
+  }
 
+  activate(): void {
     this._treeView = vscode.window.createTreeView('mongoDB', {
       treeDataProvider: this._treeController
     });
@@ -45,7 +47,7 @@ export default class ExplorerController {
   public getTreeView(): vscode.TreeView<vscode.TreeItem> | undefined {
     return this._treeView;
   }
-  public getTreeController(): ExplorerTreeController | undefined {
+  public getTreeController(): ExplorerTreeController {
     return this._treeController;
   }
 }

--- a/src/explorer/explorerController.ts
+++ b/src/explorer/explorerController.ts
@@ -17,7 +17,7 @@ export default class ExplorerController {
     this._treeController = new ExplorerTreeController(connectionController);
   }
 
-  activate(): void {
+  createTreeView(): void {
     this._treeView = vscode.window.createTreeView('mongoDB', {
       treeDataProvider: this._treeController
     });

--- a/src/explorer/explorerTreeController.ts
+++ b/src/explorer/explorerTreeController.ts
@@ -12,8 +12,7 @@ import { createLogger } from '../logging';
 
 const log = createLogger('explorer controller');
 
-export default class ExplorerTreeController
-  implements vscode.TreeDataProvider<vscode.TreeItem> {
+export default class ExplorerTreeController implements vscode.TreeDataProvider<vscode.TreeItem> {
   private _connectionController: ConnectionController;
   private _mdbConnectionsTreeItem: MDBConnectionsTreeItem;
 

--- a/src/explorer/explorerTreeController.ts
+++ b/src/explorer/explorerTreeController.ts
@@ -12,7 +12,8 @@ import { createLogger } from '../logging';
 
 const log = createLogger('explorer controller');
 
-export default class ExplorerTreeController implements vscode.TreeDataProvider<vscode.TreeItem> {
+export default class ExplorerTreeController
+  implements vscode.TreeDataProvider<vscode.TreeItem> {
   private _connectionController: ConnectionController;
   private _mdbConnectionsTreeItem: MDBConnectionsTreeItem;
 
@@ -49,17 +50,22 @@ export default class ExplorerTreeController implements vscode.TreeDataProvider<v
       this.onTreeItemUpdate();
     });
 
-    treeView.onDidExpandElement((event: any): Promise<any> => {
-      log.info('Tree item was expanded:', event.element.label);
-      return new Promise((resolve, reject) => {
-        event.element.onDidExpand().then(() => {
-          this.onTreeItemUpdate();
-          resolve(true);
-        }, (err: Error) => {
-          reject(err);
+    treeView.onDidExpandElement(
+      (event: any): Promise<any> => {
+        log.info('Tree item was expanded:', event.element.label);
+        return new Promise((resolve, reject) => {
+          event.element.onDidExpand().then(
+            () => {
+              this.onTreeItemUpdate();
+              resolve(true);
+            },
+            (err: Error) => {
+              reject(err);
+            }
+          );
         });
-      });
-    });
+      }
+    );
 
     treeView.onDidChangeSelection((event: any) => {
       if (event.selection && event.selection.length === 1) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,11 +16,10 @@ export function activate(context: vscode.ExtensionContext): void {
   log.info('activate extension called');
 
   mdbExtension = new MDBExtensionController(context);
+  mdbExtension.activate();
 
   // Add our extension to a list of disposables for when we are deactivated.
   context.subscriptions.push(mdbExtension);
-
-  mdbExtension.activate(context);
 
   log.info('extension activated');
 }

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -20,7 +20,7 @@ const log = createLogger('commands');
 // Commands which the extensions handles are defined in the function `activate`.
 export default class MDBExtensionController implements vscode.Disposable {
   _connectionController: ConnectionController;
-  _context?: vscode.ExtensionContext;
+  _context: vscode.ExtensionContext;
   _editorsController: EditorsController;
   _explorerController: ExplorerController;
   _statusView: StatusView;
@@ -75,17 +75,12 @@ export default class MDBExtensionController implements vscode.Disposable {
     this.registerCommand('mdb.createPlayground', () => this.createPlayground());
 
     this.registerEditorCommands();
-    this.registerTreeViewCommands(context);
+    this.registerTreeViewCommands();
 
     log.info('Registered commands.');
   }
 
   registerCommand = (command, commandHandler: (...args: any[]) => Promise<boolean>): void => {
-    if (!this._context) {
-      // Not yet activated.
-      return;
-    }
-
     this._context.subscriptions.push(
       vscode.commands.registerCommand(command, commandHandler)
     );
@@ -105,7 +100,7 @@ export default class MDBExtensionController implements vscode.Disposable {
     });
   }
 
-  registerTreeViewCommands(context: vscode.ExtensionContext): void {
+  registerTreeViewCommands(): void {
     this.registerCommand(
       'mdb.addConnection',
       () => this._connectionController.addMongoDBConnection()
@@ -184,7 +179,7 @@ export default class MDBExtensionController implements vscode.Disposable {
         }
 
         return new Promise((resolve, reject) => {
-          element.onAddDatabaseClicked(context).then(successfullyAddedDatabase => {
+          element.onAddDatabaseClicked(this._context).then(successfullyAddedDatabase => {
             if (successfullyAddedDatabase) {
               vscode.window.showInformationMessage('Database and collection successfully created.');
 
@@ -230,7 +225,7 @@ export default class MDBExtensionController implements vscode.Disposable {
         }
 
         return new Promise((resolve, reject) => {
-          element.onAddCollectionClicked(context).then(successfullyAddedCollection => {
+          element.onAddCollectionClicked(this._context).then(successfullyAddedCollection => {
             if (successfullyAddedCollection) {
               vscode.window.showInformationMessage('Collection successfully created.');
 

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -212,6 +212,12 @@ export default class MDBExtensionController implements vscode.Disposable {
       }
     );
     this.registerCommand(
+      'mdb.dropDatabase',
+      (element: DatabaseTreeItem) => {
+        return element.onDropDatabaseClicked();
+      }
+    );
+    this.registerCommand(
       'mdb.refreshDatabase',
       (databaseTreeItem: DatabaseTreeItem) => {
         databaseTreeItem.resetCache();
@@ -248,6 +254,12 @@ export default class MDBExtensionController implements vscode.Disposable {
             return resolve(true);
           }, reject);
         });
+      }
+    );
+    this.registerCommand(
+      'mdb.dropCollection',
+      (element: CollectionTreeItem) => {
+        return element.onDropCollectionClicked();
       }
     );
     this.registerCommand(

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -42,7 +42,7 @@ export default class MDBExtensionController implements vscode.Disposable {
     }
 
     this._editorsController = new EditorsController();
-    this._explorerController = new ExplorerController();
+    this._explorerController = new ExplorerController(this._connectionController);
   }
 
   registerCommand = (command, commandHandler: (...args: any[]) => Promise<boolean>): void => {
@@ -59,7 +59,7 @@ export default class MDBExtensionController implements vscode.Disposable {
   public activate(context): void {
     this._context = context;
     this._connectionController.activate();
-    this._explorerController.activate(this._connectionController);
+    this._explorerController.activate();
     this._editorsController.activate(context, this._connectionController);
 
     log.info('Registering commands...');

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -84,13 +84,6 @@ export default class MDBExtensionController implements vscode.Disposable {
 
     this.registerCommand('mdb.createPlayground', () => this.createPlayground());
 
-    this.registerCommand('mdb.refresh', () =>
-      this._explorerController.refresh()
-    );
-    this.registerCommand('mdb.reload', () =>
-      this._explorerController.refresh()
-    );
-
     this.registerEditorCommands();
     this.registerTreeViewCommands(context);
 
@@ -119,6 +112,22 @@ export default class MDBExtensionController implements vscode.Disposable {
     this.registerCommand(
       'mdb.addConnectionWithURI',
       () => this._connectionController.connectWithURI()
+    );
+    this.registerCommand(
+      'mdb.connectToConnectionTreeItem',
+      (connectionTreeItem: ConnectionTreeItem) => {
+        return this._connectionController.connectWithInstanceId(
+          connectionTreeItem.connectionInstanceId
+        );
+      }
+    );
+    this.registerCommand(
+      'mdb.disconnectFromConnectionTreeItem',
+      () => {
+        // In order for this command to be activated, the connection must
+        // be the active connection, so we can just generally disconnect.
+        return this._connectionController.disconnect();
+      }
     );
     this.registerCommand(
       'mdb.refreshConnection',

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -7,7 +7,10 @@ import ConnectionController, {
   DataServiceEventTypes
 } from '../../connectionController';
 import { StorageController, StorageVariables } from '../../storage';
-import { StorageScope, DefaultSavingLocations } from '../../storage/storageController';
+import {
+  StorageScope,
+  DefaultSavingLocations
+} from '../../storage/storageController';
 import { StatusView } from '../../views';
 import MDBExtensionController from '../../mdbExtensionController';
 
@@ -32,7 +35,7 @@ suite('Connection Controller Test Suite', () => {
     sinon.restore();
   });
 
-  test('it connects to mongodb', function (done) {
+  test('it connects to mongodb', function(done) {
     const testConnectionController = new ConnectionController(
       new StatusView(mockExtensionContext),
       mockStorageController
@@ -40,7 +43,7 @@ suite('Connection Controller Test Suite', () => {
 
     testConnectionController
       .addNewConnectionAndConnect(testDatabaseURI)
-      .then(succesfullyConnected => {
+      .then((succesfullyConnected) => {
         assert(
           succesfullyConnected === true,
           'Expected a successful connection response.'
@@ -58,7 +61,7 @@ suite('Connection Controller Test Suite', () => {
       .then(done, done);
   });
 
-  test('"disconnect()" disconnects from the active connection', function (done) {
+  test('"disconnect()" disconnects from the active connection', function(done) {
     const testConnectionController = new ConnectionController(
       new StatusView(mockExtensionContext),
       mockStorageController
@@ -66,7 +69,7 @@ suite('Connection Controller Test Suite', () => {
 
     testConnectionController
       .addNewConnectionAndConnect(testDatabaseURI)
-      .then(succesfullyConnected => {
+      .then((succesfullyConnected) => {
         assert(
           succesfullyConnected === true,
           'Expected a successful (true) connection response.'
@@ -74,7 +77,7 @@ suite('Connection Controller Test Suite', () => {
 
         testConnectionController
           .disconnect()
-          .then(successfullyDisconnected => {
+          .then((successfullyDisconnected) => {
             assert(
               successfullyDisconnected === true,
               'Expected a successful (true) disconnect response.'
@@ -97,7 +100,7 @@ suite('Connection Controller Test Suite', () => {
       });
   });
 
-  test('when the extension is deactivated, the active connection is disconnected', function (done) {
+  test('when the extension is deactivated, the active connection is disconnected', function(done) {
     const testConnectionController = new ConnectionController(
       new StatusView(mockExtensionContext),
       mockStorageController
@@ -110,7 +113,7 @@ suite('Connection Controller Test Suite', () => {
 
     testConnectionController
       .addNewConnectionAndConnect(testDatabaseURI)
-      .then(succesfullyConnected => {
+      .then((succesfullyConnected) => {
         assert(
           succesfullyConnected === true,
           'Expected a successful (true) connection response.'
@@ -126,10 +129,11 @@ suite('Connection Controller Test Suite', () => {
           testConnectionController.getActiveConnection() === null,
           'Expected active connection to be null.'
         );
-      }, done).then(done, done);
+      }, done)
+      .then(done, done);
   });
 
-  test('"removeMongoDBConnection()" returns a reject promise when there is no active connection', done => {
+  test('"removeMongoDBConnection()" returns a reject promise when there is no active connection', (done) => {
     const testConnectionController = new ConnectionController(
       new StatusView(mockExtensionContext),
       mockStorageController
@@ -137,13 +141,13 @@ suite('Connection Controller Test Suite', () => {
 
     testConnectionController
       .onRemoveMongoDBConnection()
-      .then(null, err => {
+      .then(null, (err) => {
         assert(!!err, `Expected an error response, recieved ${err}.`);
       })
       .then(done, done);
   });
 
-  test('"disconnect()" fails when there is no active connection', done => {
+  test('"disconnect()" fails when there is no active connection', (done) => {
     const testConnectionController = new ConnectionController(
       new StatusView(mockExtensionContext),
       mockStorageController
@@ -151,27 +155,23 @@ suite('Connection Controller Test Suite', () => {
 
     testConnectionController
       .disconnect()
-      .then(null, err => {
+      .then(null, (err) => {
         assert(!!err, 'Expected an error disconnect response.');
       })
       .then(done, done);
   });
 
-  test('when adding a new connection it disconnects from the current connection', function (done) {
+  test('when adding a new connection it disconnects from the current connection', function(done) {
     const testConnectionController = new ConnectionController(
       new StatusView(mockExtensionContext),
       mockStorageController
     );
     const fakeVscodeErrorMessage = sinon.fake();
-    sinon.replace(
-      vscode.window,
-      'showErrorMessage',
-      fakeVscodeErrorMessage
-    );
+    sinon.replace(vscode.window, 'showErrorMessage', fakeVscodeErrorMessage);
 
     testConnectionController
       .disconnect()
-      .then(disconnectSucceeded => {
+      .then((disconnectSucceeded) => {
         assert(
           disconnectSucceeded === false,
           'Expected an false success disconnect response.'
@@ -181,10 +181,11 @@ suite('Connection Controller Test Suite', () => {
           fakeVscodeErrorMessage.firstArg === expectedMessage,
           `Expected error message "${expectedMessage}" when disconnecting with no active connection, recieved "${fakeVscodeErrorMessage.firstArg}"`
         );
-      }).then(done, done);
+      })
+      .then(done, done);
   });
 
-  test('when adding a new connection it disconnects from the current connection', function (done) {
+  test('when adding a new connection it disconnects from the current connection', function(done) {
     const testConnectionController = new ConnectionController(
       new StatusView(mockExtensionContext),
       mockStorageController
@@ -193,7 +194,7 @@ suite('Connection Controller Test Suite', () => {
 
     testConnectionController
       .addNewConnectionAndConnect(testDatabaseURI)
-      .then(succesfullyConnected => {
+      .then((succesfullyConnected) => {
         assert(
           succesfullyConnected,
           'Expected a successful (true) connection response.'
@@ -201,8 +202,11 @@ suite('Connection Controller Test Suite', () => {
 
         testConnectionController
           .addNewConnectionAndConnect(testDatabaseURI2WithTimeout)
-          .then(succeededInConnecting => {
-            assert(succeededInConnecting === false, 'Expected an false succeeded promise response.');
+          .then((succeededInConnecting) => {
+            assert(
+              succeededInConnecting === false,
+              'Expected an false succeeded promise response.'
+            );
             assert(
               testConnectionController.getActiveConnection() === null,
               'Expected to current connection to be null (not connected).'
@@ -211,11 +215,12 @@ suite('Connection Controller Test Suite', () => {
               testConnectionController.getActiveConnectionInstanceId() === null,
               'Expected to current connection instanceId to be null (not connected).'
             );
-          }, done).then(done, done);
+          }, done)
+          .then(done, done);
       });
   });
 
-  test('"connect()" failed when we are currently connecting', function (done) {
+  test('"connect()" failed when we are currently connecting', function(done) {
     const testConnectionController = new ConnectionController(
       new StatusView(mockExtensionContext),
       mockStorageController
@@ -224,15 +229,11 @@ suite('Connection Controller Test Suite', () => {
     testConnectionController.setConnnecting(true);
 
     const fakeVscodeErrorMessage = sinon.fake();
-    sinon.replace(
-      vscode.window,
-      'showErrorMessage',
-      fakeVscodeErrorMessage
-    );
+    sinon.replace(vscode.window, 'showErrorMessage', fakeVscodeErrorMessage);
 
     testConnectionController
       .addNewConnectionAndConnect(testDatabaseURI)
-      .then(connectSucceeded => {
+      .then((connectSucceeded) => {
         assert(
           connectSucceeded === false,
           'Expected the connect to return a false succeeded response'
@@ -246,7 +247,7 @@ suite('Connection Controller Test Suite', () => {
       .then(done, done);
   });
 
-  test('"connect()" failed when we are currently disconnecting', function (done) {
+  test('"connect()" failed when we are currently disconnecting', function(done) {
     const testConnectionController = new ConnectionController(
       new StatusView(mockExtensionContext),
       mockStorageController
@@ -255,15 +256,11 @@ suite('Connection Controller Test Suite', () => {
     testConnectionController.setDisconnecting(true);
 
     const fakeVscodeErrorMessage = sinon.fake();
-    sinon.replace(
-      vscode.window,
-      'showErrorMessage',
-      fakeVscodeErrorMessage
-    );
+    sinon.replace(vscode.window, 'showErrorMessage', fakeVscodeErrorMessage);
 
     testConnectionController
       .addNewConnectionAndConnect(testDatabaseURI)
-      .then(connectSucceeded => {
+      .then((connectSucceeded) => {
         assert(
           connectSucceeded === false,
           'Expected the connect to return a false succeeded response'
@@ -277,7 +274,7 @@ suite('Connection Controller Test Suite', () => {
       .then(done, done);
   });
 
-  test('"disconnect()" fails when we are currently connecting', function (done) {
+  test('"disconnect()" fails when we are currently connecting', function(done) {
     const testConnectionController = new ConnectionController(
       new StatusView(mockExtensionContext),
       mockStorageController
@@ -286,20 +283,17 @@ suite('Connection Controller Test Suite', () => {
     testConnectionController.setConnnecting(true);
 
     const fakeVscodeErrorMessage = sinon.fake();
-    sinon.replace(
-      vscode.window,
-      'showErrorMessage',
-      fakeVscodeErrorMessage
-    );
+    sinon.replace(vscode.window, 'showErrorMessage', fakeVscodeErrorMessage);
 
     testConnectionController
       .disconnect()
-      .then(disconnectSucceeded => {
+      .then((disconnectSucceeded) => {
         assert(
           disconnectSucceeded === false,
           'Expected the disconnect to return a false succeeded response'
         );
-        const expectedMessage = 'Unable to disconnect: currently connecting to an instance.';
+        const expectedMessage =
+          'Unable to disconnect: currently connecting to an instance.';
         assert(
           fakeVscodeErrorMessage.firstArg === expectedMessage,
           `Expected "${expectedMessage}" when disconnecting while connecting, recieved "${fakeVscodeErrorMessage.firstArg}"`
@@ -308,7 +302,7 @@ suite('Connection Controller Test Suite', () => {
       .then(done, done);
   });
 
-  test('"disconnect()" fails when we are currently disconnecting', function (done) {
+  test('"disconnect()" fails when we are currently disconnecting', function(done) {
     const testConnectionController = new ConnectionController(
       new StatusView(mockExtensionContext),
       mockStorageController
@@ -317,20 +311,17 @@ suite('Connection Controller Test Suite', () => {
     testConnectionController.setDisconnecting(true);
 
     const fakeVscodeErrorMessage = sinon.fake();
-    sinon.replace(
-      vscode.window,
-      'showErrorMessage',
-      fakeVscodeErrorMessage
-    );
+    sinon.replace(vscode.window, 'showErrorMessage', fakeVscodeErrorMessage);
 
     testConnectionController
       .disconnect()
-      .then(disconnectSucceeded => {
+      .then((disconnectSucceeded) => {
         assert(
           disconnectSucceeded === false,
           'Expected the disconnect to return a false succeeded response'
         );
-        const expectedMessage = 'Unable to disconnect: already disconnecting from an instance.';
+        const expectedMessage =
+          'Unable to disconnect: already disconnecting from an instance.';
         assert(
           fakeVscodeErrorMessage.firstArg === expectedMessage,
           `Expected "${expectedMessage}" when disconnecting while already disconnecting, recieved "${fakeVscodeErrorMessage.firstArg}"`
@@ -339,7 +330,7 @@ suite('Connection Controller Test Suite', () => {
       .then(done, done);
   });
 
-  test('"connect()" should fire a CONNECTIONS_DID_CHANGE event', function (done) {
+  test('"connect()" should fire a CONNECTIONS_DID_CHANGE event', function(done) {
     const testConnectionController = new ConnectionController(
       new StatusView(mockExtensionContext),
       mockStorageController
@@ -357,7 +348,7 @@ suite('Connection Controller Test Suite', () => {
     testConnectionController
       .addNewConnectionAndConnect(testDatabaseURI)
       .then(() => {
-        setTimeout(function () {
+        setTimeout(function() {
           assert(
             didFireConnectionEvent === true,
             'Expected connection event to be fired.'
@@ -368,7 +359,7 @@ suite('Connection Controller Test Suite', () => {
   });
 
   const expectedTimesToFire = 3;
-  test(`"connect()" then "disconnect()" should fire the connections did change event ${expectedTimesToFire} times`, function (done) {
+  test(`"connect()" then "disconnect()" should fire the connections did change event ${expectedTimesToFire} times`, function(done) {
     const testConnectionController = new ConnectionController(
       new StatusView(mockExtensionContext),
       mockStorageController
@@ -387,7 +378,7 @@ suite('Connection Controller Test Suite', () => {
       .addNewConnectionAndConnect(testDatabaseURI)
       .then(() => {
         testConnectionController.disconnect().then(() => {
-          setTimeout(function () {
+          setTimeout(function() {
             assert(
               connectionEventFiredCount === expectedTimesToFire,
               `Expected connection event to be fired ${expectedTimesToFire} times, got ${connectionEventFiredCount}.`
@@ -398,7 +389,7 @@ suite('Connection Controller Test Suite', () => {
       });
   });
 
-  test('when there are no existing connections in the store and the connection controller loads connections', function () {
+  test('when there are no existing connections in the store and the connection controller loads connections', function() {
     const testExtensionContext = new TestExtensionContext();
     const testStorageController = new StorageController(testExtensionContext);
 
@@ -410,25 +401,27 @@ suite('Connection Controller Test Suite', () => {
     testConnectionController.loadSavedConnections();
     assert(
       Object.keys(testConnectionController.getConnections()).length === 0,
-      `Expected connections to be 0 found ${Object.keys(testConnectionController.getConnections()).length}`
+      `Expected connections to be 0 found ${
+        Object.keys(testConnectionController.getConnections()).length
+      }`
     );
   });
 
-  test('The connection model loads both global and workspace stored connection models', function () {
+  test('The connection model loads both global and workspace stored connection models', function() {
     const testExtensionContext = new TestExtensionContext();
     // Set existing connections.
     testExtensionContext.globalState.update(
       StorageVariables.GLOBAL_CONNECTION_STRINGS,
       {
-        'testGlobalConnectionModel': 'testGlobalConnectionModelDriverUrl',
-        'testGlobalConnectionModel2': 'testGlobalConnectionModel2DriverUrl'
+        testGlobalConnectionModel: 'testGlobalConnectionModelDriverUrl',
+        testGlobalConnectionModel2: 'testGlobalConnectionModel2DriverUrl'
       }
     );
     testExtensionContext.workspaceState.update(
       StorageVariables.WORKSPACE_CONNECTION_STRINGS,
       {
-        'testWorkspaceConnectionModel': 'testWorkspaceConnectionModel1DriverUrl',
-        'testWorkspaceConnectionModel2': 'testWorkspaceConnectionModel2DriverUrl'
+        testWorkspaceConnectionModel: 'testWorkspaceConnectionModel1DriverUrl',
+        testWorkspaceConnectionModel2: 'testWorkspaceConnectionModel2DriverUrl'
       }
     );
     const testStorageController = new StorageController(testExtensionContext);
@@ -443,23 +436,27 @@ suite('Connection Controller Test Suite', () => {
     const connections = testConnectionController.getConnections();
     assert(
       Object.keys(connections).length === 4,
-      `Expected 4 connection configurations found ${Object.keys(testConnectionController.getConnections()).length}`
+      `Expected 4 connection configurations found ${
+        Object.keys(testConnectionController.getConnections()).length
+      }`
     );
     assert(
       Object.keys(connections).includes('testGlobalConnectionModel2') === true,
-      'Expected connection configurations to include \'testGlobalConnectionModel2\''
+      "Expected connection configurations to include 'testGlobalConnectionModel2'"
     );
     assert(
-      Object.keys(connections).includes('testWorkspaceConnectionModel2') === true,
-      'Expected connection configurations to include \'testWorkspaceConnectionModel2\''
+      Object.keys(connections).includes('testWorkspaceConnectionModel2') ===
+        true,
+      "Expected connection configurations to include 'testWorkspaceConnectionModel2'"
     );
     assert(
-      connections.testGlobalConnectionModel2.hostname === 'testglobalconnectionmodel2driverurl',
-      'Expected connection configuration to include hostname \'testglobalconnectionmodel2driverurl\''
+      connections.testGlobalConnectionModel2.hostname ===
+        'testglobalconnectionmodel2driverurl',
+      "Expected connection configuration to include hostname 'testglobalconnectionmodel2driverurl'"
     );
   });
 
-  test('When a connection is added it is saved to the global store', async function () {
+  test('When a connection is added it is saved to the global store', async function() {
     const testExtensionContext = new TestExtensionContext();
     const testStorageController = new StorageController(testExtensionContext);
 
@@ -470,31 +467,38 @@ suite('Connection Controller Test Suite', () => {
 
     testConnectionController.loadSavedConnections();
 
-    await vscode.workspace.getConfiguration('mdb.connectionSaving').update(
-      'defaultConnectionSavingLocation',
-      DefaultSavingLocations.Global
-    );
+    await vscode.workspace
+      .getConfiguration('mdb.connectionSaving')
+      .update('defaultConnectionSavingLocation', DefaultSavingLocations.Global);
 
     await testConnectionController.addNewConnectionAndConnect(testDatabaseURI);
 
-    const globalStoreConnections = testStorageController.get(StorageVariables.GLOBAL_CONNECTION_STRINGS);
+    const globalStoreConnections = testStorageController.get(
+      StorageVariables.GLOBAL_CONNECTION_STRINGS
+    );
     assert(
       Object.keys(globalStoreConnections).length === 1,
-      `Expected global store connections to have 1 connection found ${Object.keys(globalStoreConnections).length}`
+      `Expected global store connections to have 1 connection found ${
+        Object.keys(globalStoreConnections).length
+      }`
     );
     assert(
       Object.keys(globalStoreConnections).includes(testDatabaseInstanceId),
-      `Expected global store connections to have the new connection '${testDatabaseInstanceId}' found ${Object.keys(globalStoreConnections)}`
+      `Expected global store connections to have the new connection '${testDatabaseInstanceId}' found ${Object.keys(
+        globalStoreConnections
+      )}`
     );
 
-    const workspaceStoreConnections = testStorageController.get(StorageVariables.WORKSPACE_CONNECTION_STRINGS);
+    const workspaceStoreConnections = testStorageController.get(
+      StorageVariables.WORKSPACE_CONNECTION_STRINGS
+    );
     assert(
       workspaceStoreConnections === undefined,
       `Expected workspace store connections to be 'undefined' found ${workspaceStoreConnections}`
     );
   });
 
-  test('When a connection is added it is saved to the workspace store', async function () {
+  test('When a connection is added it is saved to the workspace store', async function() {
     const testExtensionContext = new TestExtensionContext();
     const testStorageController = new StorageController(testExtensionContext);
 
@@ -505,10 +509,12 @@ suite('Connection Controller Test Suite', () => {
 
     testConnectionController.loadSavedConnections();
 
-    await vscode.workspace.getConfiguration('mdb.connectionSaving').update(
-      'defaultConnectionSavingLocation',
-      DefaultSavingLocations.Workspace
-    );
+    await vscode.workspace
+      .getConfiguration('mdb.connectionSaving')
+      .update(
+        'defaultConnectionSavingLocation',
+        DefaultSavingLocations.Workspace
+      );
 
     await testConnectionController.addNewConnectionAndConnect(testDatabaseURI);
 
@@ -519,21 +525,27 @@ suite('Connection Controller Test Suite', () => {
 
     assert(
       Object.keys(workspaceStoreConnections).length === 1,
-      `Expected workspace store connections to have 1 connection found ${Object.keys(workspaceStoreConnections).length}`
+      `Expected workspace store connections to have 1 connection found ${
+        Object.keys(workspaceStoreConnections).length
+      }`
     );
     assert(
       Object.keys(workspaceStoreConnections).includes(testDatabaseInstanceId),
-      `Expected workspace store connections to have the new connection '${testDatabaseInstanceId}' found ${Object.keys(workspaceStoreConnections)}`
+      `Expected workspace store connections to have the new connection '${testDatabaseInstanceId}' found ${Object.keys(
+        workspaceStoreConnections
+      )}`
     );
 
-    const globalStoreConnections = testStorageController.get(StorageVariables.GLOBAL_CONNECTION_STRINGS);
+    const globalStoreConnections = testStorageController.get(
+      StorageVariables.GLOBAL_CONNECTION_STRINGS
+    );
     assert(
       globalStoreConnections === undefined,
       `Expected global store connections to be 'undefined' found ${globalStoreConnections}`
     );
   });
 
-  test('A saved connection can be loaded and connected to', function (done) {
+  test('A saved connection can be loaded and connected to', function(done) {
     const testExtensionContext = new TestExtensionContext();
     const testStorageController = new StorageController(testExtensionContext);
 
@@ -544,53 +556,67 @@ suite('Connection Controller Test Suite', () => {
 
     testConnectionController.loadSavedConnections();
 
-    vscode.workspace.getConfiguration('mdb.connectionSaving').update(
-      'defaultConnectionSavingLocation',
-      DefaultSavingLocations.Workspace
-    ).then(() => {
-      testConnectionController
-        .addNewConnectionAndConnect(testDatabaseURI)
-        .then(() => {
-          const workspaceStoreConnections = testStorageController.get(
-            StorageVariables.WORKSPACE_CONNECTION_STRINGS,
-            StorageScope.WORKSPACE
-          );
-          assert(
-            Object.keys(workspaceStoreConnections).length === 1,
-            `Expected workspace store connections to have 1 connection found ${Object.keys(workspaceStoreConnections).length}`
-          );
-
-          testConnectionController.disconnect().then(() => {
-            testConnectionController.clearAllConnections();
+    vscode.workspace
+      .getConfiguration('mdb.connectionSaving')
+      .update(
+        'defaultConnectionSavingLocation',
+        DefaultSavingLocations.Workspace
+      )
+      .then(() => {
+        testConnectionController
+          .addNewConnectionAndConnect(testDatabaseURI)
+          .then(() => {
+            const workspaceStoreConnections = testStorageController.get(
+              StorageVariables.WORKSPACE_CONNECTION_STRINGS,
+              StorageScope.WORKSPACE
+            );
             assert(
-              testConnectionController.getConnectionInstanceIds().length === 0,
-              'Expected no connection configs.'
+              Object.keys(workspaceStoreConnections).length === 1,
+              `Expected workspace store connections to have 1 connection found ${
+                Object.keys(workspaceStoreConnections).length
+              }`
             );
 
-            // Activate (which will load the past connection).
-            testConnectionController.loadSavedConnections();
-            assert(
-              testConnectionController.getConnectionInstanceIds().length === 1,
-              `Expected 1 connection config, found ${testConnectionController.getConnectionInstanceIds().length}.`
-            );
+            testConnectionController.disconnect().then(() => {
+              testConnectionController.clearAllConnections();
+              assert(
+                testConnectionController.getConnectionInstanceIds().length ===
+                  0,
+                'Expected no connection configs.'
+              );
 
-            testConnectionController
-              .connectWithInstanceId(testDatabaseInstanceId)
-              .then(() => {
-                const { instanceId } = testConnectionController.getActiveConnectionConfig().getAttributes({
-                  derived: true
-                });
-                assert(
-                  instanceId === 'localhost:27018',
-                  `Expected the active connection to be 'localhost:27018', found ${instanceId}.`
-                );
-              }).then(done, done);
+              // Activate (which will load the past connection).
+              testConnectionController.loadSavedConnections();
+              assert(
+                testConnectionController.getConnectionInstanceIds().length ===
+                  1,
+                `Expected 1 connection config, found ${
+                  testConnectionController.getConnectionInstanceIds().length
+                }.`
+              );
+
+              testConnectionController
+                .connectWithInstanceId(testDatabaseInstanceId)
+                .then(() => {
+                  const {
+                    instanceId
+                  } = testConnectionController
+                    .getActiveConnectionConfig()
+                    .getAttributes({
+                      derived: true
+                    });
+                  assert(
+                    instanceId === 'localhost:27018',
+                    `Expected the active connection to be 'localhost:27018', found ${instanceId}.`
+                  );
+                })
+                .then(done, done);
+            });
           });
-        });
-    });
+      });
   });
 
-  test('"getConnectionStringFromConnectionId" returns the driver uri of a connection', function (done) {
+  test('"getConnectionStringFromConnectionId" returns the driver uri of a connection', function(done) {
     const testExtensionContext = new TestExtensionContext();
     const testStorageController = new StorageController(testExtensionContext);
 
@@ -601,21 +627,25 @@ suite('Connection Controller Test Suite', () => {
 
     testConnectionController.loadSavedConnections();
 
-    const expectedDriverUri = 'mongodb://localhost:27018/?readPreference=primary&appname=mongodb-vscode%200.0.1&ssl=false';
+    const expectedDriverUri =
+      'mongodb://localhost:27018/?readPreference=primary&appname=mongodb-vscode%200.0.1&ssl=false';
 
     testConnectionController
       .addNewConnectionAndConnect(testDatabaseURI)
       .then(() => {
-        const testDriverUri = testConnectionController.getConnectionStringFromConnectionId('localhost:27018');
+        const testDriverUri = testConnectionController.getConnectionStringFromConnectionId(
+          'localhost:27018'
+        );
 
         assert(
           testDriverUri === expectedDriverUri,
           `Expected to be returned the driver uri "${expectedDriverUri}" found ${testDriverUri}`
         );
-      }).then(done, done);
+      })
+      .then(done, done);
   });
 
-  test('When a connection is added and the user has set it to not save on default it is not saved', function (done) {
+  test('When a connection is added and the user has set it to not save on default it is not saved', function(done) {
     const testExtensionContext = new TestExtensionContext();
     const testStorageController = new StorageController(testExtensionContext);
 
@@ -626,35 +656,42 @@ suite('Connection Controller Test Suite', () => {
 
     testConnectionController.loadSavedConnections();
     // Don't save connections on default.
-    vscode.workspace.getConfiguration('mdb.connectionSaving').update(
-      'defaultConnectionSavingLocation',
-      DefaultSavingLocations['Session Only']
-    ).then(() => {
-      testConnectionController
-        .addNewConnectionAndConnect(testDatabaseURI)
-        .then(() => {
-          const objectString = JSON.stringify(undefined);
-          const globalStoreConnections = testStorageController.get(
-            StorageVariables.GLOBAL_CONNECTION_STRINGS
-          );
-          assert(
-            JSON.stringify(globalStoreConnections) === objectString,
-            `Expected global store connections to be an empty object found ${globalStoreConnections}`
-          );
+    vscode.workspace
+      .getConfiguration('mdb.connectionSaving')
+      .update(
+        'defaultConnectionSavingLocation',
+        DefaultSavingLocations['Session Only']
+      )
+      .then(() => {
+        testConnectionController
+          .addNewConnectionAndConnect(testDatabaseURI)
+          .then(() => {
+            const objectString = JSON.stringify(undefined);
+            const globalStoreConnections = testStorageController.get(
+              StorageVariables.GLOBAL_CONNECTION_STRINGS
+            );
+            assert(
+              JSON.stringify(globalStoreConnections) === objectString,
+              `Expected global store connections to be an empty object found ${globalStoreConnections}`
+            );
 
-          const workspaceStoreConnections = testStorageController.get(
-            StorageVariables.WORKSPACE_CONNECTION_STRINGS,
-            StorageScope.WORKSPACE
-          );
-          assert(
-            JSON.stringify(workspaceStoreConnections) === objectString,
-            `Expected workspace store connections to be an empty object found ${JSON.stringify(workspaceStoreConnections)}`
-          );
-        }).then(done).catch(done);
-    }, done);
+            const workspaceStoreConnections = testStorageController.get(
+              StorageVariables.WORKSPACE_CONNECTION_STRINGS,
+              StorageScope.WORKSPACE
+            );
+            assert(
+              JSON.stringify(workspaceStoreConnections) === objectString,
+              `Expected workspace store connections to be an empty object found ${JSON.stringify(
+                workspaceStoreConnections
+              )}`
+            );
+          })
+          .then(done)
+          .catch(done);
+      }, done);
   });
 
-  test('When a connection is removed it is also removed from workspace storage', function (done) {
+  test('When a connection is removed it is also removed from workspace storage', function(done) {
     const testExtensionContext = new TestExtensionContext();
     const testStorageController = new StorageController(testExtensionContext);
 
@@ -665,38 +702,48 @@ suite('Connection Controller Test Suite', () => {
 
     testConnectionController.loadSavedConnections();
 
-    vscode.workspace.getConfiguration('mdb.connectionSaving').update(
-      'defaultConnectionSavingLocation',
-      DefaultSavingLocations.Workspace
-    ).then(() => {
-      testConnectionController
-        .addNewConnectionAndConnect(testDatabaseURI)
-        .then(() => {
-          const workspaceStoreConnections = testStorageController.get(
-            StorageVariables.WORKSPACE_CONNECTION_STRINGS,
-            StorageScope.WORKSPACE
-          );
+    vscode.workspace
+      .getConfiguration('mdb.connectionSaving')
+      .update(
+        'defaultConnectionSavingLocation',
+        DefaultSavingLocations.Workspace
+      )
+      .then(() => {
+        testConnectionController
+          .addNewConnectionAndConnect(testDatabaseURI)
+          .then(() => {
+            const workspaceStoreConnections = testStorageController.get(
+              StorageVariables.WORKSPACE_CONNECTION_STRINGS,
+              StorageScope.WORKSPACE
+            );
 
-          assert(
-            Object.keys(workspaceStoreConnections).length === 1,
-            `Expected workspace store connections to have 1 connection found ${Object.keys(workspaceStoreConnections).length}`
-          );
+            assert(
+              Object.keys(workspaceStoreConnections).length === 1,
+              `Expected workspace store connections to have 1 connection found ${
+                Object.keys(workspaceStoreConnections).length
+              }`
+            );
 
-          testConnectionController.removeConnectionConfig(testDatabaseInstanceId);
+            testConnectionController.removeConnectionConfig(
+              testDatabaseInstanceId
+            );
 
-          const postWorkspaceStoreConnections = testStorageController.get(
-            StorageVariables.WORKSPACE_CONNECTION_STRINGS,
-            StorageScope.WORKSPACE
-          );
-          assert(
-            Object.keys(postWorkspaceStoreConnections).length === 0,
-            `Expected workspace store connections to have 0 connections found ${Object.keys(postWorkspaceStoreConnections).length}`
-          );
-        }).then(done, done);
-    });
+            const postWorkspaceStoreConnections = testStorageController.get(
+              StorageVariables.WORKSPACE_CONNECTION_STRINGS,
+              StorageScope.WORKSPACE
+            );
+            assert(
+              Object.keys(postWorkspaceStoreConnections).length === 0,
+              `Expected workspace store connections to have 0 connections found ${
+                Object.keys(postWorkspaceStoreConnections).length
+              }`
+            );
+          })
+          .then(done, done);
+      });
   });
 
-  test('When a connection is removed it is also removed from global storage', async function () {
+  test('When a connection is removed it is also removed from global storage', async function() {
     const testExtensionContext = new TestExtensionContext();
     const testStorageController = new StorageController(testExtensionContext);
 
@@ -707,10 +754,9 @@ suite('Connection Controller Test Suite', () => {
 
     testConnectionController.loadSavedConnections();
 
-    await vscode.workspace.getConfiguration('mdb.connectionSaving').update(
-      'defaultConnectionSavingLocation',
-      DefaultSavingLocations.Global
-    );
+    await vscode.workspace
+      .getConfiguration('mdb.connectionSaving')
+      .update('defaultConnectionSavingLocation', DefaultSavingLocations.Global);
 
     await testConnectionController.addNewConnectionAndConnect(testDatabaseURI);
     const globalStoreConnections = testStorageController.get(
@@ -719,7 +765,9 @@ suite('Connection Controller Test Suite', () => {
 
     assert(
       Object.keys(globalStoreConnections).length === 1,
-      `Expected workspace store connections to have 1 connection found ${Object.keys(globalStoreConnections).length}`
+      `Expected workspace store connections to have 1 connection found ${
+        Object.keys(globalStoreConnections).length
+      }`
     );
 
     testConnectionController.removeConnectionConfig(testDatabaseInstanceId);
@@ -729,7 +777,9 @@ suite('Connection Controller Test Suite', () => {
     );
     assert(
       Object.keys(postGlobalStoreConnections).length === 0,
-      `Expected global store connections to have 0 connections found ${Object.keys(postGlobalStoreConnections).length}`
+      `Expected global store connections to have 0 connections found ${
+        Object.keys(postGlobalStoreConnections).length
+      }`
     );
   });
 });

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -398,7 +398,7 @@ suite('Connection Controller Test Suite', () => {
       });
   });
 
-  test('when there are no existing connections in the store and the connection controller is activated', function () {
+  test('when there are no existing connections in the store and the connection controller loads connections', function () {
     const testExtensionContext = new TestExtensionContext();
     const testStorageController = new StorageController(testExtensionContext);
 
@@ -407,14 +407,14 @@ suite('Connection Controller Test Suite', () => {
       testStorageController
     );
 
-    testConnectionController.activate();
+    testConnectionController.loadSavedConnections();
     assert(
       Object.keys(testConnectionController.getConnections()).length === 0,
       `Expected connections to be 0 found ${Object.keys(testConnectionController.getConnections()).length}`
     );
   });
 
-  test('When activated, the connection model loads both global and workspace stored connection models', function () {
+  test('The connection model loads both global and workspace stored connection models', function () {
     const testExtensionContext = new TestExtensionContext();
     // Set existing connections.
     testExtensionContext.globalState.update(
@@ -438,7 +438,7 @@ suite('Connection Controller Test Suite', () => {
       testStorageController
     );
 
-    testConnectionController.activate();
+    testConnectionController.loadSavedConnections();
 
     const connections = testConnectionController.getConnections();
     assert(
@@ -468,7 +468,7 @@ suite('Connection Controller Test Suite', () => {
       testStorageController
     );
 
-    testConnectionController.activate();
+    testConnectionController.loadSavedConnections();
 
     await vscode.workspace.getConfiguration('mdb.connectionSaving').update(
       'defaultConnectionSavingLocation',
@@ -503,7 +503,7 @@ suite('Connection Controller Test Suite', () => {
       testStorageController
     );
 
-    testConnectionController.activate();
+    testConnectionController.loadSavedConnections();
 
     await vscode.workspace.getConfiguration('mdb.connectionSaving').update(
       'defaultConnectionSavingLocation',
@@ -542,7 +542,7 @@ suite('Connection Controller Test Suite', () => {
       testStorageController
     );
 
-    testConnectionController.activate();
+    testConnectionController.loadSavedConnections();
 
     vscode.workspace.getConfiguration('mdb.connectionSaving').update(
       'defaultConnectionSavingLocation',
@@ -568,7 +568,7 @@ suite('Connection Controller Test Suite', () => {
             );
 
             // Activate (which will load the past connection).
-            testConnectionController.activate();
+            testConnectionController.loadSavedConnections();
             assert(
               testConnectionController.getConnectionInstanceIds().length === 1,
               `Expected 1 connection config, found ${testConnectionController.getConnectionInstanceIds().length}.`
@@ -599,7 +599,7 @@ suite('Connection Controller Test Suite', () => {
       testStorageController
     );
 
-    testConnectionController.activate();
+    testConnectionController.loadSavedConnections();
 
     const expectedDriverUri = 'mongodb://localhost:27018/?readPreference=primary&appname=mongodb-vscode%200.0.1&ssl=false';
 
@@ -624,7 +624,7 @@ suite('Connection Controller Test Suite', () => {
       testStorageController
     );
 
-    testConnectionController.activate();
+    testConnectionController.loadSavedConnections();
     // Don't save connections on default.
     vscode.workspace.getConfiguration('mdb.connectionSaving').update(
       'defaultConnectionSavingLocation',
@@ -663,7 +663,7 @@ suite('Connection Controller Test Suite', () => {
       testStorageController
     );
 
-    testConnectionController.activate();
+    testConnectionController.loadSavedConnections();
 
     vscode.workspace.getConfiguration('mdb.connectionSaving').update(
       'defaultConnectionSavingLocation',
@@ -705,7 +705,7 @@ suite('Connection Controller Test Suite', () => {
       testStorageController
     );
 
-    testConnectionController.activate();
+    testConnectionController.loadSavedConnections();
 
     await vscode.workspace.getConfiguration('mdb.connectionSaving').update(
       'defaultConnectionSavingLocation',

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -505,7 +505,7 @@ suite('Connection Controller Test Suite', () => {
           );
 
           testConnectionController.disconnect().then(() => {
-            testConnectionController.clearConnectionConfigs();
+            testConnectionController.clearAllConnections();
             assert(
               testConnectionController.getConnectionInstanceIds().length === 0,
               'Expected no connection configs.'

--- a/src/test/suite/editors/editorsController.test.ts
+++ b/src/test/suite/editors/editorsController.test.ts
@@ -7,11 +7,10 @@ suite('Editors Controller Test Suite', () => {
   vscode.window.showInformationMessage('Starting tests...');
 
   test('getViewCollectionDocumentsUri builds a uri from the namespace and connection info', function () {
-    const testEditorsController = new EditorsController();
     const testOpId = '100011011101110011';
     const testNamespace = 'myFavoriteNamespace';
     const testConnectionId = 'alienSateliteConnection';
-    const testUri = testEditorsController.getViewCollectionDocumentsUri(testOpId, testNamespace, testConnectionId);
+    const testUri = EditorsController.getViewCollectionDocumentsUri(testOpId, testNamespace, testConnectionId);
 
     assert(
       testUri.path === 'Results: myFavoriteNamespace.json',

--- a/src/test/suite/explorer/databaseTreeItem.test.ts
+++ b/src/test/suite/explorer/databaseTreeItem.test.ts
@@ -7,7 +7,7 @@ import { DataServiceStub, mockDatabaseNames, mockDatabases } from '../stubs';
 suite('DatabaseTreeItem Test Suite', () => {
   vscode.window.showInformationMessage('Starting tests...');
 
-  test('when not expanded it does not show collections', function (done) {
+  test('when not expanded it does not show collections', function(done) {
     const testDatabaseTreeItem = new DatabaseTreeItem(
       mockDatabaseNames[1],
       new DataServiceStub(),
@@ -26,7 +26,7 @@ suite('DatabaseTreeItem Test Suite', () => {
       .then(done, done);
   });
 
-  test('when expanded shows the collections of a database in tree', function (done) {
+  test('when expanded shows the collections of a database in tree', function(done) {
     const testDatabaseTreeItem = new DatabaseTreeItem(
       mockDatabaseNames[1],
       new DataServiceStub(),
@@ -46,14 +46,16 @@ suite('DatabaseTreeItem Test Suite', () => {
 
         assert(
           collections[1].label ===
-          mockDatabases[mockDatabaseNames[1]].collections[1].name,
-          `Expected a tree item child with the label collection name ${mockDatabases[mockDatabaseNames[1]].collections[1].name} found ${collections[1].label}`
+            mockDatabases[mockDatabaseNames[1]].collections[1].name,
+          `Expected a tree item child with the label collection name ${
+            mockDatabases[mockDatabaseNames[1]].collections[1].name
+          } found ${collections[1].label}`
         );
       })
       .then(done, done);
   });
 
-  test('when expanded and collapsed its collections cache their expanded documents', function (done) {
+  test('when expanded and collapsed its collections cache their expanded documents', function(done) {
     const testDatabaseTreeItem = new DatabaseTreeItem(
       mockDatabaseNames[1],
       new DataServiceStub(),
@@ -63,7 +65,7 @@ suite('DatabaseTreeItem Test Suite', () => {
 
     testDatabaseTreeItem.onDidExpand();
 
-    testDatabaseTreeItem.getChildren().then(collectionTreeItems => {
+    testDatabaseTreeItem.getChildren().then((collectionTreeItems) => {
       assert(
         collectionTreeItems[1].isExpanded === false,
         'Expected collection tree item not to be expanded on default.'
@@ -79,28 +81,35 @@ suite('DatabaseTreeItem Test Suite', () => {
         );
 
         testDatabaseTreeItem.onDidCollapse();
-        testDatabaseTreeItem.getChildren().then(postCollapseCollectionTreeItems => {
-          assert(
-            postCollapseCollectionTreeItems.length === 0,
-            `Expected the database tree to return no children when collapsed, found ${collectionTreeItems.length}`
-          );
-
-          testDatabaseTreeItem.onDidExpand();
-          testDatabaseTreeItem.getChildren().then(newCollectionTreeItems => {
+        testDatabaseTreeItem
+          .getChildren()
+          .then((postCollapseCollectionTreeItems) => {
             assert(
-              newCollectionTreeItems[1].isExpanded === true,
-              'Expected collection tree item to be expanded from cache.'
+              postCollapseCollectionTreeItems.length === 0,
+              `Expected the database tree to return no children when collapsed, found ${collectionTreeItems.length}`
             );
 
-            newCollectionTreeItems[1].getChildren().then((documentsPostCollapseExpand) => {
-              // It should cache that we activated show more.
-              assert(
-                documentsPostCollapseExpand.length === 21,
-                `Expected a cached 21 documents to be returned, found ${documents.length}`
-              );
-            }).then(done, done);
+            testDatabaseTreeItem.onDidExpand();
+            testDatabaseTreeItem
+              .getChildren()
+              .then((newCollectionTreeItems) => {
+                assert(
+                  newCollectionTreeItems[1].isExpanded === true,
+                  'Expected collection tree item to be expanded from cache.'
+                );
+
+                newCollectionTreeItems[1]
+                  .getChildren()
+                  .then((documentsPostCollapseExpand) => {
+                    // It should cache that we activated show more.
+                    assert(
+                      documentsPostCollapseExpand.length === 21,
+                      `Expected a cached 21 documents to be returned, found ${documents.length}`
+                    );
+                  })
+                  .then(done, done);
+              });
           });
-        });
       });
     });
   });

--- a/src/test/suite/explorer/explorerController.test.ts
+++ b/src/test/suite/explorer/explorerController.test.ts
@@ -11,82 +11,94 @@ const testDatabaseURI = 'mongodb://localhost:27018';
 const testDatabaseURI2WithTimeout =
   'mongodb://shouldfail?connectTimeoutMS=1000&serverSelectionTimeoutMS=500';
 
-suite('Explorer Controller Test Suite', function () {
+suite('Explorer Controller Test Suite', function() {
   vscode.window.showInformationMessage('Starting tests...');
 
   beforeEach(async () => {
     // Don't save connections on default.
-    await vscode.workspace.getConfiguration('mdb.connectionSaving').update(
-      'defaultConnectionSavingLocation',
-      DefaultSavingLocations['Session Only']
-    );
+    await vscode.workspace
+      .getConfiguration('mdb.connectionSaving')
+      .update(
+        'defaultConnectionSavingLocation',
+        DefaultSavingLocations['Session Only']
+      );
   });
   afterEach(async () => {
     // Unset the variable we set in `beforeEach`.
-    await vscode.workspace.getConfiguration('mdb.connectionSaving').update(
-      'defaultConnectionSavingLocation',
-      DefaultSavingLocations.Workspace
-    );
+    await vscode.workspace
+      .getConfiguration('mdb.connectionSaving')
+      .update(
+        'defaultConnectionSavingLocation',
+        DefaultSavingLocations.Workspace
+      );
     // Reset our connections.
     mdbTestExtension.testExtensionController._connectionController.clearAllConnections();
   });
 
-
-  test('should have a connections root', function (done) {
-    const testExplorerController = mdbTestExtension.testExtensionController._explorerController;
+  test('should have a connections root', function(done) {
+    const testExplorerController =
+      mdbTestExtension.testExtensionController._explorerController;
 
     const treeController = testExplorerController.getTreeController();
 
     assert(!!treeController, 'Tree controller should not be undefined');
-    treeController.getChildren().then(treeControllerChildren => {
-      assert(
-        treeControllerChildren.length === 1,
-        `Tree controller should have 1 child, found ${treeControllerChildren.length}`
-      );
-      assert(
-        treeControllerChildren[0].label === 'Connections',
-        'Tree controller should have a "Connections" child'
-      );
-    }).then(done, done);
+    treeController
+      .getChildren()
+      .then((treeControllerChildren) => {
+        assert(
+          treeControllerChildren.length === 1,
+          `Tree controller should have 1 child, found ${treeControllerChildren.length}`
+        );
+        assert(
+          treeControllerChildren[0].label === 'Connections',
+          'Tree controller should have a "Connections" child'
+        );
+      })
+      .then(done, done);
   });
 
-  test('it updates the connections to account for a change in the connection controller', function (done) {
-    const testConnectionController = mdbTestExtension.testExtensionController._connectionController;
-    const testExplorerController = mdbTestExtension.testExtensionController._explorerController;
+  test('it updates the connections to account for a change in the connection controller', function(done) {
+    const testConnectionController =
+      mdbTestExtension.testExtensionController._connectionController;
+    const testExplorerController =
+      mdbTestExtension.testExtensionController._explorerController;
 
     const treeController = testExplorerController.getTreeController();
 
     const mockConnectionInstanceId = 'testInstanceId';
 
-    testConnectionController.setConnnectingInstanceId(
-      mockConnectionInstanceId
-    );
+    testConnectionController.setConnnectingInstanceId(mockConnectionInstanceId);
     testConnectionController.setConnnecting(true);
 
-    treeController.getChildren().then(treeControllerChildren => {
-      treeControllerChildren[0].getChildren().then(connectionsItems => {
-        assert(
-          connectionsItems.length === 1,
-          `Expected there to be 1 connection tree item, found ${connectionsItems.length}`
-        );
-        assert(
-          connectionsItems[0].label === 'testInstanceId',
-          'There should be a connection tree item with the label "testInstanceId"'
-        );
-        testExplorerController.deactivate();
-      }).then(done, done);
+    treeController.getChildren().then((treeControllerChildren) => {
+      treeControllerChildren[0]
+        .getChildren()
+        .then((connectionsItems) => {
+          assert(
+            connectionsItems.length === 1,
+            `Expected there to be 1 connection tree item, found ${connectionsItems.length}`
+          );
+          assert(
+            connectionsItems[0].label === 'testInstanceId',
+            'There should be a connection tree item with the label "testInstanceId"'
+          );
+          testExplorerController.deactivate();
+        })
+        .then(done, done);
     });
   });
 
-  test('when a connection is added and connected it is added to the tree and expanded', function (done) {
-    const testConnectionController = mdbTestExtension.testExtensionController._connectionController;
-    const testExplorerController = mdbTestExtension.testExtensionController._explorerController;
+  test('when a connection is added and connected it is added to the tree and expanded', function(done) {
+    const testConnectionController =
+      mdbTestExtension.testExtensionController._connectionController;
+    const testExplorerController =
+      mdbTestExtension.testExtensionController._explorerController;
 
     const treeController = testExplorerController.getTreeController();
 
     testConnectionController
       .addNewConnectionAndConnect(testDatabaseURI)
-      .then(succesfullyConnected => {
+      .then((succesfullyConnected) => {
         assert(
           succesfullyConnected === true,
           'Expected a successful connection response.'
@@ -101,10 +113,10 @@ suite('Explorer Controller Test Suite', function () {
           `Expected active connection to be 'localhost:27018' found ${instanceId}`
         );
 
-        treeController.getChildren().then(treeControllerChildren => {
+        treeController.getChildren().then((treeControllerChildren) => {
           treeControllerChildren[0]
             .getChildren()
-            .then(connectionsItems => {
+            .then((connectionsItems) => {
               assert(
                 connectionsItems.length === 1,
                 `Expected there be 1 connection tree item, found ${connectionsItems.length}`
@@ -129,15 +141,17 @@ suite('Explorer Controller Test Suite', function () {
       });
   });
 
-  test('only the active connection is displayed as connected in the tree', function (done) {
-    const testConnectionController = mdbTestExtension.testExtensionController._connectionController;
-    const testExplorerController = mdbTestExtension.testExtensionController._explorerController;
+  test('only the active connection is displayed as connected in the tree', function(done) {
+    const testConnectionController =
+      mdbTestExtension.testExtensionController._connectionController;
+    const testExplorerController =
+      mdbTestExtension.testExtensionController._explorerController;
 
     const treeController = testExplorerController.getTreeController();
 
     testConnectionController
       .addNewConnectionAndConnect(testDatabaseURI)
-      .then(succesfullyConnected => {
+      .then((succesfullyConnected) => {
         assert(
           succesfullyConnected === true,
           'Expected a successful connection response.'
@@ -153,15 +167,18 @@ suite('Explorer Controller Test Suite', function () {
         );
 
         // This will timeout in 500ms, which is enough time for us to just check.
-        testConnectionController.addNewConnectionAndConnect(
-          testDatabaseURI2WithTimeout
-        ).then(() => { }, () => { } /* Silent fail (should fail) */);
+        testConnectionController
+          .addNewConnectionAndConnect(testDatabaseURI2WithTimeout)
+          .then(
+            () => {},
+            () => {} /* Silent fail (should fail) */
+          );
 
         setTimeout(() => {
-          treeController.getChildren().then(treeControllerChildren => {
+          treeController.getChildren().then((treeControllerChildren) => {
             treeControllerChildren[0]
               .getChildren()
-              .then(connectionsItems => {
+              .then((connectionsItems) => {
                 assert(
                   connectionsItems.length === 2,
                   `Expected there be 2 connection tree item, found ${connectionsItems.length}`
@@ -188,23 +205,26 @@ suite('Explorer Controller Test Suite', function () {
                 );
 
                 testExplorerController.deactivate();
-              }).then(done, done);
+              })
+              .then(done, done);
           });
         }, 100);
       });
   });
 
-  test('shows the databases of connected connection in tree', function (done) {
-    const testConnectionController = mdbTestExtension.testExtensionController._connectionController;
-    const testExplorerController = mdbTestExtension.testExtensionController._explorerController;
+  test('shows the databases of connected connection in tree', function(done) {
+    const testConnectionController =
+      mdbTestExtension.testExtensionController._connectionController;
+    const testExplorerController =
+      mdbTestExtension.testExtensionController._explorerController;
 
     const treeController = testExplorerController.getTreeController();
 
     testConnectionController
       .addNewConnectionAndConnect(testDatabaseURI)
       .then(() => {
-        treeController.getChildren().then(treeControllerChildren => {
-          treeControllerChildren[0].getChildren().then(connectionsItems => {
+        treeController.getChildren().then((treeControllerChildren) => {
+          treeControllerChildren[0].getChildren().then((connectionsItems) => {
             // Expand the connection.
             treeControllerChildren[0].onDidExpand();
 
@@ -228,56 +248,65 @@ suite('Explorer Controller Test Suite', function () {
       });
   });
 
-  test('caches the expanded state of databases in the tree when a connection is expanded or collapsed', function (done) {
-    const testConnectionController = mdbTestExtension.testExtensionController._connectionController;
-    const testExplorerController = mdbTestExtension.testExtensionController._explorerController;
+  test('caches the expanded state of databases in the tree when a connection is expanded or collapsed', function(done) {
+    const testConnectionController =
+      mdbTestExtension.testExtensionController._connectionController;
+    const testExplorerController =
+      mdbTestExtension.testExtensionController._explorerController;
 
     const treeController = testExplorerController.getTreeController();
 
-    testConnectionController.addNewConnectionAndConnect(testDatabaseURI).then(() => {
-      treeController.getChildren().then(rootTreeItem => {
-        const connectionsTreeItem = rootTreeItem[0];
-        connectionsTreeItem.getChildren().then(connectionsItems => {
-          // Expand the connection.
-          const testConnectionTreeItem = connectionsItems[0];
-          testConnectionTreeItem.onDidExpand().then(() => {
-            testConnectionTreeItem.getChildren().then((databaseItems) => {
-              assert(
-                databaseItems[1].isExpanded === false,
-                'Expected database tree item not to be expanded on default.'
-              );
-
-              // Expand the first database item.
-              databaseItems[1].onDidExpand().then(() => {
+    testConnectionController
+      .addNewConnectionAndConnect(testDatabaseURI)
+      .then(() => {
+        treeController.getChildren().then((rootTreeItem) => {
+          const connectionsTreeItem = rootTreeItem[0];
+          connectionsTreeItem.getChildren().then((connectionsItems) => {
+            // Expand the connection.
+            const testConnectionTreeItem = connectionsItems[0];
+            testConnectionTreeItem.onDidExpand().then(() => {
+              testConnectionTreeItem.getChildren().then((databaseItems) => {
                 assert(
-                  databaseItems[1].isExpanded === true,
-                  'Expected database tree item be expanded.'
+                  databaseItems[1].isExpanded === false,
+                  'Expected database tree item not to be expanded on default.'
                 );
 
-                // Collapse the connection.
-                testConnectionTreeItem.onDidCollapse();
-
-                testConnectionTreeItem.getChildren().then((databaseTreeItems) => {
+                // Expand the first database item.
+                databaseItems[1].onDidExpand().then(() => {
                   assert(
-                    databaseTreeItems.length === 0,
-                    `Expected the connection tree to return no children when collapsed, found ${databaseTreeItems.length}`
+                    databaseItems[1].isExpanded === true,
+                    'Expected database tree item be expanded.'
                   );
 
-                  testConnectionTreeItem.onDidExpand();
-                  testConnectionTreeItem.getChildren().then((newDatabaseItems) => {
-                    assert(
-                      newDatabaseItems[1].isExpanded === true,
-                      'Expected database tree to be expanded from cache.'
-                    );
+                  // Collapse the connection.
+                  testConnectionTreeItem.onDidCollapse();
 
-                    testExplorerController.deactivate();
-                  }).then(done, done);
+                  testConnectionTreeItem
+                    .getChildren()
+                    .then((databaseTreeItems) => {
+                      assert(
+                        databaseTreeItems.length === 0,
+                        `Expected the connection tree to return no children when collapsed, found ${databaseTreeItems.length}`
+                      );
+
+                      testConnectionTreeItem.onDidExpand();
+                      testConnectionTreeItem
+                        .getChildren()
+                        .then((newDatabaseItems) => {
+                          assert(
+                            newDatabaseItems[1].isExpanded === true,
+                            'Expected database tree to be expanded from cache.'
+                          );
+
+                          testExplorerController.deactivate();
+                        })
+                        .then(done, done);
+                    });
                 });
               });
             });
           });
         });
       });
-    });
   });
 });

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -34,7 +34,7 @@ export function run(): Promise<void> {
       mdbTestExtension.testExtensionController = new MDBExtensionController(
         mdbTestExtension.testExtensionContext
       );
-      mdbTestExtension.testExtensionController.activate(mdbTestExtension.testExtensionContext);
+      mdbTestExtension.testExtensionController.activate();
 
       // Disable the dialogue for prompting the user where to store the connection.
       vscode.workspace.getConfiguration('mdb.connectionSaving').update(

--- a/src/test/suite/mdbExtensionController.test.ts
+++ b/src/test/suite/mdbExtensionController.test.ts
@@ -6,10 +6,9 @@ const sinon = require('sinon');
 import { CollectionTreeItem } from '../../explorer';
 import { VIEW_COLLECTION_SCHEME } from '../../editors/collectionDocumentsProvider';
 import ConnectionTreeItem from '../../explorer/connectionTreeItem';
-
-import { mdbTestExtension } from './stubbableMdbExtension';
 import DatabaseTreeItem from '../../explorer/databaseTreeItem';
 import { CollectionTypes } from '../../explorer/collectionTreeItem';
+import { mdbTestExtension } from './stubbableMdbExtension';
 
 suite('MDBExtensionController Test Suite', () => {
   afterEach(function () {
@@ -602,14 +601,52 @@ suite('MDBExtensionController Test Suite', () => {
 
     const mockInputBoxResolves = sinon.stub();
     mockInputBoxResolves.onCall(0).resolves('mintChocolateChips');
+
+    vscode.commands.executeCommand('mdb.addCollection', mockTreeItem).then(() => {
+      assert(stubHideMessage.called === true);
+    }).then(done, done);
+  });
+
+  // https://code.visualstudio.com/api/references/contribution-points#Sorting-of-groups
+
+  test('mdb.dropCollection the collection after inputting the collection name', (done) => {
+    const dropCollectionFake = sinon.stub();
+    const testCollectionTreeItem = new CollectionTreeItem(
+      {
+        name: 'testColName'
+      },
+      'testDbName',
+      {
+        dropCollection: dropCollectionFake
+      },
+      false,
+      [],
+      10
+    );
+
+    // TODO: Full test with db, not stubbing db behavior.
+
+    const mockInputBoxResolves = sinon.stub();
+    mockInputBoxResolves.onCall(0).resolves('testColName');
     sinon.replace(
       vscode.window,
       'showInputBox',
       mockInputBoxResolves
     );
 
-    vscode.commands.executeCommand('mdb.addCollection', mockTreeItem).then(() => {
-      assert(stubHideMessage.called === true);
+    vscode.commands.executeCommand('mdb.dropCollection', testCollectionTreeItem).then(() => {
+      assert(
+        false,
+        'Expected to error'
+      );
+    }, err => {
+      assert(
+        err.message === 'Unable to add collection: currently disconnecting.',
+        `Expected "Unable to add collection: currently disconnecting." when adding a database to a not connected connection, recieved "${err.message}"`
+      );
     }).then(done, done);
   });
+
+  // Drop collection fails when the input doesn't match.
+  // Drop collection fails when the input is empty.
 });

--- a/src/test/suite/mdbExtensionController.test.ts
+++ b/src/test/suite/mdbExtensionController.test.ts
@@ -402,11 +402,8 @@ suite('MDBExtensionController Test Suite', () => {
     );
 
     const fakeVscodeErrorMessage = sinon.fake();
-    sinon.replace(
-      vscode.window,
-      'showErrorMessage',
-      fakeVscodeErrorMessage
-    );
+    sinon.replace(vscode.window, 'showErrorMessage', fakeVscodeErrorMessage);
+
     const mockActiveConnectionId = sinon.fake.returns('tasty_sandwhich');
     sinon.replace(
       mdbTestExtension.testExtensionController._connectionController,
@@ -453,11 +450,7 @@ suite('MDBExtensionController Test Suite', () => {
     );
 
     const fakeVscodeErrorMessage = sinon.fake();
-    sinon.replace(
-      vscode.window,
-      'showErrorMessage',
-      fakeVscodeErrorMessage
-    );
+    sinon.replace(vscode.window, 'showErrorMessage', fakeVscodeErrorMessage);
     const mockActiveConnectionId = sinon.fake.returns('tasty_sandwhich');
     sinon.replace(
       mdbTestExtension.testExtensionController._connectionController,
@@ -552,11 +545,7 @@ suite('MDBExtensionController Test Suite', () => {
 
     const mockInputBoxResolves = sinon.stub();
     mockInputBoxResolves.onCall(0).resolves('mintChocolateChips');
-    sinon.replace(
-      vscode.window,
-      'showInputBox',
-      mockInputBoxResolves
-    );
+    sinon.replace(vscode.window, 'showInputBox', mockInputBoxResolves);
 
     vscode.commands.executeCommand('mdb.addCollection', mockTreeItem).then(addCollectionSucceeded => {
       assert(addCollectionSucceeded);
@@ -595,11 +584,7 @@ suite('MDBExtensionController Test Suite', () => {
     );
 
     const fakeVscodeErrorMessage = sinon.fake();
-    sinon.replace(
-      vscode.window,
-      'showErrorMessage',
-      fakeVscodeErrorMessage
-    );
+    sinon.replace(vscode.window, 'showErrorMessage', fakeVscodeErrorMessage);
 
     vscode.commands.executeCommand('mdb.addCollection', mockTreeItem).then(addCollectionSucceeded => {
       assert(
@@ -658,9 +643,7 @@ suite('MDBExtensionController Test Suite', () => {
   test('mdb.dropCollection calls dataservice to drop the collection after inputting the collection name', (done) => {
     let calledNamespace = '';
     const testCollectionTreeItem = new CollectionTreeItem(
-      {
-        name: 'testColName'
-      },
+      { name: 'testColName' },
       'testDbName',
       {
         dropCollection: (namespace, callback): void => {
@@ -697,9 +680,7 @@ suite('MDBExtensionController Test Suite', () => {
       testDatabaseURI
     ).then(() => {
       const testCollectionTreeItem = new CollectionTreeItem(
-        {
-          name: 'doesntExistColName'
-        },
+        { name: 'doesntExistColName' },
         'doesntExistDBName',
         testConnectionController.getActiveConnection(),
         false,
@@ -709,18 +690,10 @@ suite('MDBExtensionController Test Suite', () => {
 
       const mockInputBoxResolves = sinon.stub();
       mockInputBoxResolves.onCall(0).resolves('doesntExistColName');
-      sinon.replace(
-        vscode.window,
-        'showInputBox',
-        mockInputBoxResolves
-      );
+      sinon.replace(vscode.window, 'showInputBox', mockInputBoxResolves);
 
       const fakeVscodeErrorMessage = sinon.fake();
-      sinon.replace(
-        vscode.window,
-        'showErrorMessage',
-        fakeVscodeErrorMessage
-      );
+      sinon.replace(vscode.window, 'showErrorMessage', fakeVscodeErrorMessage);
 
       vscode.commands.executeCommand('mdb.dropCollection', testCollectionTreeItem).then(successfullyDropped => {
         assert(
@@ -738,9 +711,7 @@ suite('MDBExtensionController Test Suite', () => {
 
   test('mdb.dropCollection fails when the input doesnt match the collection name', (done) => {
     const testCollectionTreeItem = new CollectionTreeItem(
-      {
-        name: 'orange'
-      },
+      { name: 'orange' },
       'fruitsThatAreTasty',
       {},
       false,
@@ -756,13 +727,6 @@ suite('MDBExtensionController Test Suite', () => {
       mockInputBoxResolves
     );
 
-    const fakeVscodeErrorMessage = sinon.fake();
-    sinon.replace(
-      vscode.window,
-      'showErrorMessage',
-      fakeVscodeErrorMessage
-    );
-
     vscode.commands.executeCommand('mdb.dropCollection', testCollectionTreeItem).then(successfullyDropped => {
       assert(
         successfullyDropped === false,
@@ -773,9 +737,7 @@ suite('MDBExtensionController Test Suite', () => {
 
   test('mdb.dropCollection fails when the collection name input is empty', (done) => {
     const testCollectionTreeItem = new CollectionTreeItem(
-      {
-        name: 'orange'
-      },
+      { name: 'orange' },
       'fruitsThatAreTasty',
       {},
       false,
@@ -791,13 +753,6 @@ suite('MDBExtensionController Test Suite', () => {
       mockInputBoxResolves
     );
 
-    const fakeVscodeErrorMessage = sinon.fake();
-    sinon.replace(
-      vscode.window,
-      'showErrorMessage',
-      fakeVscodeErrorMessage
-    );
-
     vscode.commands.executeCommand('mdb.dropCollection', testCollectionTreeItem).then(successfullyDropped => {
       assert(
         successfullyDropped === false,
@@ -809,7 +764,7 @@ suite('MDBExtensionController Test Suite', () => {
   test('mdb.dropDatabase calls dataservice to drop the database after inputting the database name', (done) => {
     let calledDatabaseName = '';
     const testDatabaseTreeItem = new DatabaseTreeItem(
-      'clubMateTheBestDrinkEverConfirmed',
+      'iMissTangerineAltoids',
       {
         dropDatabase: (dbName, callback): void => {
           calledDatabaseName = dbName;
@@ -821,7 +776,7 @@ suite('MDBExtensionController Test Suite', () => {
     );
 
     const mockInputBoxResolves = sinon.stub();
-    mockInputBoxResolves.onCall(0).resolves('clubMateTheBestDrinkEverConfirmed');
+    mockInputBoxResolves.onCall(0).resolves('iMissTangerineAltoids');
     sinon.replace(
       vscode.window,
       'showInputBox',
@@ -830,7 +785,7 @@ suite('MDBExtensionController Test Suite', () => {
 
     vscode.commands.executeCommand('mdb.dropDatabase', testDatabaseTreeItem).then(successfullyDropped => {
       assert(successfullyDropped);
-      assert(calledDatabaseName === 'clubMateTheBestDrinkEverConfirmed');
+      assert(calledDatabaseName === 'iMissTangerineAltoids');
     }).then(done, done);
   });
 
@@ -894,13 +849,6 @@ suite('MDBExtensionController Test Suite', () => {
       mockInputBoxResolves
     );
 
-    const fakeVscodeErrorMessage = sinon.fake();
-    sinon.replace(
-      vscode.window,
-      'showErrorMessage',
-      fakeVscodeErrorMessage
-    );
-
     vscode.commands.executeCommand('mdb.dropDatabase', testDatabaseTreeItem).then(successfullyDropped => {
       assert(
         successfullyDropped === false,
@@ -923,13 +871,6 @@ suite('MDBExtensionController Test Suite', () => {
       vscode.window,
       'showInputBox',
       mockInputBoxResolves
-    );
-
-    const fakeVscodeErrorMessage = sinon.fake();
-    sinon.replace(
-      vscode.window,
-      'showErrorMessage',
-      fakeVscodeErrorMessage
     );
 
     vscode.commands.executeCommand('mdb.dropDatabase', testDatabaseTreeItem).then(successfullyDropped => {

--- a/src/test/suite/mdbExtensionController.test.ts
+++ b/src/test/suite/mdbExtensionController.test.ts
@@ -632,6 +632,11 @@ suite('MDBExtensionController Test Suite', () => {
 
     const mockInputBoxResolves = sinon.stub();
     mockInputBoxResolves.onCall(0).resolves('mintChocolateChips');
+    sinon.replace(
+      vscode.window,
+      'showInputBox',
+      mockInputBoxResolves
+    );
 
     vscode.commands.executeCommand('mdb.addCollection', mockTreeItem).then(() => {
       assert(stubHideMessage.called === true);

--- a/src/test/suite/mdbExtensionController.test.ts
+++ b/src/test/suite/mdbExtensionController.test.ts
@@ -15,7 +15,7 @@ import { StorageController } from '../../storage';
 const testDatabaseURI = 'mongodb://localhost:27018';
 
 suite('MDBExtensionController Test Suite', () => {
-  afterEach(function () {
+  afterEach(function() {
     sinon.restore();
   });
 
@@ -37,17 +37,28 @@ suite('MDBExtensionController Test Suite', () => {
       10
     );
 
-    vscode.commands.executeCommand('mdb.viewCollectionDocuments', textCollectionTree).then(() => {
-      assert(mockOpenTextDocument.firstArg.path.indexOf('Results: testDbName.testColName') === 0);
-      assert(mockOpenTextDocument.firstArg.path.includes('.json'));
-      assert(mockOpenTextDocument.firstArg.scheme === VIEW_COLLECTION_SCHEME);
-      assert(mockOpenTextDocument.firstArg.query.includes('namespace=testDbName.testColName'));
+    vscode.commands
+      .executeCommand('mdb.viewCollectionDocuments', textCollectionTree)
+      .then(() => {
+        assert(
+          mockOpenTextDocument.firstArg.path.indexOf(
+            'Results: testDbName.testColName'
+          ) === 0
+        );
+        assert(mockOpenTextDocument.firstArg.path.includes('.json'));
+        assert(mockOpenTextDocument.firstArg.scheme === VIEW_COLLECTION_SCHEME);
+        assert(
+          mockOpenTextDocument.firstArg.query.includes(
+            'namespace=testDbName.testColName'
+          )
+        );
 
-      assert(
-        mockShowTextDocument.firstArg === 'magna carta',
-        'Expected it to call vscode to show the returned documents from the provider'
-      );
-    }).then(done, done);
+        assert(
+          mockShowTextDocument.firstArg === 'magna carta',
+          'Expected it to call vscode to show the returned documents from the provider'
+        );
+      })
+      .then(done, done);
   });
 
   test('mdb.addConnection command should call addMongoDBConnection on the connection controller', (done) => {
@@ -58,12 +69,15 @@ suite('MDBExtensionController Test Suite', () => {
       mockAddConnection
     );
 
-    vscode.commands.executeCommand('mdb.addConnection').then(() => {
-      assert(
-        mockAddConnection.called,
-        'Expected "addMongoDBConnection" to be called on the connection controller.'
-      );
-    }).then(done, done);
+    vscode.commands
+      .executeCommand('mdb.addConnection')
+      .then(() => {
+        assert(
+          mockAddConnection.called,
+          'Expected "addMongoDBConnection" to be called on the connection controller.'
+        );
+      })
+      .then(done, done);
   });
 
   test('mdb.addConnectionWithURI command should call connectWithURI on the connection controller', (done) => {
@@ -74,12 +88,15 @@ suite('MDBExtensionController Test Suite', () => {
       mockConnectWithUri
     );
 
-    vscode.commands.executeCommand('mdb.addConnectionWithURI').then(() => {
-      assert(
-        mockConnectWithUri.called,
-        'Expected "connectWithURI" to be called on the connection controller.'
-      );
-    }).then(done, done);
+    vscode.commands
+      .executeCommand('mdb.addConnectionWithURI')
+      .then(() => {
+        assert(
+          mockConnectWithUri.called,
+          'Expected "connectWithURI" to be called on the connection controller.'
+        );
+      })
+      .then(done, done);
   });
 
   test('mdb.refreshConnection command should reset the cache on a connection tree item', (done) => {
@@ -100,16 +117,19 @@ suite('MDBExtensionController Test Suite', () => {
       mockExplorerControllerRefresh
     );
 
-    vscode.commands.executeCommand('mdb.refreshConnection', mockTreeItem).then(() => {
-      assert(
-        mockTreeItem._childrenCacheIsUpToDate === false,
-        'Expected cache on tree item to be set to not up to date.'
-      );
-      assert(
-        mockExplorerControllerRefresh.called === true,
-        'Expected explorer controller refresh to be called.'
-      );
-    }).then(done, done);
+    vscode.commands
+      .executeCommand('mdb.refreshConnection', mockTreeItem)
+      .then(() => {
+        assert(
+          mockTreeItem._childrenCacheIsUpToDate === false,
+          'Expected cache on tree item to be set to not up to date.'
+        );
+        assert(
+          mockExplorerControllerRefresh.called === true,
+          'Expected explorer controller refresh to be called.'
+        );
+      })
+      .then(done, done);
   });
 
   test('mdb.treeItemRemoveConnection command should call removeMongoDBConnection on the connection controller with the tree item connection id', (done) => {
@@ -128,16 +148,20 @@ suite('MDBExtensionController Test Suite', () => {
       mockRemoveMongoDBConnection
     );
 
-    vscode.commands.executeCommand('mdb.treeItemRemoveConnection', mockTreeItem).then(() => {
-      assert(
-        mockRemoveMongoDBConnection.called,
-        'Expected "removeMongoDBConnection" to be called on the connection controller.'
-      );
-      assert(
-        mockRemoveMongoDBConnection.firstArg === 'craving_for_pancakes_with_maple_syrup',
-        `Expected the mock connection controller to be called to remove the connection with the id "craving_for_pancakes_with_maple_syrup", found ${mockRemoveMongoDBConnection.firstArg}.`
-      );
-    }).then(done, done);
+    vscode.commands
+      .executeCommand('mdb.treeItemRemoveConnection', mockTreeItem)
+      .then(() => {
+        assert(
+          mockRemoveMongoDBConnection.called,
+          'Expected "removeMongoDBConnection" to be called on the connection controller.'
+        );
+        assert(
+          mockRemoveMongoDBConnection.firstArg ===
+            'craving_for_pancakes_with_maple_syrup',
+          `Expected the mock connection controller to be called to remove the connection with the id "craving_for_pancakes_with_maple_syrup", found ${mockRemoveMongoDBConnection.firstArg}.`
+        );
+      })
+      .then(done, done);
   });
 
   test('mdb.copyConnectionString command should try to copy the driver url to the vscode env clipboard', (done) => {
@@ -150,11 +174,7 @@ suite('MDBExtensionController Test Suite', () => {
     );
 
     const mockCopyToClipboard = sinon.fake.resolves();
-    sinon.replace(
-      vscode.env.clipboard,
-      'writeText',
-      mockCopyToClipboard
-    );
+    sinon.replace(vscode.env.clipboard, 'writeText', mockCopyToClipboard);
 
     const mockStubUri = sinon.fake.returns('weStubThisUri');
     sinon.replace(
@@ -163,16 +183,19 @@ suite('MDBExtensionController Test Suite', () => {
       mockStubUri
     );
 
-    vscode.commands.executeCommand('mdb.copyConnectionString', mockTreeItem).then(() => {
-      assert(
-        mockCopyToClipboard.called,
-        'Expected "writeText" to be called on "vscode.env.clipboard".'
-      );
-      assert(
-        mockCopyToClipboard.firstArg === 'weStubThisUri',
-        `Expected the clipboard to be sent the uri string "weStubThisUri", found ${mockCopyToClipboard.firstArg}.`
-      );
-    }).then(done, done);
+    vscode.commands
+      .executeCommand('mdb.copyConnectionString', mockTreeItem)
+      .then(() => {
+        assert(
+          mockCopyToClipboard.called,
+          'Expected "writeText" to be called on "vscode.env.clipboard".'
+        );
+        assert(
+          mockCopyToClipboard.firstArg === 'weStubThisUri',
+          `Expected the clipboard to be sent the uri string "weStubThisUri", found ${mockCopyToClipboard.firstArg}.`
+        );
+      })
+      .then(done, done);
   });
 
   test('mdb.copyDatabaseName command should try to copy the database name to the vscode env clipboard', (done) => {
@@ -184,22 +207,21 @@ suite('MDBExtensionController Test Suite', () => {
     );
 
     const mockCopyToClipboard = sinon.fake.resolves();
-    sinon.replace(
-      vscode.env.clipboard,
-      'writeText',
-      mockCopyToClipboard
-    );
+    sinon.replace(vscode.env.clipboard, 'writeText', mockCopyToClipboard);
 
-    vscode.commands.executeCommand('mdb.copyDatabaseName', mockTreeItem).then(() => {
-      assert(
-        mockCopyToClipboard.called,
-        'Expected "writeText" to be called on "vscode.env.clipboard".'
-      );
-      assert(
-        mockCopyToClipboard.firstArg === 'isClubMateTheBestDrinkEver',
-        `Expected the clipboard to be sent the uri string "isClubMateTheBestDrinkEver", found ${mockCopyToClipboard.firstArg}.`
-      );
-    }).then(done, done);
+    vscode.commands
+      .executeCommand('mdb.copyDatabaseName', mockTreeItem)
+      .then(() => {
+        assert(
+          mockCopyToClipboard.called,
+          'Expected "writeText" to be called on "vscode.env.clipboard".'
+        );
+        assert(
+          mockCopyToClipboard.firstArg === 'isClubMateTheBestDrinkEver',
+          `Expected the clipboard to be sent the uri string "isClubMateTheBestDrinkEver", found ${mockCopyToClipboard.firstArg}.`
+        );
+      })
+      .then(done, done);
   });
 
   test('mdb.copyCollectionName command should try to copy the collection name to the vscode env clipboard', (done) => {
@@ -216,31 +238,25 @@ suite('MDBExtensionController Test Suite', () => {
     );
 
     const mockCopyToClipboard = sinon.fake.resolves();
-    sinon.replace(
-      vscode.env.clipboard,
-      'writeText',
-      mockCopyToClipboard
-    );
+    sinon.replace(vscode.env.clipboard, 'writeText', mockCopyToClipboard);
 
-    vscode.commands.executeCommand('mdb.copyCollectionName', mockTreeItem).then(() => {
-      assert(
-        mockCopyToClipboard.called,
-        'Expected "writeText" to be called on "vscode.env.clipboard".'
-      );
-      assert(
-        mockCopyToClipboard.firstArg === 'waterBuffalo',
-        `Expected the clipboard to be sent the uri string "waterBuffalo", found ${mockCopyToClipboard.firstArg}.`
-      );
-    }).then(done, done);
+    vscode.commands
+      .executeCommand('mdb.copyCollectionName', mockTreeItem)
+      .then(() => {
+        assert(
+          mockCopyToClipboard.called,
+          'Expected "writeText" to be called on "vscode.env.clipboard".'
+        );
+        assert(
+          mockCopyToClipboard.firstArg === 'waterBuffalo',
+          `Expected the clipboard to be sent the uri string "waterBuffalo", found ${mockCopyToClipboard.firstArg}.`
+        );
+      })
+      .then(done, done);
   });
 
   test('mdb.refreshDatabase command should reset the cache on the database tree item', (done) => {
-    const mockTreeItem = new DatabaseTreeItem(
-      'pinkLemonade',
-      {},
-      false,
-      {}
-    );
+    const mockTreeItem = new DatabaseTreeItem('pinkLemonade', {}, false, {});
 
     mockTreeItem._childrenCacheIsUpToDate = true;
 
@@ -251,16 +267,19 @@ suite('MDBExtensionController Test Suite', () => {
       mockExplorerControllerRefresh
     );
 
-    vscode.commands.executeCommand('mdb.refreshDatabase', mockTreeItem).then(() => {
-      assert(
-        mockTreeItem._childrenCacheIsUpToDate === false,
-        'Expected cache on tree item to be set to not up to date.'
-      );
-      assert(
-        mockExplorerControllerRefresh.called === true,
-        'Expected explorer controller refresh to be called.'
-      );
-    }).then(done, done);
+    vscode.commands
+      .executeCommand('mdb.refreshDatabase', mockTreeItem)
+      .then(() => {
+        assert(
+          mockTreeItem._childrenCacheIsUpToDate === false,
+          'Expected cache on tree item to be set to not up to date.'
+        );
+        assert(
+          mockExplorerControllerRefresh.called === true,
+          'Expected explorer controller refresh to be called.'
+        );
+      })
+      .then(done, done);
   });
 
   test('mdb.refreshCollection command should reset the cache on the collection tree item and call to refresh the explorer controller', (done) => {
@@ -285,16 +304,19 @@ suite('MDBExtensionController Test Suite', () => {
       mockExplorerControllerRefresh
     );
 
-    vscode.commands.executeCommand('mdb.refreshCollection', mockTreeItem).then(() => {
-      assert(
-        mockTreeItem._childrenCacheIsUpToDate === false,
-        'Expected cache on tree item to be set to not up to date.'
-      );
-      assert(
-        mockExplorerControllerRefresh.called === true,
-        'Expected explorer controller refresh to be called.'
-      );
-    }).then(done, done);
+    vscode.commands
+      .executeCommand('mdb.refreshCollection', mockTreeItem)
+      .then(() => {
+        assert(
+          mockTreeItem._childrenCacheIsUpToDate === false,
+          'Expected cache on tree item to be set to not up to date.'
+        );
+        assert(
+          mockExplorerControllerRefresh.called === true,
+          'Expected explorer controller refresh to be called.'
+        );
+      })
+      .then(done, done);
   });
 
   test('mdb.addDatabase command fails when not connected to the connection', (done) => {
@@ -307,23 +329,23 @@ suite('MDBExtensionController Test Suite', () => {
     );
 
     const fakeVscodeErrorMessage = sinon.fake();
-    sinon.replace(
-      vscode.window,
-      'showErrorMessage',
-      fakeVscodeErrorMessage
-    );
+    sinon.replace(vscode.window, 'showErrorMessage', fakeVscodeErrorMessage);
 
-    vscode.commands.executeCommand('mdb.addDatabase', mockTreeItem).then(addDatabaseSucceeded => {
-      assert(
-        addDatabaseSucceeded === false,
-        'Expected the command handler to return a false succeeded response'
-      );
-      const expectedMessage = 'Please connect to this connection before adding a database.';
-      assert(
-        fakeVscodeErrorMessage.firstArg === expectedMessage,
-        `Expected an error message "${expectedMessage}" to be shown when attempting to add a database to a not connected connection found "${fakeVscodeErrorMessage.firstArg}"`
-      );
-    }, done).then(done, done);
+    vscode.commands
+      .executeCommand('mdb.addDatabase', mockTreeItem)
+      .then((addDatabaseSucceeded) => {
+        assert(
+          addDatabaseSucceeded === false,
+          'Expected the command handler to return a false succeeded response'
+        );
+        const expectedMessage =
+          'Please connect to this connection before adding a database.';
+        assert(
+          fakeVscodeErrorMessage.firstArg === expectedMessage,
+          `Expected an error message "${expectedMessage}" to be shown when attempting to add a database to a not connected connection found "${fakeVscodeErrorMessage.firstArg}"`
+        );
+      }, done)
+      .then(done, done);
   });
 
   test('mdb.addDatabase command calls the dataservice to add the database and collection the user inputs', (done) => {
@@ -338,11 +360,7 @@ suite('MDBExtensionController Test Suite', () => {
     const mockInputBoxResolves = sinon.stub();
     mockInputBoxResolves.onCall(0).resolves('theDbName');
     mockInputBoxResolves.onCall(1).resolves('theCollectionName');
-    sinon.replace(
-      vscode.window,
-      'showInputBox',
-      mockInputBoxResolves
-    );
+    sinon.replace(vscode.window, 'showInputBox', mockInputBoxResolves);
 
     let returnedNamespaceArg = '';
     const mockGetActiveConnection = sinon.fake.returns({
@@ -363,17 +381,20 @@ suite('MDBExtensionController Test Suite', () => {
       mockActiveConnectionId
     );
 
-    vscode.commands.executeCommand('mdb.addDatabase', mockTreeItem).then(succeeded => {
-      assert(succeeded);
-      assert(
-        mockInputBoxResolves.called === true,
-        'Expected show input box to be called'
-      );
-      assert(
-        returnedNamespaceArg === 'theDbName.theCollectionName',
-        'Expected create collection to be called with the namespace supplied.'
-      );
-    }).then(done, done);
+    vscode.commands
+      .executeCommand('mdb.addDatabase', mockTreeItem)
+      .then((succeeded) => {
+        assert(succeeded);
+        assert(
+          mockInputBoxResolves.called === true,
+          'Expected show input box to be called'
+        );
+        assert(
+          returnedNamespaceArg === 'theDbName.theCollectionName',
+          'Expected create collection to be called with the namespace supplied.'
+        );
+      })
+      .then(done, done);
   });
 
   test('mdb.addDatabase command fails when disconnecting', (done) => {
@@ -388,11 +409,7 @@ suite('MDBExtensionController Test Suite', () => {
     const mockInputBoxResolves = sinon.stub();
     mockInputBoxResolves.onCall(0).resolves('theDbName');
     mockInputBoxResolves.onCall(1).resolves('theCollectionName');
-    sinon.replace(
-      vscode.window,
-      'showInputBox',
-      mockInputBoxResolves
-    );
+    sinon.replace(vscode.window, 'showInputBox', mockInputBoxResolves);
 
     const mockIsDisconnecting = sinon.fake.returns(true);
     sinon.replace(
@@ -411,17 +428,21 @@ suite('MDBExtensionController Test Suite', () => {
       mockActiveConnectionId
     );
 
-    vscode.commands.executeCommand('mdb.addDatabase', mockTreeItem).then(addDatabaseSucceeded => {
-      assert(
-        addDatabaseSucceeded === false,
-        'Expected the add database command handler to return a false succeeded response'
-      );
-      const expectedMessage = 'Unable to add database: currently disconnecting.';
-      assert(
-        fakeVscodeErrorMessage.firstArg === expectedMessage,
-        `Expected the error message "${expectedMessage}" to be shown when attempting to add a database while disconnecting, found "${fakeVscodeErrorMessage.firstArg}"`
-      );
-    }, done).then(done, done);
+    vscode.commands
+      .executeCommand('mdb.addDatabase', mockTreeItem)
+      .then((addDatabaseSucceeded) => {
+        assert(
+          addDatabaseSucceeded === false,
+          'Expected the add database command handler to return a false succeeded response'
+        );
+        const expectedMessage =
+          'Unable to add database: currently disconnecting.';
+        assert(
+          fakeVscodeErrorMessage.firstArg === expectedMessage,
+          `Expected the error message "${expectedMessage}" to be shown when attempting to add a database while disconnecting, found "${fakeVscodeErrorMessage.firstArg}"`
+        );
+      }, done)
+      .then(done, done);
   });
 
   test('mdb.addDatabase command fails when connecting', (done) => {
@@ -436,11 +457,7 @@ suite('MDBExtensionController Test Suite', () => {
     const mockInputBoxResolves = sinon.stub();
     mockInputBoxResolves.onCall(0).resolves('theDbName');
     mockInputBoxResolves.onCall(1).resolves('theCollectionName');
-    sinon.replace(
-      vscode.window,
-      'showInputBox',
-      mockInputBoxResolves
-    );
+    sinon.replace(vscode.window, 'showInputBox', mockInputBoxResolves);
 
     const mockIsConnecting = sinon.fake.returns(true);
     sinon.replace(
@@ -458,17 +475,20 @@ suite('MDBExtensionController Test Suite', () => {
       mockActiveConnectionId
     );
 
-    vscode.commands.executeCommand('mdb.addDatabase', mockTreeItem).then(addDatabaseSucceeded => {
-      assert(
-        addDatabaseSucceeded === false,
-        'Expected the add database command handler to return a false succeeded response'
-      );
-      const expectedMessage = 'Unable to add database: currently connecting.';
-      assert(
-        fakeVscodeErrorMessage.firstArg === expectedMessage,
-        `Expected the error message "${expectedMessage}" to be shown when attempting to add a database while disconnecting, found "${fakeVscodeErrorMessage.firstArg}"`
-      );
-    }).then(done, done);
+    vscode.commands
+      .executeCommand('mdb.addDatabase', mockTreeItem)
+      .then((addDatabaseSucceeded) => {
+        assert(
+          addDatabaseSucceeded === false,
+          'Expected the add database command handler to return a false succeeded response'
+        );
+        const expectedMessage = 'Unable to add database: currently connecting.';
+        assert(
+          fakeVscodeErrorMessage.firstArg === expectedMessage,
+          `Expected the error message "${expectedMessage}" to be shown when attempting to add a database while disconnecting, found "${fakeVscodeErrorMessage.firstArg}"`
+        );
+      })
+      .then(done, done);
   });
 
   test('mdb.addDatabase shows a status bar item while it is creating the collection then hide it', (done) => {
@@ -494,11 +514,7 @@ suite('MDBExtensionController Test Suite', () => {
     const mockInputBoxResolves = sinon.stub();
     mockInputBoxResolves.onCall(0).resolves('theDbName');
     mockInputBoxResolves.onCall(1).resolves('theCollectionName');
-    sinon.replace(
-      vscode.window,
-      'showInputBox',
-      mockInputBoxResolves
-    );
+    sinon.replace(vscode.window, 'showInputBox', mockInputBoxResolves);
     const mockGetActiveConnection = sinon.fake.returns({
       createCollection: (namespace, options, callback) => {
         assert(stubShowMessage.called);
@@ -524,9 +540,12 @@ suite('MDBExtensionController Test Suite', () => {
       mockActiveConnectionId
     );
 
-    vscode.commands.executeCommand('mdb.addDatabase', mockTreeItem).then(() => {
-      assert(stubHideMessage.called === true);
-    }).then(done, done);
+    vscode.commands
+      .executeCommand('mdb.addDatabase', mockTreeItem)
+      .then(() => {
+        assert(stubHideMessage.called === true);
+      })
+      .then(done, done);
   });
 
   test('mdb.addCollection command calls the dataservice to add the collection the user inputs', (done) => {
@@ -547,34 +566,28 @@ suite('MDBExtensionController Test Suite', () => {
     mockInputBoxResolves.onCall(0).resolves('mintChocolateChips');
     sinon.replace(vscode.window, 'showInputBox', mockInputBoxResolves);
 
-    vscode.commands.executeCommand('mdb.addCollection', mockTreeItem).then(addCollectionSucceeded => {
-      assert(addCollectionSucceeded);
-      assert(
-        mockInputBoxResolves.called === true,
-        'Expected show input box to be called'
-      );
-      assert(
-        returnedNamespaceArg === 'iceCreamDB.mintChocolateChips',
-        `Expected create collection to be called with the namespace "iceCreamDB.mintChocolateChips" got ${returnedNamespaceArg}.`
-      );
-    }).then(done, done);
+    vscode.commands
+      .executeCommand('mdb.addCollection', mockTreeItem)
+      .then((addCollectionSucceeded) => {
+        assert(addCollectionSucceeded);
+        assert(
+          mockInputBoxResolves.called === true,
+          'Expected show input box to be called'
+        );
+        assert(
+          returnedNamespaceArg === 'iceCreamDB.mintChocolateChips',
+          `Expected create collection to be called with the namespace "iceCreamDB.mintChocolateChips" got ${returnedNamespaceArg}.`
+        );
+      })
+      .then(done, done);
   });
 
   test('mdb.addCollection command fails when disconnecting', (done) => {
-    const mockTreeItem = new DatabaseTreeItem(
-      'iceCreamDB',
-      {},
-      false,
-      {}
-    );
+    const mockTreeItem = new DatabaseTreeItem('iceCreamDB', {}, false, {});
 
     const mockInputBoxResolves = sinon.stub();
     mockInputBoxResolves.onCall(0).resolves('mintChocolateChips');
-    sinon.replace(
-      vscode.window,
-      'showInputBox',
-      mockInputBoxResolves
-    );
+    sinon.replace(vscode.window, 'showInputBox', mockInputBoxResolves);
 
     const mockIsDisconnecting = sinon.fake.returns(true);
     sinon.replace(
@@ -586,17 +599,21 @@ suite('MDBExtensionController Test Suite', () => {
     const fakeVscodeErrorMessage = sinon.fake();
     sinon.replace(vscode.window, 'showErrorMessage', fakeVscodeErrorMessage);
 
-    vscode.commands.executeCommand('mdb.addCollection', mockTreeItem).then(addCollectionSucceeded => {
-      assert(
-        addCollectionSucceeded === false,
-        'Expected the add collection command handler to return a false succeeded response'
-      );
-      const expectedMessage = 'Unable to add collection: currently disconnecting.';
-      assert(
-        fakeVscodeErrorMessage.firstArg === expectedMessage,
-        `Expected "${expectedMessage}" when adding a database to a not connected connection, recieved "${fakeVscodeErrorMessage.firstArg}"`
-      );
-    }).then(done, done);
+    vscode.commands
+      .executeCommand('mdb.addCollection', mockTreeItem)
+      .then((addCollectionSucceeded) => {
+        assert(
+          addCollectionSucceeded === false,
+          'Expected the add collection command handler to return a false succeeded response'
+        );
+        const expectedMessage =
+          'Unable to add collection: currently disconnecting.';
+        assert(
+          fakeVscodeErrorMessage.firstArg === expectedMessage,
+          `Expected "${expectedMessage}" when adding a database to a not connected connection, recieved "${fakeVscodeErrorMessage.firstArg}"`
+        );
+      })
+      .then(done, done);
   });
 
   test('mdb.addCollection shows a status bar item while it is creating the collection then hide it', (done) => {
@@ -632,15 +649,14 @@ suite('MDBExtensionController Test Suite', () => {
 
     const mockInputBoxResolves = sinon.stub();
     mockInputBoxResolves.onCall(0).resolves('mintChocolateChips');
-    sinon.replace(
-      vscode.window,
-      'showInputBox',
-      mockInputBoxResolves
-    );
+    sinon.replace(vscode.window, 'showInputBox', mockInputBoxResolves);
 
-    vscode.commands.executeCommand('mdb.addCollection', mockTreeItem).then(() => {
-      assert(stubHideMessage.called === true);
-    }).then(done, done);
+    vscode.commands
+      .executeCommand('mdb.addCollection', mockTreeItem)
+      .then(() => {
+        assert(stubHideMessage.called === true);
+      })
+      .then(done, done);
   });
 
   // https://code.visualstudio.com/api/references/contribution-points#Sorting-of-groups
@@ -663,16 +679,15 @@ suite('MDBExtensionController Test Suite', () => {
 
     const mockInputBoxResolves = sinon.stub();
     mockInputBoxResolves.onCall(0).resolves('testColName');
-    sinon.replace(
-      vscode.window,
-      'showInputBox',
-      mockInputBoxResolves
-    );
+    sinon.replace(vscode.window, 'showInputBox', mockInputBoxResolves);
 
-    vscode.commands.executeCommand('mdb.dropCollection', testCollectionTreeItem).then(successfullyDropped => {
-      assert(successfullyDropped);
-      assert(calledNamespace === 'testDbName.testColName');
-    }).then(done, done);
+    vscode.commands
+      .executeCommand('mdb.dropCollection', testCollectionTreeItem)
+      .then((successfullyDropped) => {
+        assert(successfullyDropped);
+        assert(calledNamespace === 'testDbName.testColName');
+      })
+      .then(done, done);
   });
 
   test('mdb.dropCollection fails when a collection doesnt exist', (done) => {
@@ -681,37 +696,44 @@ suite('MDBExtensionController Test Suite', () => {
       new StorageController(mdbTestExtension.testExtensionContext)
     );
 
-    testConnectionController.addNewConnectionAndConnect(
-      testDatabaseURI
-    ).then(() => {
-      const testCollectionTreeItem = new CollectionTreeItem(
-        { name: 'doesntExistColName' },
-        'doesntExistDBName',
-        testConnectionController.getActiveConnection(),
-        false,
-        [],
-        10
-      );
-
-      const mockInputBoxResolves = sinon.stub();
-      mockInputBoxResolves.onCall(0).resolves('doesntExistColName');
-      sinon.replace(vscode.window, 'showInputBox', mockInputBoxResolves);
-
-      const fakeVscodeErrorMessage = sinon.fake();
-      sinon.replace(vscode.window, 'showErrorMessage', fakeVscodeErrorMessage);
-
-      vscode.commands.executeCommand('mdb.dropCollection', testCollectionTreeItem).then(successfullyDropped => {
-        assert(
-          successfullyDropped === false,
-          'Expected the drop collection command handler to return a false succeeded response'
+    testConnectionController
+      .addNewConnectionAndConnect(testDatabaseURI)
+      .then(() => {
+        const testCollectionTreeItem = new CollectionTreeItem(
+          { name: 'doesntExistColName' },
+          'doesntExistDBName',
+          testConnectionController.getActiveConnection(),
+          false,
+          [],
+          10
         );
-        const expectedMessage = 'Drop collection failed: ns not found';
-        assert(
-          fakeVscodeErrorMessage.firstArg === expectedMessage,
-          `Expected "${expectedMessage}" when dropping a collection that doesn't exist, recieved "${fakeVscodeErrorMessage.firstArg}"`
+
+        const mockInputBoxResolves = sinon.stub();
+        mockInputBoxResolves.onCall(0).resolves('doesntExistColName');
+        sinon.replace(vscode.window, 'showInputBox', mockInputBoxResolves);
+
+        const fakeVscodeErrorMessage = sinon.fake();
+        sinon.replace(
+          vscode.window,
+          'showErrorMessage',
+          fakeVscodeErrorMessage
         );
-      }).then(done, done);
-    });
+
+        vscode.commands
+          .executeCommand('mdb.dropCollection', testCollectionTreeItem)
+          .then((successfullyDropped) => {
+            assert(
+              successfullyDropped === false,
+              'Expected the drop collection command handler to return a false succeeded response'
+            );
+            const expectedMessage = 'Drop collection failed: ns not found';
+            assert(
+              fakeVscodeErrorMessage.firstArg === expectedMessage,
+              `Expected "${expectedMessage}" when dropping a collection that doesn't exist, recieved "${fakeVscodeErrorMessage.firstArg}"`
+            );
+          })
+          .then(done, done);
+      });
   });
 
   test('mdb.dropCollection fails when the input doesnt match the collection name', (done) => {
@@ -726,18 +748,17 @@ suite('MDBExtensionController Test Suite', () => {
 
     const mockInputBoxResolves = sinon.stub();
     mockInputBoxResolves.onCall(0).resolves('apple');
-    sinon.replace(
-      vscode.window,
-      'showInputBox',
-      mockInputBoxResolves
-    );
+    sinon.replace(vscode.window, 'showInputBox', mockInputBoxResolves);
 
-    vscode.commands.executeCommand('mdb.dropCollection', testCollectionTreeItem).then(successfullyDropped => {
-      assert(
-        successfullyDropped === false,
-        'Expected the drop collection command handler to return a false succeeded response'
-      );
-    }).then(done, done);
+    vscode.commands
+      .executeCommand('mdb.dropCollection', testCollectionTreeItem)
+      .then((successfullyDropped) => {
+        assert(
+          successfullyDropped === false,
+          'Expected the drop collection command handler to return a false succeeded response'
+        );
+      })
+      .then(done, done);
   });
 
   test('mdb.dropCollection fails when the collection name input is empty', (done) => {
@@ -752,18 +773,17 @@ suite('MDBExtensionController Test Suite', () => {
 
     const mockInputBoxResolves = sinon.stub();
     mockInputBoxResolves.onCall(0).resolves(/* Return undefined. */);
-    sinon.replace(
-      vscode.window,
-      'showInputBox',
-      mockInputBoxResolves
-    );
+    sinon.replace(vscode.window, 'showInputBox', mockInputBoxResolves);
 
-    vscode.commands.executeCommand('mdb.dropCollection', testCollectionTreeItem).then(successfullyDropped => {
-      assert(
-        successfullyDropped === false,
-        'Expected the drop collection command handler to return a false succeeded response'
-      );
-    }).then(done, done);
+    vscode.commands
+      .executeCommand('mdb.dropCollection', testCollectionTreeItem)
+      .then((successfullyDropped) => {
+        assert(
+          successfullyDropped === false,
+          'Expected the drop collection command handler to return a false succeeded response'
+        );
+      })
+      .then(done, done);
   });
 
   test('mdb.dropDatabase calls dataservice to drop the database after inputting the database name', (done) => {
@@ -782,16 +802,15 @@ suite('MDBExtensionController Test Suite', () => {
 
     const mockInputBoxResolves = sinon.stub();
     mockInputBoxResolves.onCall(0).resolves('iMissTangerineAltoids');
-    sinon.replace(
-      vscode.window,
-      'showInputBox',
-      mockInputBoxResolves
-    );
+    sinon.replace(vscode.window, 'showInputBox', mockInputBoxResolves);
 
-    vscode.commands.executeCommand('mdb.dropDatabase', testDatabaseTreeItem).then(successfullyDropped => {
-      assert(successfullyDropped);
-      assert(calledDatabaseName === 'iMissTangerineAltoids');
-    }).then(done, done);
+    vscode.commands
+      .executeCommand('mdb.dropDatabase', testDatabaseTreeItem)
+      .then((successfullyDropped) => {
+        assert(successfullyDropped);
+        assert(calledDatabaseName === 'iMissTangerineAltoids');
+      })
+      .then(done, done);
   });
 
   test('mdb.dropDatabase succeeds even when a database doesnt exist (mdb behavior)', (done) => {
@@ -800,42 +819,41 @@ suite('MDBExtensionController Test Suite', () => {
       new StorageController(mdbTestExtension.testExtensionContext)
     );
 
-    testConnectionController.addNewConnectionAndConnect(
-      testDatabaseURI
-    ).then(() => {
-      const testDatabaseTreeItem = new DatabaseTreeItem(
-        'narnia____a',
-        testConnectionController.getActiveConnection(),
-        false,
-        {}
-      );
-
-      const mockInputBoxResolves = sinon.stub();
-      mockInputBoxResolves.onCall(0).resolves('narnia____a');
-      sinon.replace(
-        vscode.window,
-        'showInputBox',
-        mockInputBoxResolves
-      );
-
-      const fakeVscodeErrorMessage = sinon.fake();
-      sinon.replace(
-        vscode.window,
-        'showErrorMessage',
-        fakeVscodeErrorMessage
-      );
-
-      vscode.commands.executeCommand('mdb.dropDatabase', testDatabaseTreeItem).then(successfullyDropped => {
-        assert(
-          successfullyDropped,
-          'Expected the drop database command handler to return a successful boolean response'
+    testConnectionController
+      .addNewConnectionAndConnect(testDatabaseURI)
+      .then(() => {
+        const testDatabaseTreeItem = new DatabaseTreeItem(
+          'narnia____a',
+          testConnectionController.getActiveConnection(),
+          false,
+          {}
         );
-        assert(
-          fakeVscodeErrorMessage.called === false,
-          'Expected no error messages'
+
+        const mockInputBoxResolves = sinon.stub();
+        mockInputBoxResolves.onCall(0).resolves('narnia____a');
+        sinon.replace(vscode.window, 'showInputBox', mockInputBoxResolves);
+
+        const fakeVscodeErrorMessage = sinon.fake();
+        sinon.replace(
+          vscode.window,
+          'showErrorMessage',
+          fakeVscodeErrorMessage
         );
-      }).then(done, done);
-    });
+
+        vscode.commands
+          .executeCommand('mdb.dropDatabase', testDatabaseTreeItem)
+          .then((successfullyDropped) => {
+            assert(
+              successfullyDropped,
+              'Expected the drop database command handler to return a successful boolean response'
+            );
+            assert(
+              fakeVscodeErrorMessage.called === false,
+              'Expected no error messages'
+            );
+          })
+          .then(done, done);
+      });
   });
 
   test('mdb.dropDatabase fails when the input doesnt match the database name', (done) => {
@@ -848,18 +866,17 @@ suite('MDBExtensionController Test Suite', () => {
 
     const mockInputBoxResolves = sinon.stub();
     mockInputBoxResolves.onCall(0).resolves('apple');
-    sinon.replace(
-      vscode.window,
-      'showInputBox',
-      mockInputBoxResolves
-    );
+    sinon.replace(vscode.window, 'showInputBox', mockInputBoxResolves);
 
-    vscode.commands.executeCommand('mdb.dropDatabase', testDatabaseTreeItem).then(successfullyDropped => {
-      assert(
-        successfullyDropped === false,
-        'Expected the drop database command handler to return a false succeeded response'
-      );
-    }).then(done, done);
+    vscode.commands
+      .executeCommand('mdb.dropDatabase', testDatabaseTreeItem)
+      .then((successfullyDropped) => {
+        assert(
+          successfullyDropped === false,
+          'Expected the drop database command handler to return a false succeeded response'
+        );
+      })
+      .then(done, done);
   });
 
   test('mdb.dropDatabase fails when the database name input is empty', (done) => {
@@ -872,17 +889,16 @@ suite('MDBExtensionController Test Suite', () => {
 
     const mockInputBoxResolves = sinon.stub();
     mockInputBoxResolves.onCall(0).resolves(/* Return undefined. */);
-    sinon.replace(
-      vscode.window,
-      'showInputBox',
-      mockInputBoxResolves
-    );
+    sinon.replace(vscode.window, 'showInputBox', mockInputBoxResolves);
 
-    vscode.commands.executeCommand('mdb.dropDatabase', testDatabaseTreeItem).then(successfullyDropped => {
-      assert(
-        successfullyDropped === false,
-        'Expected the drop database command handler to return a false succeeded response'
-      );
-    }).then(done, done);
+    vscode.commands
+      .executeCommand('mdb.dropDatabase', testDatabaseTreeItem)
+      .then((successfullyDropped) => {
+        assert(
+          successfullyDropped === false,
+          'Expected the drop database command handler to return a false succeeded response'
+        );
+      })
+      .then(done, done);
   });
 });


### PR DESCRIPTION
https://jira.mongodb.org/browse/VSCODE-43

This PR adds the ability to `Drop Database` on a Database tree item, `Drop Collection` on a Collection tree item, and adds `Connect` and `Disconnect` to Connection tree items. Connection tree items now have different actions based on if they are connected or not.

Dropping databases and collections both have text input prompts that require the user to type in the name of the database or collection they are trying to drop.

I also lumped into this pr a bit of cleaning up on the error messages, previously we were letting vscode create error messages when commands failed, now we display them ourselves so we can remove a bit of the extra text vscode would add into the messages. Sorry for the large diff.

I added tests as end to end command handling tests, which is adding a good amount of code into `mdbExtensionController.test.ts` I'm planning on refactoring this a bit or moving code into more descriptive files although the initial command handling does happen in `mdbExtensionController.ts`... maybe in this pr or just in a future smaller one for a smaller diff. Open to thoughts.

A consideration is we can add groups to the tree actions, which separate the actions by a line (try right clicking). I'm thinking about how we could best lay these out. Not doing that in this PR.

Also this pr shrinks the size of the leaf icon on the left a bit - maybe shrink it a bit more? @fredtruman 
*Before*
<img width="160" alt="Screen Shot 2020-03-05 at 5 58 06 PM" src="https://user-images.githubusercontent.com/1791149/76012666-f1de0500-5f16-11ea-9c63-7aa0522799c9.png">

*After*  Made it a little smaller than this screenshot shows
<img width="146" alt="Screen Shot 2020-03-05 at 5 57 44 PM" src="https://user-images.githubusercontent.com/1791149/76012677-f99da980-5f16-11ea-958f-028d910fe1c9.png">


**Screenshots**
___
*Disconnected connection tree item actions*
<img width="526" alt="Screen Shot 2020-03-05 at 7 19 57 PM" src="https://user-images.githubusercontent.com/1791149/76012696-04583e80-5f17-11ea-9c37-fe5761014511.png">

*Connected connection tree item actions*
<img width="550" alt="Screen Shot 2020-03-05 at 7 19 49 PM" src="https://user-images.githubusercontent.com/1791149/76012706-091cf280-5f17-11ea-8231-cf3b1b2b0661.png">

*Dropping actions & prompt*
<img width="321" alt="Screen Shot 2020-03-05 at 7 19 34 PM" src="https://user-images.githubusercontent.com/1791149/76012714-0d491000-5f17-11ea-8a4b-c71ea8cca51e.png">
<img width="312" alt="Screen Shot 2020-03-05 at 7 19 20 PM" src="https://user-images.githubusercontent.com/1791149/76012720-0fab6a00-5f17-11ea-8421-292591fba00d.png">
<img width="628" alt="Screen Shot 2020-03-05 at 7 19 07 PM" src="https://user-images.githubusercontent.com/1791149/76012723-10dc9700-5f17-11ea-9b02-4de64e9f07b5.png">

