### PR TITLE
VSCODE-57: Collection schema tree view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -437,6 +437,16 @@
         }
       }
     },
+    "JSONStream": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "optional": true,
+      "requires": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      }
+    },
     "acorn": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
@@ -663,7 +673,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -1149,11 +1158,22 @@
         "restore-cursor": "^2.0.0"
       }
     },
+<<<<<<< HEAD
     "cli-spinners": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.2.0.tgz",
       "integrity": "sha512-tgU3fKwzYjiLEQgPMD9Jt+JjHVL9kW93FiIMX/l7rivvOD4/LL0Mf7gda3+4U2KJBloybwgj5KEoQgGRioMiKQ==",
       "dev": true
+=======
+    "cli-table": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+      "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
+      "optional": true,
+      "requires": {
+        "colors": "1.0.3"
+      }
+>>>>>>> Add schema tree item and document list tree item
     },
     "cli-width": {
       "version": "2.2.0",
@@ -1234,6 +1254,12 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
+    },
+    "colors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+      "optional": true
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -2529,8 +2555,7 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esquery": {
       "version": "1.1.0",
@@ -3449,11 +3474,19 @@
         "side-channel": "^1.0.2"
       }
     },
+<<<<<<< HEAD
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
+=======
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "optional": true
+>>>>>>> Add schema tree item and document list tree item
     },
     "is-binary-path": {
       "version": "2.1.0",
@@ -3653,6 +3686,12 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
+    "isnumber": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isnumber/-/isnumber-1.0.0.tgz",
+      "integrity": "sha1-Dj+XWbWB2Z3YUIbw7Cp0kJz63QE=",
+      "optional": true
+    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -3678,7 +3717,6 @@
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -3730,6 +3768,12 @@
       "requires": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+      "optional": true
     },
     "jsonpointer.js": {
       "version": "0.4.0",
@@ -3795,6 +3839,15 @@
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.9"
+      }
+    },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "optional": true,
+      "requires": {
+        "invert-kv": "^1.0.0"
       }
     },
     "levn": {
@@ -4734,6 +4787,7 @@
         "lodash.keys": "^3.0.0"
       }
     },
+<<<<<<< HEAD
     "lodash.union": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-3.1.0.tgz",
@@ -4743,6 +4797,13 @@
         "lodash._baseuniq": "^3.0.0",
         "lodash.restparam": "^3.0.0"
       }
+=======
+    "lodash.transform": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.transform/-/lodash.transform-4.6.0.tgz",
+      "integrity": "sha1-EjBkIvYzJK7YSD0/ODMrX2cFR6A=",
+      "optional": true
+>>>>>>> Add schema tree item and document list tree item
     },
     "lodash.uniq": {
       "version": "4.5.0",
@@ -5157,6 +5218,12 @@
         "ast-module-types": "^2.6.0",
         "node-source-walk": "^4.0.0"
       }
+    },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
+      "optional": true
     },
     "mongodb": {
       "version": "3.5.2",
@@ -5579,6 +5646,30 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
+        }
+      }
+    },
+    "mongodb-extended-json": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/mongodb-extended-json/-/mongodb-extended-json-1.11.0.tgz",
+      "integrity": "sha512-+PLUMH7amvTYumCUR6alR474KmqtlmYeceJjsC+zcfdXls9IotfTp2WIuD6X5tO9dLDVCDqboqjgvXj/JjGj6g==",
+      "optional": true,
+      "requires": {
+        "JSONStream": "^1.1.1",
+        "async": "^3.1.0",
+        "bson": "^1.0.1",
+        "event-stream": "^4.0.1",
+        "lodash.isfunction": "^3.0.6",
+        "lodash.transform": "^4.6.0",
+        "moment": "^2.10.6",
+        "raf": "^3.1.0"
+      },
+      "dependencies": {
+        "bson": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.3.tgz",
+          "integrity": "sha512-TdiJxMVnodVS7r0BdL42y/pqC9cL2iKynVwA0Ho3qbsQYr428veL3l7BQyuqiw+Q5SqqoT0m4srSY/BlZ9AxXg==",
+          "optional": true
         }
       }
     },
@@ -6092,6 +6183,127 @@
         }
       }
     },
+    "mongodb-schema": {
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/mongodb-schema/-/mongodb-schema-8.2.5.tgz",
+      "integrity": "sha512-847OmAJR5s4kUKN/ZxL3GnsddGiCaXXZ7T5b6So3yl+GTwgoTGSryJEAxkCpzaPo5NMxIF606tK16Sumnt6KBg==",
+      "requires": {
+        "async": "^1.5.2",
+        "cli-table": "^0.3.1",
+        "event-stream": "^4.0.1",
+        "js-yaml": "^3.5.2",
+        "lodash": "^3.8.0",
+        "mongodb": "^3.1.4",
+        "mongodb-collection-sample": "^4.4.2",
+        "mongodb-extended-json": "^1.6.2",
+        "mongodb-ns": "^2.0.0",
+        "numeral": "^1.5.3",
+        "progress": "^1.1.8",
+        "reservoir": "^0.1.2",
+        "stats-lite": "^2.0.0",
+        "yargs": "^3.32.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "optional": true
+        },
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        },
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+          "optional": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "optional": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "optional": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+        },
+        "progress": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+          "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74="
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "optional": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "optional": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "optional": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
+          }
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "optional": true
+        },
+        "yargs": {
+          "version": "3.32.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+          "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+          "optional": true,
+          "requires": {
+            "camelcase": "^2.0.1",
+            "cliui": "^3.0.3",
+            "decamelize": "^1.1.1",
+            "os-locale": "^1.4.0",
+            "string-width": "^1.0.1",
+            "window-size": "^0.1.4",
+            "y18n": "^3.2.0"
+          }
+        }
+      }
+    },
     "mongodb-security": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/mongodb-security/-/mongodb-security-0.2.0.tgz",
@@ -6439,6 +6651,12 @@
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
+    "numeral": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/numeral/-/numeral-1.5.6.tgz",
+      "integrity": "sha1-ODHbloRRuc9q/5v5WSXx7443sz8=",
+      "optional": true
+    },
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
@@ -6739,6 +6957,15 @@
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
+    },
+    "os-locale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "optional": true,
+      "requires": {
+        "lcid": "^1.0.0"
+      }
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -7685,8 +7912,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "ssh2": {
       "version": "0.8.8",
@@ -7720,6 +7946,15 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
+      }
+    },
+    "stats-lite": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stats-lite/-/stats-lite-2.2.0.tgz",
+      "integrity": "sha512-/Kz55rgUIv2KP2MKphwYT/NCuSfAlbbMRv2ZWw7wyXayu230zdtzhxxuXXcvsc6EmmhS8bSJl3uS1wmMHFumbA==",
+      "optional": true,
+      "requires": {
+        "isnumber": "~1.0.0"
       }
     },
     "storage-mixin": {
@@ -8362,6 +8597,12 @@
       "requires": {
         "string-width": "^1.0.2 || 2"
       }
+    },
+    "window-size": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
+      "optional": true
     },
     "wolfy87-eventemitter": {
       "version": "5.2.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1158,13 +1158,12 @@
         "restore-cursor": "^2.0.0"
       }
     },
-<<<<<<< HEAD
     "cli-spinners": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.2.0.tgz",
       "integrity": "sha512-tgU3fKwzYjiLEQgPMD9Jt+JjHVL9kW93FiIMX/l7rivvOD4/LL0Mf7gda3+4U2KJBloybwgj5KEoQgGRioMiKQ==",
       "dev": true
-=======
+    },
     "cli-table": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
@@ -1173,7 +1172,6 @@
       "requires": {
         "colors": "1.0.3"
       }
->>>>>>> Add schema tree item and document list tree item
     },
     "cli-width": {
       "version": "2.2.0",
@@ -3558,19 +3556,17 @@
         "side-channel": "^1.0.2"
       }
     },
-<<<<<<< HEAD
-    "is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
-=======
     "invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
       "optional": true
->>>>>>> Add schema tree item and document list tree item
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
     },
     "is-binary-path": {
       "version": "2.1.0",
@@ -4871,7 +4867,12 @@
         "lodash.keys": "^3.0.0"
       }
     },
-<<<<<<< HEAD
+    "lodash.transform": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.transform/-/lodash.transform-4.6.0.tgz",
+      "integrity": "sha1-EjBkIvYzJK7YSD0/ODMrX2cFR6A=",
+      "optional": true
+    },
     "lodash.union": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-3.1.0.tgz",
@@ -4881,13 +4882,6 @@
         "lodash._baseuniq": "^3.0.0",
         "lodash.restparam": "^3.0.0"
       }
-=======
-    "lodash.transform": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.transform/-/lodash.transform-4.6.0.tgz",
-      "integrity": "sha1-EjBkIvYzJK7YSD0/ODMrX2cFR6A=",
-      "optional": true
->>>>>>> Add schema tree item and document list tree item
     },
     "lodash.uniq": {
       "version": "4.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2191,18 +2191,32 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-          "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+          "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
+          "dev": true
+        },
+        "acorn-jsx": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+          "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
           "dev": true
         },
         "ansi-escapes": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
-          "integrity": "sha512-EiYhwo0v255HUL6eDyuLrXEkTi7WwVCLAw+SeOQ7M7qdun1z1pum4DEm/nuqIVbPvi9RPPc9k9LbyBv6H0DwVg==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+          "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
           "dev": true,
           "requires": {
-            "type-fest": "^0.8.1"
+            "type-fest": "^0.11.0"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "0.11.0",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+              "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+              "dev": true
+            }
           }
         },
         "ansi-regex": {
@@ -2210,6 +2224,16 @@
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
           "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
         },
         "cli-cursor": {
           "version": "3.1.0",
@@ -2219,6 +2243,21 @@
           "requires": {
             "restore-cursor": "^3.1.0"
           }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         },
         "debug": {
           "version": "4.1.1",
@@ -2246,53 +2285,80 @@
           }
         },
         "espree": {
-          "version": "6.1.2",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
-          "integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.0.tgz",
+          "integrity": "sha512-Xs8airJ7RQolnDIbLtRutmfvSsAe0xqMMAantCN/GMoqf81TFbeI1T7Jpd56qYu1uuh32dOG5W/X9uO+ghPXzA==",
           "dev": true,
           "requires": {
             "acorn": "^7.1.0",
-            "acorn-jsx": "^5.1.0",
+            "acorn-jsx": "^5.2.0",
             "eslint-visitor-keys": "^1.1.0"
           }
         },
         "figures": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz",
-          "integrity": "sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+          "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
           "dev": true,
           "requires": {
             "escape-string-regexp": "^1.0.5"
           }
         },
         "globals": {
-          "version": "12.3.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
-          "integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
+          "version": "12.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
           "dev": true,
           "requires": {
             "type-fest": "^0.8.1"
           }
         },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
         "inquirer": {
-          "version": "7.0.4",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.4.tgz",
-          "integrity": "sha512-Bu5Td5+j11sCkqfqmUTiwv+tWisMtP0L7Q8WrqA2C/BbBhy1YTdFrvjjlrKq8oagA/tLQBski2Gcx/Sqyi2qSQ==",
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.6.tgz",
+          "integrity": "sha512-7SVO4h+QIdMq6XcqIqrNte3gS5MzCCKZdsq9DO4PJziBFNYzP3PGFbDjgadDb//MCahzgjCxvQ/O2wa7kx9o4w==",
           "dev": true,
           "requires": {
             "ansi-escapes": "^4.2.1",
-            "chalk": "^2.4.2",
+            "chalk": "^3.0.0",
             "cli-cursor": "^3.1.0",
             "cli-width": "^2.0.0",
             "external-editor": "^3.0.3",
             "figures": "^3.0.0",
             "lodash": "^4.17.15",
             "mute-stream": "0.0.8",
-            "run-async": "^2.2.0",
+            "run-async": "^2.4.0",
             "rxjs": "^6.5.3",
             "string-width": "^4.1.0",
-            "strip-ansi": "^5.1.0",
+            "strip-ansi": "^6.0.0",
             "through": "^2.3.6"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+              "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "6.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+              "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^5.0.0"
+              }
+            }
           }
         },
         "is-fullwidth-code-point": {
@@ -2339,6 +2405,15 @@
           "requires": {
             "onetime": "^5.1.0",
             "signal-exit": "^3.0.2"
+          }
+        },
+        "run-async": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.0.tgz",
+          "integrity": "sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==",
+          "dev": true,
+          "requires": {
+            "is-promise": "^2.1.0"
           }
         },
         "semver": {
@@ -2391,6 +2466,15 @@
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
           "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
           "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -362,6 +362,7 @@
     "mongodb-connection-model": "^14.6.2",
     "mongodb-data-service": "^16.5.6",
     "mongodb-ns": "^2.2.0",
+    "mongodb-schema": "^8.2.5",
     "ts-log": "^2.1.4",
     "uuid": "^7.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -290,6 +290,10 @@
           "when": "view == mongoDB && viewItem == collectionTreeItem"
         },
         {
+          "command": "mdb.viewCollectionDocuments",
+          "when": "view == mongoDB && viewItem == documentListTreeItem"
+        },
+        {
           "command": "mdb.dropCollection",
           "when": "view == mongoDB && viewItem == collectionTreeItem"
         },

--- a/src/connectionConfig.ts
+++ b/src/connectionConfig.ts
@@ -1,0 +1,12 @@
+
+export type ConnectionAttributes = {
+  driverUrl: string;
+  instanceId: string;
+};
+
+export type ConnectionConfigType = {
+  appname: string;
+
+  getAttributes(options: object): ConnectionAttributes;
+  disconnect(callback: (n: Error | undefined) => void): void;
+};

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
-import * as Connection from 'mongodb-connection-model/lib/model';
-import * as DataService from 'mongodb-data-service';
+import Connection = require('mongodb-connection-model/lib/model');
+import DataService = require('mongodb-data-service');
 
 const { name, version } = require('../package.json');
 

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -1,6 +1,8 @@
 import path = require('path');
 import * as vscode from 'vscode';
 
+import { ConnectionConfigType } from './connectionConfig';
+import { DataServiceType } from './dataServiceType';
 import { createLogger } from './logging';
 import { StatusView } from './views';
 import { EventEmitter } from 'events';
@@ -35,11 +37,11 @@ export enum DataServiceEventTypes {
 export default class ConnectionController {
   // This is a map of connection instance ids to their connection model.
   private _connectionConfigs: {
-    [key: string]: any;
+    [key: string]: ConnectionConfigType;
   } = {};
 
-  _currentConnection: any;
-  private _currentConnectionConfig: any;
+  _currentConnection: DataServiceType | null = null;
+  private _currentConnectionConfig: ConnectionConfigType | null = null;
   private _currentConnectionInstanceId: string | null = null;
 
   private _connecting = false;
@@ -65,10 +67,14 @@ export default class ConnectionController {
     if (Object.keys(existingGlobalConnectionStrings).length > 0) {
       // Try to pull in the previous connections. We are open to failing here
       // in case the old connection has been corrupted or is no longer supported.
-      Object.keys(existingGlobalConnectionStrings).forEach((connectionId) => {
+
+      Object.keys(existingGlobalConnectionStrings).forEach(connectionId => {
         Connection.from(
           existingGlobalConnectionStrings[connectionId],
-          (err, loadedGlobalConnectionConfig) => {
+          (
+            err: Error | undefined,
+            loadedGlobalConnectionConfig: ConnectionConfigType
+          ) => {
             if (err) {
               // This may indicate a connection has been corrupted or is no longer supported.
               return;
@@ -177,7 +183,7 @@ export default class ConnectionController {
     return new Promise<boolean>((resolve, reject) => {
       Connection.from(
         connectionString,
-        (error: any, newConnectionConfig: any) => {
+        (error: Error | null, newConnectionConfig: ConnectionConfigType) => {
           if (error) {
             vscode.window.showErrorMessage(`Unable to connect: ${error}`);
             return resolve(false);
@@ -214,7 +220,7 @@ export default class ConnectionController {
     });
   }
 
-  public async connect(connectionConfig: any): Promise<boolean> {
+  public async connect(connectionConfig: ConnectionConfigType): Promise<boolean> {
     log.info(
       'Connect called to connect to instance:',
       connectionConfig.getAttributes({
@@ -246,8 +252,8 @@ export default class ConnectionController {
     this._statusView.showMessage('Connecting to MongoDB...');
 
     return new Promise<boolean>((resolve) => {
-      const newConnection = new DataService(connectionConfig);
-      newConnection.connect((err: any) => {
+      const newConnection: DataServiceType = new DataService(connectionConfig);
+      newConnection.connect((err: Error | undefined) => {
         this._statusView.hideMessage();
 
         if (err) {
@@ -272,7 +278,7 @@ export default class ConnectionController {
         this._connecting = false;
         this.eventEmitter.emit(DataServiceEventTypes.CONNECTIONS_DID_CHANGE);
 
-        resolve(true);
+        return resolve(true);
       });
     });
   }
@@ -306,18 +312,18 @@ export default class ConnectionController {
       return Promise.resolve(false);
     }
 
-    if (!this._currentConnection) {
-      vscode.window.showErrorMessage(
-        'Unable to disconnect: no active connection.'
-      );
-      return Promise.resolve(false);
-    }
-
     // Disconnect from the active connection.
-    return new Promise<boolean>((resolve) => {
+    return new Promise<boolean>(resolve => {
+      if (!this._currentConnection) {
+        vscode.window.showErrorMessage(
+          'Unable to disconnect: no active connection.'
+        );
+        return resolve(false);
+      }
+
       this._disconnecting = true;
       this._statusView.showMessage('Disconnecting from current connection...');
-      this._currentConnection.disconnect((err: any) => {
+      this._currentConnection.disconnect((err: Error | undefined): void => {
         if (err) {
           // Show an error, however we still reset the active connection to free up the extension.
           vscode.window.showErrorMessage(

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -183,7 +183,7 @@ export default class ConnectionController {
     return new Promise<boolean>((resolve, reject) => {
       Connection.from(
         connectionString,
-        (error: Error | null, newConnectionConfig: ConnectionConfigType) => {
+        (error: Error | undefined, newConnectionConfig: ConnectionConfigType) => {
           if (error) {
             vscode.window.showErrorMessage(`Unable to connect: ${error}`);
             return resolve(false);

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -1,5 +1,8 @@
-import path = require('path');
 import * as vscode from 'vscode';
+import * as Connection from 'mongodb-connection-model/lib/model';
+import * as DataService from 'mongodb-data-service';
+
+const { name, version } = require('../package.json');
 
 import { ConnectionConfigType } from './connectionConfig';
 import { DataServiceType } from './dataServiceType';
@@ -9,10 +12,7 @@ import { EventEmitter } from 'events';
 import { StorageController, StorageVariables } from './storage';
 import { StorageScope } from './storage/storageController';
 
-const Connection = require('mongodb-connection-model/lib/model');
-const DataService = require('mongodb-data-service');
 const log = createLogger('connection controller');
-const { name, version } = require(path.resolve(__dirname, '../package.json'));
 
 function getConnectWebviewContent(): string {
   return `<!DOCTYPE html>
@@ -156,7 +156,7 @@ export default class ConnectionController {
         placeHolder:
           'e.g. mongodb+srv://username:password@cluster0.mongodb.net/admin',
         prompt: 'Enter your connection string (SRV or standard)',
-        validateInput: (uri: any) => {
+        validateInput: (uri: string) => {
           if (!Connection.isURI(uri)) {
             return 'MongoDB connection strings begin with "mongodb://" or "mongodb+srv://"';
           }

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -40,9 +40,9 @@ export default class ConnectionController {
     [key: string]: ConnectionConfigType;
   } = {};
 
-  _currentConnection: DataServiceType | null = null;
-  private _currentConnectionConfig: ConnectionConfigType | null = null;
-  private _currentConnectionInstanceId: string | null = null;
+  _currentConnection: null | DataServiceType = null;
+  private _currentConnectionConfig: null | ConnectionConfigType = null;
+  private _currentConnectionInstanceId: null | string = null;
 
   private _connecting = false;
   private _connectingInstanceId = '';

--- a/src/dataServiceType.ts
+++ b/src/dataServiceType.ts
@@ -1,0 +1,5 @@
+
+export type DataServiceType = {
+  connect(callback: (n: Error | undefined) => void): void;
+  disconnect(callback: (n: Error | undefined) => void): void;
+};

--- a/src/explorer/collectionTreeItem.ts
+++ b/src/explorer/collectionTreeItem.ts
@@ -1,6 +1,9 @@
 import * as vscode from 'vscode';
 
-import DocumentListTreeItem, { CollectionTypes, MAX_DOCUMENTS_VISIBLE } from './documentListTreeItem';
+import DocumentListTreeItem, {
+  CollectionTypes,
+  MAX_DOCUMENTS_VISIBLE
+} from './documentListTreeItem';
 import TreeItemParent from './treeItemParentInterface';
 import SchemaTreeItem from './schemaTreeItem';
 
@@ -59,6 +62,7 @@ export default class CollectionTreeItem extends vscode.TreeItem
         this.databaseName,
         this._dataService,
         false, // Collapsed.
+        false, // Show more fields has not been clicked.
         null // No existing cache.
       );
   }
@@ -90,12 +94,10 @@ export default class CollectionTreeItem extends vscode.TreeItem
       this.databaseName,
       this._dataService,
       this._schemaChild.isExpanded,
+      this._schemaChild.hasClickedShowMoreFields,
       this._schemaChild.getChildrenCache()
     );
-    return Promise.resolve([
-      this._documentListChild,
-      this._schemaChild
-    ]);
+    return Promise.resolve([this._documentListChild, this._schemaChild]);
   }
 
   onDidCollapse(): void {
@@ -123,6 +125,7 @@ export default class CollectionTreeItem extends vscode.TreeItem
       this.databaseName,
       this._dataService,
       false, // Collapsed.
+      false, // Show more fields has not been clicked.
       null // No existing cache.
     );
   }

--- a/src/explorer/collectionTreeItem.ts
+++ b/src/explorer/collectionTreeItem.ts
@@ -9,10 +9,12 @@ import SchemaTreeItem from './schemaTreeItem';
 
 export default class CollectionTreeItem extends vscode.TreeItem
   implements TreeItemParent, vscode.TreeDataProvider<CollectionTreeItem> {
+  static contextValue = 'collectionTreeItem';
+
   private _documentListChild: DocumentListTreeItem;
   private _schemaChild: SchemaTreeItem;
 
-  contextValue = 'collectionTreeItem';
+  isSynchronousResource = true;
 
   collectionName: string;
   databaseName: string;

--- a/src/explorer/collectionTreeItem.ts
+++ b/src/explorer/collectionTreeItem.ts
@@ -1,44 +1,15 @@
 import * as vscode from 'vscode';
-const path = require('path');
 
-import DocumentTreeItem from './documentTreeItem';
+import DocumentListTreeItem, { CollectionTypes, MAX_DOCUMENTS_VISIBLE } from './documentListTreeItem';
 import TreeItemParent from './treeItemParentInterface';
-
-// We fetch 1 more than this in order to see if there are more to fetch.
-// Each time `show more` is clicked, the collection item increases the amount
-// of documents shown by this amount.
-export const MAX_DOCUMENTS_VISIBLE = 10;
-
-class ShowMoreDocumentsTreeItem extends vscode.TreeItem {
-  // This is the identifier we use to identify this tree item when a tree item
-  // has been clicked. Activated from the explorer controller `onDidChangeSelection`.
-  public isShowMoreItem = true;
-  public onShowMoreClicked: () => void;
-
-  constructor(namespace: string, showMore: () => void, documentsShown: number) {
-    super('Show more...', vscode.TreeItemCollapsibleState.None);
-
-    // We assign the item a unique id so that when it is selected the selection
-    // resets (de-selects) when the documents are fetched and a new item is shown.
-    this.id = `show-more-${namespace}-${documentsShown}`;
-    this.onShowMoreClicked = showMore;
-  }
-}
-
-export enum CollectionTypes {
-  collection = 'collection',
-  view = 'view'
-}
+import SchemaTreeItem from './schemaTreeItem';
 
 export default class CollectionTreeItem extends vscode.TreeItem
   implements TreeItemParent, vscode.TreeDataProvider<CollectionTreeItem> {
-  _childrenCacheIsUpToDate = false;
-  private _childrenCache: vscode.TreeItem[] = [];
+  private _documentListChild: DocumentListTreeItem;
+  private _schemaChild: SchemaTreeItem;
 
   contextValue = 'collectionTreeItem';
-
-  // We fetch 1 more than this in order to see if there are more to fetch.
-  private _maxDocumentsToShow: number;
 
   collectionName: string;
   databaseName: string;
@@ -53,8 +24,8 @@ export default class CollectionTreeItem extends vscode.TreeItem
     databaseName: string,
     dataService: any,
     isExpanded: boolean,
-    existingChildrenCache: vscode.TreeItem[],
-    maxDocumentsToShow: number
+    existingDocumentListChild?: DocumentListTreeItem,
+    existingSchemaChild?: SchemaTreeItem
   ) {
     super(
       collection.name,
@@ -70,8 +41,26 @@ export default class CollectionTreeItem extends vscode.TreeItem
     this._dataService = dataService;
 
     this.isExpanded = isExpanded;
-    this._childrenCache = existingChildrenCache;
-    this._maxDocumentsToShow = maxDocumentsToShow;
+    this._documentListChild = existingDocumentListChild
+      ? existingDocumentListChild
+      : new DocumentListTreeItem(
+        this.collectionName,
+        this.databaseName,
+        this._type,
+        this._dataService,
+        false, // Collapsed.
+        MAX_DOCUMENTS_VISIBLE,
+        null // No existing cache.
+      );
+    this._schemaChild = existingSchemaChild
+      ? existingSchemaChild
+      : new SchemaTreeItem(
+        this.collectionName,
+        this.databaseName,
+        this._dataService,
+        false, // Collapsed.
+        null // No existing cache.
+      );
   }
 
   get tooltip(): string {
@@ -85,101 +74,68 @@ export default class CollectionTreeItem extends vscode.TreeItem
   }
 
   getChildren(): Thenable<any[]> {
-    if (!this.isExpanded) {
-      return Promise.resolve([]);
-    }
-
-    if (this._childrenCacheIsUpToDate) {
-      return Promise.resolve(this._childrenCache);
-    }
-
-    return new Promise((resolve, reject) => {
-      const namespace = `${this.databaseName}.${this.collectionName}`;
-
-      this._dataService.find(
-        namespace,
-        {
-          /* No filter */
-        },
-        {
-          // We fetch 1 more than the max documents to show to see if
-          // there are more documents we aren't showing.
-          limit: 1 + this._maxDocumentsToShow
-        },
-        (err: Error, documents: []) => {
-          if (err) {
-            return reject(new Error(`Unable to list documents: ${err}`));
-          }
-
-          this._childrenCacheIsUpToDate = true;
-
-          if (documents) {
-            this._childrenCache = documents.map((document, index) => {
-              if (index === this._maxDocumentsToShow) {
-                return new ShowMoreDocumentsTreeItem(
-                  namespace,
-                  () => this.onShowMoreClicked(),
-                  this._maxDocumentsToShow
-                );
-              }
-
-              return new DocumentTreeItem(document, index);
-            });
-          } else {
-            this._childrenCache = [];
-          }
-
-          return resolve(this._childrenCache);
-        }
-      );
-    });
-  }
-
-  public get iconPath():
-    | string
-    | vscode.Uri
-    | { light: string | vscode.Uri; dark: string | vscode.Uri } {
-    const LIGHT = path.join(__dirname, '..', '..', '..', 'images', 'light');
-    const DARK = path.join(__dirname, '..', '..', '..', 'images', 'dark');
-
-    const iconName =
-      this._type === CollectionTypes.collection ? 'collection' : 'view';
-
-    return {
-      light: path.join(LIGHT, `${iconName}.svg`),
-      dark: path.join(DARK, `${iconName}.svg`)
-    };
-  }
-
-  onShowMoreClicked(): void {
-    this._maxDocumentsToShow += MAX_DOCUMENTS_VISIBLE;
-    this._childrenCacheIsUpToDate = false;
+    // We rebuild the children here so their controlled `expanded` state
+    // is ensure to be set by vscode.
+    this._documentListChild = new DocumentListTreeItem(
+      this.collectionName,
+      this.databaseName,
+      this._type,
+      this._dataService,
+      this._documentListChild.isExpanded,
+      this._documentListChild.getMaxDocumentsToShow(),
+      this._documentListChild.getChildrenCache()
+    );
+    this._schemaChild = new SchemaTreeItem(
+      this.collectionName,
+      this.databaseName,
+      this._dataService,
+      this._schemaChild.isExpanded,
+      this._schemaChild.getChildrenCache()
+    );
+    return Promise.resolve([
+      this._documentListChild,
+      this._schemaChild
+    ]);
   }
 
   onDidCollapse(): void {
     this.isExpanded = false;
-    this._childrenCacheIsUpToDate = false;
-    this._maxDocumentsToShow = MAX_DOCUMENTS_VISIBLE;
   }
 
   onDidExpand(): Promise<boolean> {
-    this._childrenCacheIsUpToDate = false;
     this.isExpanded = true;
 
     return Promise.resolve(true);
   }
 
   resetCache(): void {
-    this._childrenCache = [];
-    this._childrenCacheIsUpToDate = false;
+    this._documentListChild = new DocumentListTreeItem(
+      this.collectionName,
+      this.databaseName,
+      this._type,
+      this._dataService,
+      false, // Collapsed.
+      MAX_DOCUMENTS_VISIBLE,
+      null // No existing cache.
+    );
+    this._schemaChild = new SchemaTreeItem(
+      this.collectionName,
+      this.databaseName,
+      this._dataService,
+      false, // Collapsed.
+      null // No existing cache.
+    );
   }
 
-  getChildrenCache(): vscode.TreeItem[] {
-    return this._childrenCache;
+  getDocumentListChild(): DocumentListTreeItem {
+    return this._documentListChild;
+  }
+  getSchemaChild(): SchemaTreeItem {
+    return this._schemaChild;
   }
 
   getMaxDocumentsToShow(): number {
-    return this._maxDocumentsToShow;
+    return this._documentListChild.getMaxDocumentsToShow();
   }
 
   async onDropCollectionClicked(): Promise<boolean> {
@@ -223,7 +179,6 @@ export default class CollectionTreeItem extends vscode.TreeItem
             return resolve(false);
           }
 
-          this._childrenCacheIsUpToDate = false;
           return resolve(successfullyDroppedCollection);
         }
       );

--- a/src/explorer/collectionTreeItem.ts
+++ b/src/explorer/collectionTreeItem.ts
@@ -9,7 +9,7 @@ import SchemaTreeItem from './schemaTreeItem';
 
 export default class CollectionTreeItem extends vscode.TreeItem
   implements TreeItemParent, vscode.TreeDataProvider<CollectionTreeItem> {
-  static contextValue = 'collectionTreeItem';
+  contextValue = 'collectionTreeItem';
 
   private _documentListChild: DocumentListTreeItem;
   private _schemaChild: SchemaTreeItem;

--- a/src/explorer/connectionTreeItem.ts
+++ b/src/explorer/connectionTreeItem.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
-const ns = require('mongodb-ns');
-const path = require('path');
+import ns = require('mongodb-ns');
+import path = require('path');
 
 import DatabaseTreeItem from './databaseTreeItem';
 import ConnectionController from '../connectionController';

--- a/src/explorer/connectionTreeItem.ts
+++ b/src/explorer/connectionTreeItem.ts
@@ -11,6 +11,7 @@ enum ConnectionItemContextValues {
   disconnected = 'disconnectedConnectionTreeItem',
   connected = 'connectedConnectionTreeItem'
 }
+export { ConnectionItemContextValues };
 
 export default class ConnectionTreeItem extends vscode.TreeItem
   implements TreeItemParent, vscode.TreeDataProvider<ConnectionTreeItem> {

--- a/src/explorer/databaseTreeItem.ts
+++ b/src/explorer/databaseTreeItem.ts
@@ -3,7 +3,6 @@ const ns = require('mongodb-ns');
 const path = require('path');
 import { StatusView } from '../views';
 
-import { MAX_DOCUMENTS_VISIBLE } from './documentListTreeItem';
 import CollectionTreeItem from './collectionTreeItem';
 import TreeItemParent from './treeItemParentInterface';
 
@@ -89,7 +88,7 @@ export default class DatabaseTreeItem extends vscode.TreeItem
                   collection,
                   this.databaseName,
                   this._dataService,
-                  false, // Not expanded.
+                  false // Not expanded.
                 );
               }
             });
@@ -182,7 +181,7 @@ export default class DatabaseTreeItem extends vscode.TreeItem
       this._dataService.createCollection(
         `${databaseName}.${collectionName}`,
         {}, // No options.
-        (err) => {
+        err => {
           statusBarItem.hideMessage();
 
           if (err) {

--- a/src/explorer/databaseTreeItem.ts
+++ b/src/explorer/databaseTreeItem.ts
@@ -8,7 +8,7 @@ import TreeItemParent from './treeItemParentInterface';
 
 export default class DatabaseTreeItem extends vscode.TreeItem
   implements TreeItemParent, vscode.TreeDataProvider<DatabaseTreeItem> {
-  static contextValue = 'databaseTreeItem';
+  contextValue = 'databaseTreeItem';
 
   _childrenCacheIsUpToDate = false;
   private _childrenCache: { [collectionName: string]: CollectionTreeItem };

--- a/src/explorer/databaseTreeItem.ts
+++ b/src/explorer/databaseTreeItem.ts
@@ -3,9 +3,8 @@ const ns = require('mongodb-ns');
 const path = require('path');
 import { StatusView } from '../views';
 
-import CollectionTreeItem, {
-  MAX_DOCUMENTS_VISIBLE
-} from './collectionTreeItem';
+import { MAX_DOCUMENTS_VISIBLE } from './documentListTreeItem';
+import CollectionTreeItem from './collectionTreeItem';
 import TreeItemParent from './treeItemParentInterface';
 
 export default class DatabaseTreeItem extends vscode.TreeItem
@@ -61,7 +60,7 @@ export default class DatabaseTreeItem extends vscode.TreeItem
       this._dataService.listCollections(
         this.databaseName,
         {}, // No filter.
-        (err: any, collections: string[]) => {
+        (err: Error | undefined, collections: string[]) => {
           if (err) {
             return reject(
               new Error(`Unable to list collections: ${err.message}`)
@@ -82,8 +81,8 @@ export default class DatabaseTreeItem extends vscode.TreeItem
                   this.databaseName,
                   this._dataService,
                   pastChildrenCache[collection.name].isExpanded,
-                  pastChildrenCache[collection.name].getChildrenCache(),
-                  pastChildrenCache[collection.name].getMaxDocumentsToShow()
+                  pastChildrenCache[collection.name].getDocumentListChild(),
+                  pastChildrenCache[collection.name].getSchemaChild()
                 );
               } else {
                 this._childrenCache[collection.name] = new CollectionTreeItem(
@@ -91,8 +90,6 @@ export default class DatabaseTreeItem extends vscode.TreeItem
                   this.databaseName,
                   this._dataService,
                   false, // Not expanded.
-                  [], // No cached documents.
-                  MAX_DOCUMENTS_VISIBLE
                 );
               }
             });
@@ -225,7 +222,7 @@ export default class DatabaseTreeItem extends vscode.TreeItem
       });
     } catch (e) {
       return Promise.reject(
-        new Error(`An error occured parsing the collection name: ${e}`)
+        new Error(`An error occured parsing the database name: ${e}`)
       );
     }
 

--- a/src/explorer/databaseTreeItem.ts
+++ b/src/explorer/databaseTreeItem.ts
@@ -8,7 +8,7 @@ import TreeItemParent from './treeItemParentInterface';
 
 export default class DatabaseTreeItem extends vscode.TreeItem
   implements TreeItemParent, vscode.TreeDataProvider<DatabaseTreeItem> {
-  contextValue = 'databaseTreeItem';
+  static contextValue = 'databaseTreeItem';
 
   _childrenCacheIsUpToDate = false;
   private _childrenCache: { [collectionName: string]: CollectionTreeItem };

--- a/src/explorer/documentListTreeItem.ts
+++ b/src/explorer/documentListTreeItem.ts
@@ -40,7 +40,7 @@ export default class DocumentListTreeItem extends vscode.TreeItem
   _childrenCacheIsUpToDate = false;
   private _childrenCache: vscode.TreeItem[] = [];
 
-  contextValue = 'documentListTreeItem';
+  static contextValue = 'documentListTreeItem';
 
   // We fetch 1 more than this in order to see if there are more to fetch.
   private _maxDocumentsToShow: number;
@@ -54,7 +54,7 @@ export default class DocumentListTreeItem extends vscode.TreeItem
   isExpanded: boolean;
 
   constructor(
-    collectionName: any,
+    collectionName: string,
     databaseName: string,
     type: CollectionTypes,
     dataService: any,

--- a/src/explorer/documentListTreeItem.ts
+++ b/src/explorer/documentListTreeItem.ts
@@ -40,7 +40,7 @@ export default class DocumentListTreeItem extends vscode.TreeItem
   _childrenCacheIsUpToDate = false;
   private _childrenCache: vscode.TreeItem[] = [];
 
-  static contextValue = 'documentListTreeItem';
+  contextValue = 'documentListTreeItem';
 
   // We fetch 1 more than this in order to see if there are more to fetch.
   private _maxDocumentsToShow: number;

--- a/src/explorer/documentListTreeItem.ts
+++ b/src/explorer/documentListTreeItem.ts
@@ -106,11 +106,15 @@ export default class DocumentListTreeItem extends vscode.TreeItem
     return new Promise((resolve, reject) => {
       const namespace = `${this.databaseName}.${this.collectionName}`;
 
-      log.info(`fetching ${this._maxDocumentsToShow} documents from namespace ${namespace}`);
+      log.info(
+        `fetching ${this._maxDocumentsToShow} documents from namespace ${namespace}`
+      );
 
       this._dataService.find(
         namespace,
-        { /* No filter */ },
+        {
+          /* No filter */
+        },
         {
           // We fetch 1 more than the max documents to show to see if
           // there are more documents we aren't showing.
@@ -118,28 +122,24 @@ export default class DocumentListTreeItem extends vscode.TreeItem
         },
         (err: Error, documents: []) => {
           if (err) {
-            vscode.window.showErrorMessage(
-              `Unable to list documents: ${err}`
-            );
+            vscode.window.showErrorMessage(`Unable to list documents: ${err}`);
             return reject();
           }
 
           this._childrenCacheIsUpToDate = true;
 
           if (documents) {
-            this._childrenCache = documents.map(
-              (document, index) => {
-                if (index === this._maxDocumentsToShow) {
-                  return new ShowMoreDocumentsTreeItem(
-                    namespace,
-                    () => this.onShowMoreClicked(),
-                    this._maxDocumentsToShow
-                  );
-                }
-
-                return new DocumentTreeItem(document, index);
+            this._childrenCache = documents.map((document, index) => {
+              if (index === this._maxDocumentsToShow) {
+                return new ShowMoreDocumentsTreeItem(
+                  namespace,
+                  () => this.onShowMoreClicked(),
+                  this._maxDocumentsToShow
+                );
               }
-            );
+
+              return new DocumentTreeItem(document, index);
+            });
           } else {
             this._childrenCache = [];
           }
@@ -150,7 +150,10 @@ export default class DocumentListTreeItem extends vscode.TreeItem
     });
   }
 
-  get iconPath(): string | vscode.Uri | { light: string | vscode.Uri; dark: string | vscode.Uri } {
+  get iconPath():
+    | string
+    | vscode.Uri
+    | { light: string | vscode.Uri; dark: string | vscode.Uri } {
     return this._type === CollectionTypes.collection
       ? {
         light: path.join(__filename, '..', '..', '..', 'resources', 'light', 'collection.svg'),

--- a/src/explorer/documentListTreeItem.ts
+++ b/src/explorer/documentListTreeItem.ts
@@ -1,0 +1,201 @@
+import * as vscode from 'vscode';
+const path = require('path');
+
+import { createLogger } from '../logging';
+import DocumentTreeItem from './documentTreeItem';
+import TreeItemParent from './treeItemParentInterface';
+
+const log = createLogger('tree view document list');
+
+// We fetch 1 more than this in order to see if there are more to fetch.
+// Each time `show more` is clicked, the collection item increases the amount
+// of documents shown by this amount.
+export const MAX_DOCUMENTS_VISIBLE = 10;
+
+const ITEM_LABEL = 'Documents';
+
+export enum CollectionTypes {
+  collection = 'collection',
+  view = 'view'
+}
+
+class ShowMoreDocumentsTreeItem extends vscode.TreeItem {
+  // This is the identifier we use to identify this tree item when a tree item
+  // has been clicked. Activated from the explorer controller `onDidChangeSelection`.
+  isShowMoreItem = true;
+  onShowMoreClicked: () => void;
+
+  constructor(namespace: string, showMore: () => void, documentsShown: number) {
+    super('Show more...', vscode.TreeItemCollapsibleState.None);
+
+    // We assign the item a unique id so that when it is selected the selection
+    // resets (de-selects) when the documents are fetched and a new item is shown.
+    this.id = `show-more-${namespace}-${documentsShown}`;
+    this.onShowMoreClicked = showMore;
+  }
+}
+
+export default class DocumentListTreeItem extends vscode.TreeItem
+  implements TreeItemParent, vscode.TreeDataProvider<DocumentListTreeItem> {
+  _childrenCacheIsUpToDate = false;
+  private _childrenCache: vscode.TreeItem[] = [];
+
+  contextValue = 'documentListTreeItem';
+
+  // We fetch 1 more than this in order to see if there are more to fetch.
+  private _maxDocumentsToShow: number;
+
+  collectionName: string;
+  databaseName: string;
+
+  private _dataService: any;
+  private _type: CollectionTypes;
+
+  isExpanded: boolean;
+
+  constructor(
+    collectionName: any,
+    databaseName: string,
+    type: CollectionTypes,
+    dataService: any,
+    isExpanded: boolean,
+    maxDocumentsToShow: number,
+    existingCache: vscode.TreeItem[] | null
+  ) {
+    super(
+      ITEM_LABEL,
+      isExpanded
+        ? vscode.TreeItemCollapsibleState.Expanded
+        : vscode.TreeItemCollapsibleState.Collapsed
+    );
+
+    this.collectionName = collectionName;
+    this.databaseName = databaseName;
+
+    this._type = type; // Type can be `collection` or `view`.
+    this._dataService = dataService;
+
+    this.isExpanded = isExpanded;
+
+    this._maxDocumentsToShow = maxDocumentsToShow;
+
+    if (existingCache !== null) {
+      this._childrenCache = existingCache;
+      this._childrenCacheIsUpToDate = true;
+    }
+  }
+
+  get tooltip(): string {
+    const typeString = CollectionTypes.view ? 'View' : 'Collection';
+    return `${typeString} Documents`;
+  }
+
+  getTreeItem(element: DocumentListTreeItem): DocumentListTreeItem {
+    return element;
+  }
+
+  getChildren(): Thenable<any[]> {
+    if (!this.isExpanded) {
+      return Promise.resolve([]);
+    }
+
+    if (this._childrenCacheIsUpToDate) {
+      return Promise.resolve(this._childrenCache);
+    }
+
+    return new Promise((resolve, reject) => {
+      const namespace = `${this.databaseName}.${this.collectionName}`;
+
+      log.info(`fetching ${this._maxDocumentsToShow} documents from namespace ${namespace}`);
+
+      this._dataService.find(
+        namespace,
+        { /* No filter */ },
+        {
+          // We fetch 1 more than the max documents to show to see if
+          // there are more documents we aren't showing.
+          limit: 1 + this._maxDocumentsToShow
+        },
+        (err: Error, documents: []) => {
+          if (err) {
+            vscode.window.showErrorMessage(
+              `Unable to list documents: ${err}`
+            );
+            return reject();
+          }
+
+          this._childrenCacheIsUpToDate = true;
+
+          if (documents) {
+            this._childrenCache = documents.map(
+              (document, index) => {
+                if (index === this._maxDocumentsToShow) {
+                  return new ShowMoreDocumentsTreeItem(
+                    namespace,
+                    () => this.onShowMoreClicked(),
+                    this._maxDocumentsToShow
+                  );
+                }
+
+                return new DocumentTreeItem(document, index);
+              }
+            );
+          } else {
+            this._childrenCache = [];
+          }
+
+          return resolve(this._childrenCache);
+        }
+      );
+    });
+  }
+
+  get iconPath(): string | vscode.Uri | { light: string | vscode.Uri; dark: string | vscode.Uri } {
+    return this._type === CollectionTypes.collection
+      ? {
+        light: path.join(__filename, '..', '..', '..', 'resources', 'light', 'collection.svg'),
+        dark: path.join(__filename, '..', '..', '..', 'resources', 'dark', 'collection.svg')
+      }
+      : {
+        light: path.join(__filename, '..', '..', '..', 'resources', 'light', 'view.svg'),
+        dark: path.join(__filename, '..', '..', '..', 'resources', 'dark', 'view.svg')
+      };
+  }
+
+  onShowMoreClicked(): void {
+    log.info('show more clicked');
+
+    this._maxDocumentsToShow += MAX_DOCUMENTS_VISIBLE;
+    this._childrenCacheIsUpToDate = false;
+  }
+
+  onDidCollapse(): void {
+    this.isExpanded = false;
+    this._childrenCacheIsUpToDate = false;
+    this._maxDocumentsToShow = MAX_DOCUMENTS_VISIBLE;
+  }
+
+  onDidExpand(): Promise<boolean> {
+    this._childrenCacheIsUpToDate = false;
+    this.isExpanded = true;
+
+    return Promise.resolve(true);
+  }
+
+  resetCache(): void {
+    this._childrenCache = [];
+    this._childrenCacheIsUpToDate = false;
+  }
+
+  getChildrenCache(): vscode.TreeItem[] | null {
+    if (this._childrenCacheIsUpToDate) {
+      return this._childrenCache;
+    }
+
+    return null;
+  }
+
+  getMaxDocumentsToShow(): number {
+    return this._maxDocumentsToShow;
+  }
+}

--- a/src/explorer/explorerTreeController.ts
+++ b/src/explorer/explorerTreeController.ts
@@ -44,7 +44,14 @@ export default class ExplorerTreeController implements vscode.TreeDataProvider<v
   ): void => {
     treeView.onDidCollapseElement((event: any) => {
       log.info('Tree item was collapsed:', event.element.label);
+
       event.element.onDidCollapse();
+
+      if (event.element.doesNotRequireTreeUpdate) {
+        // When the element is already loaded (synchronous), we do not need to
+        // fully refresh the tree.
+        return;
+      }
 
       this.onTreeItemUpdate();
     });
@@ -55,7 +62,14 @@ export default class ExplorerTreeController implements vscode.TreeDataProvider<v
         return new Promise((resolve, reject) => {
           event.element.onDidExpand().then(
             () => {
+              if (event.element.doesNotRequireTreeUpdate) {
+                // When the element is already loaded (synchronous), we do not
+                //  need to fully refresh the tree.
+                return resolve(true);
+              }
+
               this.onTreeItemUpdate();
+
               resolve(true);
             },
             (err: Error) => {
@@ -70,6 +84,7 @@ export default class ExplorerTreeController implements vscode.TreeDataProvider<v
       if (event.selection && event.selection.length === 1) {
         if (event.selection[0].isShowMoreItem) {
           event.selection[0].onShowMoreClicked();
+
           this.onTreeItemUpdate();
         }
       }

--- a/src/explorer/fieldTreeItem.ts
+++ b/src/explorer/fieldTreeItem.ts
@@ -70,17 +70,12 @@ export default class FieldTreeItem extends vscode.TreeItem
     return element;
   }
 
-  getChildren(): Thenable<any[]> {
-    console.log('get children of field', this.field.name);
+  getChildren(): Thenable<FieldTreeItem[]> {
     if (!fieldIsExpandable(this.field)) {
       return Promise.resolve([]);
     }
 
-    console.log('to children of field', this.field.name);
-
     if (this.field.bsonType === FieldTypes.document) {
-      console.log('is bsondoc', this.field.name);
-
       const subDocumentFields = this.field.fields;
       return Promise.resolve(
         subDocumentFields
@@ -88,10 +83,8 @@ export default class FieldTreeItem extends vscode.TreeItem
           : []
       );
     } else if (this.field.type === FieldTypes.document) {
-      console.log('is doc', this.field.name);
-      console.log(' make fields', this.field.types[0].fields);
-
       const subDocumentFields = this.field.types[0].fields;
+
       return Promise.resolve(
         subDocumentFields
           ? subDocumentFields.map((subField) => new FieldTreeItem(subField))
@@ -100,16 +93,12 @@ export default class FieldTreeItem extends vscode.TreeItem
     } else if (
       this.field.type === FieldTypes.array || this.field.bsonType === FieldTypes.array
     ) {
-      console.log('get is array', this.field.name);
-
       const arrayElement = this.field.types[0];
+
       return Promise.resolve([
         new FieldTreeItem(arrayElement)
       ]);
     }
-
-    console.log('errrorroororororor', this.field.name);
-
 
     return Promise.resolve([]);
   }

--- a/src/explorer/fieldTreeItem.ts
+++ b/src/explorer/fieldTreeItem.ts
@@ -1,0 +1,115 @@
+import * as vscode from 'vscode';
+
+import TreeItemParent from './treeItemParentInterface';
+
+export enum FieldTypes {
+  document = 'Document',
+  array = 'Array'
+}
+
+export type SchemaFieldType = {
+  name: string;
+  isExpanded: boolean;
+  probability: number;
+  type: string;
+  fields: SchemaFieldType[] | undefined;
+};
+
+function fieldIsExpandable(field: SchemaFieldType): boolean {
+  return (
+    field.probability === 1 &&
+    (field.type === FieldTypes.document || field.type === FieldTypes.array)
+  );
+}
+
+function getCollapsibleStateForField(
+  field: SchemaFieldType
+): vscode.TreeItemCollapsibleState {
+  if (!fieldIsExpandable(field)) {
+    return vscode.TreeItemCollapsibleState.None;
+  }
+
+  return field.isExpanded
+    ? vscode.TreeItemCollapsibleState.Expanded
+    : vscode.TreeItemCollapsibleState.Collapsed;
+}
+
+export default class FieldTreeItem extends vscode.TreeItem
+  implements TreeItemParent, vscode.TreeDataProvider<FieldTreeItem> {
+  _childrenCacheIsUpToDate = false;
+  private _childrenCache: vscode.TreeItem[] = [];
+
+  field: SchemaFieldType;
+
+  contextValue = 'fieldTreeItem';
+
+  fieldName: string;
+
+  isExpanded: boolean;
+
+  constructor(field: SchemaFieldType) {
+    super(field.name, getCollapsibleStateForField(field));
+
+    this.field = field;
+
+    this.fieldName = field.name;
+
+    this.isExpanded = field.isExpanded;
+
+    // if (existingCache !== null) {
+    //   this._childrenCache = existingCache;
+    //   this._childrenCacheIsUpToDate = true;
+    // }
+  }
+
+  get tooltip(): string {
+    return this.fieldName;
+  }
+
+  getTreeItem(element: FieldTreeItem): FieldTreeItem {
+    return element;
+  }
+
+  getChildren(): Thenable<any[]> {
+    if (!fieldIsExpandable(this.field)) {
+      return Promise.resolve([]);
+    }
+
+    return new Promise((resolve) => {
+      resolve(
+        this.field.fields
+          ? this.field.fields.map((subField) => new FieldTreeItem(subField))
+          : []
+      );
+    });
+  }
+
+  onShowMoreClicked(): void {
+    this._childrenCacheIsUpToDate = false;
+  }
+
+  onDidCollapse(): void {
+    this.isExpanded = false;
+    this._childrenCacheIsUpToDate = false;
+  }
+
+  onDidExpand(): Promise<boolean> {
+    this._childrenCacheIsUpToDate = false;
+    this.isExpanded = true;
+
+    return Promise.resolve(true);
+  }
+
+  resetCache(): void {
+    this._childrenCache = [];
+    this._childrenCacheIsUpToDate = false;
+  }
+
+  getChildrenCache(): vscode.TreeItem[] | null {
+    if (this._childrenCacheIsUpToDate) {
+      return this._childrenCache;
+    }
+
+    return null;
+  }
+}

--- a/src/explorer/fieldTreeItem.ts
+++ b/src/explorer/fieldTreeItem.ts
@@ -7,7 +7,6 @@ export enum FieldTypes {
 
 export type SchemaFieldType = {
   name: string;
-  isExpanded: boolean;
   probability: number;
   bsonType: string | undefined;
   type: string | undefined;
@@ -20,12 +19,10 @@ export type SchemaFieldType = {
 export function fieldIsExpandable(field: SchemaFieldType): boolean {
   return (
     field.probability === 1 &&
-    (
-      field.type === FieldTypes.document ||
+    (field.type === FieldTypes.document ||
       field.type === FieldTypes.array ||
       field.bsonType === FieldTypes.document ||
-      field.bsonType === FieldTypes.array
-    )
+      field.bsonType === FieldTypes.array)
   );
 }
 
@@ -36,9 +33,7 @@ function getCollapsibleStateForField(
     return vscode.TreeItemCollapsibleState.None;
   }
 
-  return field.isExpanded
-    ? vscode.TreeItemCollapsibleState.Expanded
-    : vscode.TreeItemCollapsibleState.Collapsed;
+  return vscode.TreeItemCollapsibleState.Collapsed;
 }
 
 export default class FieldTreeItem extends vscode.TreeItem
@@ -91,24 +86,23 @@ export default class FieldTreeItem extends vscode.TreeItem
           : []
       );
     } else if (
-      this.field.type === FieldTypes.array || this.field.bsonType === FieldTypes.array
+      this.field.type === FieldTypes.array ||
+      this.field.bsonType === FieldTypes.array
     ) {
       const arrayElement = this.field.types[0];
 
-      return Promise.resolve([
-        new FieldTreeItem(arrayElement)
-      ]);
+      return Promise.resolve([new FieldTreeItem(arrayElement)]);
     }
 
     return Promise.resolve([]);
   }
 
   onDidCollapse(): void {
-    this.field.isExpanded = false;
+    // no-op until we add caching expanded state.
   }
 
   onDidExpand(): Promise<boolean> {
-    this.field.isExpanded = true;
+    // no-op until we add caching expanded state.
 
     return Promise.resolve(true);
   }

--- a/src/explorer/fieldTreeItem.ts
+++ b/src/explorer/fieldTreeItem.ts
@@ -71,11 +71,16 @@ export default class FieldTreeItem extends vscode.TreeItem
   }
 
   getChildren(): Thenable<any[]> {
+    console.log('get children of field', this.field.name);
     if (!fieldIsExpandable(this.field)) {
       return Promise.resolve([]);
     }
 
+    console.log('to children of field', this.field.name);
+
     if (this.field.bsonType === FieldTypes.document) {
+      console.log('is bsondoc', this.field.name);
+
       const subDocumentFields = this.field.fields;
       return Promise.resolve(
         subDocumentFields
@@ -83,6 +88,9 @@ export default class FieldTreeItem extends vscode.TreeItem
           : []
       );
     } else if (this.field.type === FieldTypes.document) {
+      console.log('is doc', this.field.name);
+      console.log(' make fields', this.field.types[0].fields);
+
       const subDocumentFields = this.field.types[0].fields;
       return Promise.resolve(
         subDocumentFields
@@ -92,11 +100,16 @@ export default class FieldTreeItem extends vscode.TreeItem
     } else if (
       this.field.type === FieldTypes.array || this.field.bsonType === FieldTypes.array
     ) {
+      console.log('get is array', this.field.name);
+
       const arrayElement = this.field.types[0];
       return Promise.resolve([
         new FieldTreeItem(arrayElement)
       ]);
     }
+
+    console.log('errrorroororororor', this.field.name);
+
 
     return Promise.resolve([]);
   }

--- a/src/explorer/index.ts
+++ b/src/explorer/index.ts
@@ -1,8 +1,4 @@
-
 import CollectionTreeItem from './collectionTreeItem';
 import ExplorerController from './explorerController';
 
-export {
-  CollectionTreeItem,
-  ExplorerController
-};
+export { CollectionTreeItem, ExplorerController };

--- a/src/explorer/mdbConnectionsTreeItem.ts
+++ b/src/explorer/mdbConnectionsTreeItem.ts
@@ -41,17 +41,21 @@ export default class MDBConnectionsTreeItem extends vscode.TreeItem
     this._connectionTreeItems = {};
 
     // Create new connection tree items, using cached children whereever possible.
-    connectionIds.forEach(connectionId => {
-      const isActiveConnection = connectionId === this._connectionController.getActiveConnectionInstanceId();
-      const isBeingConnectedTo = this._connectionController.isConnecting()
-        && connectionId === this._connectionController.getConnectingInstanceId();
+    connectionIds.forEach((connectionId) => {
+      const isActiveConnection =
+        connectionId ===
+        this._connectionController.getActiveConnectionInstanceId();
+      const isBeingConnectedTo =
+        this._connectionController.isConnecting() &&
+        connectionId === this._connectionController.getConnectingInstanceId();
 
       let connectionExpandedState = isActiveConnection
         ? vscode.TreeItemCollapsibleState.Expanded
         : vscode.TreeItemCollapsibleState.Collapsed;
 
-      if (pastConnectionTreeItems[connectionId]
-        && !pastConnectionTreeItems[connectionId].isExpanded
+      if (
+        pastConnectionTreeItems[connectionId] &&
+        !pastConnectionTreeItems[connectionId].isExpanded
       ) {
         // Connection was manually collapsed while being active.
         connectionExpandedState = vscode.TreeItemCollapsibleState.Collapsed;
@@ -76,10 +80,11 @@ export default class MDBConnectionsTreeItem extends vscode.TreeItem
       );
     });
 
-    if (this._connectionController.isConnecting()
-      && !this._connectionController.getConnectionInstanceIds().includes(
-        this._connectionController.getConnectingInstanceId()
-      )
+    if (
+      this._connectionController.isConnecting() &&
+      !this._connectionController
+        .getConnectionInstanceIds()
+        .includes(this._connectionController.getConnectingInstanceId())
     ) {
       const notYetEstablishConnectionTreeItem = new vscode.TreeItem(
         this._connectionController.getConnectingInstanceId()

--- a/src/explorer/schemaTreeItem.ts
+++ b/src/explorer/schemaTreeItem.ts
@@ -11,7 +11,7 @@ const log = createLogger('tree view document list');
 
 const ITEM_LABEL = 'Schema';
 
-const FIELDS_TO_SHOW = 10;
+export const FIELDS_TO_SHOW = 15;
 
 class ShowAllFieldsTreeItem extends vscode.TreeItem {
   // This is the identifier we use to identify this tree item when a tree item

--- a/src/explorer/schemaTreeItem.ts
+++ b/src/explorer/schemaTreeItem.ts
@@ -140,11 +140,11 @@ export default class SchemaTreeItem extends vscode.TreeItem
               this._childrenCache.push(new FieldTreeItem(schema.fields[i]));
             }
 
-            // Add a clickable show more option when a schema has more fields
-            // than the default amount we show.
+            // Add a clickable show more option when a schema has more
+            // fields than the default amount we show.
             if (
               !this.hasClickedShowMoreFields &&
-              schema.fields.length >= FIELDS_TO_SHOW
+              schema.fields.length > FIELDS_TO_SHOW
             ) {
               this._childrenCache.push(
                 new ShowAllFieldsTreeItem(() => this.onShowMoreClicked())

--- a/src/explorer/schemaTreeItem.ts
+++ b/src/explorer/schemaTreeItem.ts
@@ -20,7 +20,7 @@ class ShowAllFieldsTreeItem extends vscode.TreeItem {
   onShowMoreClicked: () => void;
 
   constructor(showMore: () => void) {
-    super('Show all fields...', vscode.TreeItemCollapsibleState.None);
+    super('Show more fields...', vscode.TreeItemCollapsibleState.None);
 
     this.onShowMoreClicked = showMore;
   }
@@ -31,7 +31,7 @@ export default class SchemaTreeItem extends vscode.TreeItem
   _childrenCacheIsUpToDate = false;
   private _childrenCache: vscode.TreeItem[] = [];
 
-  contextValue = 'schemaTreeItem';
+  static contextValue = 'schemaTreeItem';
 
   collectionName: string;
   databaseName: string;
@@ -112,12 +112,11 @@ export default class SchemaTreeItem extends vscode.TreeItem
             return reject(`Unable to list documents: ${findError}`);
           }
 
-          this._childrenCacheIsUpToDate = true;
-
           if (!documents || documents.length === 0) {
             vscode.window.showInformationMessage(
               'No documents were found when attempting to parse schema.'
             );
+            this._childrenCacheIsUpToDate = true;
             this._childrenCache = [];
             return resolve(this._childrenCache);
           }
@@ -130,7 +129,9 @@ export default class SchemaTreeItem extends vscode.TreeItem
               return reject(`Unable to parse schema: ${parseError.message}`);
             }
 
+            this._childrenCacheIsUpToDate = true;
             this._childrenCache = [];
+
             const fieldsToShow = this.hasClickedShowMoreFields
               ? schema.fields.length
               : Math.min(FIELDS_TO_SHOW, schema.fields.length);

--- a/src/explorer/schemaTreeItem.ts
+++ b/src/explorer/schemaTreeItem.ts
@@ -1,0 +1,141 @@
+import * as vscode from 'vscode';
+
+const parseSchema = require('mongodb-schema');
+
+import { createLogger } from '../logging';
+import TreeItemParent from './treeItemParentInterface';
+import { MAX_DOCUMENTS_VISIBLE } from './documentListTreeItem';
+
+const ITEM_LABEL = 'Schema';
+
+const log = createLogger('tree view document list');
+
+export default class SchemaTreeItem extends vscode.TreeItem
+  implements TreeItemParent, vscode.TreeDataProvider<SchemaTreeItem> {
+  _childrenCacheIsUpToDate = false;
+  private _childrenCache: vscode.TreeItem[] = [];
+
+  contextValue = 'schemaTreeItem';
+
+  collectionName: string;
+  databaseName: string;
+
+  private _dataService: any;
+
+  isExpanded: boolean;
+
+  constructor(
+    collectionName: string,
+    databaseName: string,
+    dataService: any,
+    isExpanded: boolean,
+    existingCache: vscode.TreeItem[] | null
+  ) {
+    super(
+      ITEM_LABEL,
+      isExpanded
+        ? vscode.TreeItemCollapsibleState.Expanded
+        : vscode.TreeItemCollapsibleState.Collapsed
+    );
+
+    this.collectionName = collectionName;
+    this.databaseName = databaseName;
+
+    this._dataService = dataService;
+
+    this.isExpanded = isExpanded;
+
+    if (existingCache !== null) {
+      this._childrenCache = existingCache;
+      this._childrenCacheIsUpToDate = true;
+    }
+  }
+
+  get tooltip(): string {
+    return 'Derived Document Schema';
+  }
+
+  getTreeItem(element: SchemaTreeItem): SchemaTreeItem {
+    return element;
+  }
+
+  getChildren(): Thenable<any[]> {
+    if (!this.isExpanded) {
+      return Promise.resolve([]);
+    }
+
+    if (this._childrenCacheIsUpToDate) {
+      return Promise.resolve(this._childrenCache);
+    }
+
+    return new Promise((resolve, reject) => {
+      const namespace = `${this.databaseName}.${this.collectionName}`;
+
+      log.info(`parsing schema for namespace ${namespace}`);
+
+      this._childrenCacheIsUpToDate = true;
+
+      this._dataService.find(
+        namespace,
+        { /* No filter */ },
+        {
+          limit: MAX_DOCUMENTS_VISIBLE
+        },
+        (findError: Error | undefined, documents: []) => {
+          if (findError) {
+            vscode.window.showErrorMessage(`Unable to list documents: ${findError}`);
+            return reject(`Unable to list documents: ${findError}`);
+          }
+
+          this._childrenCacheIsUpToDate = true;
+
+          if (!documents || documents.length === 0) {
+            vscode.window.showInformationMessage('No documents were found when attempting to parse schema.');
+            this._childrenCache = [];
+            return resolve(this._childrenCache);
+          }
+
+          parseSchema(documents, (parseError: Error | undefined, schema) => {
+            if (parseError) {
+              vscode.window.showErrorMessage(`Unable to parse schema: ${parseError.message}`);
+              return reject(`Unable to parse schema: ${parseError.message}`);
+            }
+
+            console.log('Got schema.');
+            // console.log(JSON.stringify(schema, null, 2));
+            return resolve(this._childrenCache);
+          });
+        }
+      );
+    });
+  }
+
+  onShowMoreClicked(): void {
+    this._childrenCacheIsUpToDate = false;
+  }
+
+  onDidCollapse(): void {
+    this.isExpanded = false;
+    this._childrenCacheIsUpToDate = false;
+  }
+
+  onDidExpand(): Promise<boolean> {
+    this._childrenCacheIsUpToDate = false;
+    this.isExpanded = true;
+
+    return Promise.resolve(true);
+  }
+
+  resetCache(): void {
+    this._childrenCache = [];
+    this._childrenCacheIsUpToDate = false;
+  }
+
+  getChildrenCache(): vscode.TreeItem[] | null {
+    if (this._childrenCacheIsUpToDate) {
+      return this._childrenCache;
+    }
+
+    return null;
+  }
+}

--- a/src/explorer/schemaTreeItem.ts
+++ b/src/explorer/schemaTreeItem.ts
@@ -122,14 +122,15 @@ export default class SchemaTreeItem extends vscode.TreeItem
           }
 
           parseSchema(documents, (parseError: Error | undefined, schema) => {
+            this._childrenCacheIsUpToDate = true;
+
             if (parseError) {
               vscode.window.showErrorMessage(
                 `Unable to parse schema: ${parseError.message}`
               );
-              return reject(`Unable to parse schema: ${parseError.message}`);
+              return resolve([]);
             }
 
-            this._childrenCacheIsUpToDate = true;
             this._childrenCache = [];
 
             const fieldsToShow = this.hasClickedShowMoreFields

--- a/src/explorer/schemaTreeItem.ts
+++ b/src/explorer/schemaTreeItem.ts
@@ -1,6 +1,5 @@
 import * as vscode from 'vscode';
-
-const parseSchema = require('mongodb-schema');
+import parseSchema = require('mongodb-schema');
 
 import { createLogger } from '../logging';
 import TreeItemParent from './treeItemParentInterface';
@@ -31,7 +30,7 @@ export default class SchemaTreeItem extends vscode.TreeItem
   _childrenCacheIsUpToDate = false;
   private _childrenCache: vscode.TreeItem[] = [];
 
-  static contextValue = 'schemaTreeItem';
+  contextValue = 'schemaTreeItem';
 
   collectionName: string;
   databaseName: string;

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import path = require('path');
 
 import { runTests } from 'vscode-test';
 

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -15,15 +15,13 @@ import { StatusView } from '../../views';
 import MDBExtensionController from '../../mdbExtensionController';
 
 import { TestExtensionContext } from './stubs';
+import { TEST_DATABASE_URI } from './dbTestHelper';
 
-const testDatabaseURI = 'mongodb://localhost:27018';
 const testDatabaseInstanceId = 'localhost:27018';
 const testDatabaseURI2WithTimeout =
   'mongodb://shouldfail?connectTimeoutMS=1000&serverSelectionTimeoutMS=1000';
 
 suite('Connection Controller Test Suite', () => {
-  vscode.window.showInformationMessage('Starting tests...');
-
   const mockExtensionContext = new TestExtensionContext();
   const mockStorageController = new StorageController(mockExtensionContext);
 
@@ -35,14 +33,14 @@ suite('Connection Controller Test Suite', () => {
     sinon.restore();
   });
 
-  test('it connects to mongodb', function(done) {
+  test('it connects to mongodb', function (done) {
     const testConnectionController = new ConnectionController(
       new StatusView(mockExtensionContext),
       mockStorageController
     );
 
     testConnectionController
-      .addNewConnectionAndConnect(testDatabaseURI)
+      .addNewConnectionAndConnect(TEST_DATABASE_URI)
       .then((succesfullyConnected) => {
         assert(
           succesfullyConnected === true,
@@ -61,14 +59,14 @@ suite('Connection Controller Test Suite', () => {
       .then(done, done);
   });
 
-  test('"disconnect()" disconnects from the active connection', function(done) {
+  test('"disconnect()" disconnects from the active connection', function (done) {
     const testConnectionController = new ConnectionController(
       new StatusView(mockExtensionContext),
       mockStorageController
     );
 
     testConnectionController
-      .addNewConnectionAndConnect(testDatabaseURI)
+      .addNewConnectionAndConnect(TEST_DATABASE_URI)
       .then((succesfullyConnected) => {
         assert(
           succesfullyConnected === true,
@@ -100,7 +98,7 @@ suite('Connection Controller Test Suite', () => {
       });
   });
 
-  test('when the extension is deactivated, the active connection is disconnected', function(done) {
+  test('when the extension is deactivated, the active connection is disconnected', function (done) {
     const testConnectionController = new ConnectionController(
       new StatusView(mockExtensionContext),
       mockStorageController
@@ -112,7 +110,7 @@ suite('Connection Controller Test Suite', () => {
     );
 
     testConnectionController
-      .addNewConnectionAndConnect(testDatabaseURI)
+      .addNewConnectionAndConnect(TEST_DATABASE_URI)
       .then((succesfullyConnected) => {
         assert(
           succesfullyConnected === true,
@@ -161,7 +159,7 @@ suite('Connection Controller Test Suite', () => {
       .then(done, done);
   });
 
-  test('when adding a new connection it disconnects from the current connection', function(done) {
+  test('when adding a new connection it disconnects from the current connection', function (done) {
     const testConnectionController = new ConnectionController(
       new StatusView(mockExtensionContext),
       mockStorageController
@@ -185,7 +183,7 @@ suite('Connection Controller Test Suite', () => {
       .then(done, done);
   });
 
-  test('when adding a new connection it disconnects from the current connection', function(done) {
+  test('when adding a new connection it disconnects from the current connection', function (done) {
     const testConnectionController = new ConnectionController(
       new StatusView(mockExtensionContext),
       mockStorageController
@@ -193,7 +191,7 @@ suite('Connection Controller Test Suite', () => {
     this.timeout(2000);
 
     testConnectionController
-      .addNewConnectionAndConnect(testDatabaseURI)
+      .addNewConnectionAndConnect(TEST_DATABASE_URI)
       .then((succesfullyConnected) => {
         assert(
           succesfullyConnected,
@@ -220,7 +218,7 @@ suite('Connection Controller Test Suite', () => {
       });
   });
 
-  test('"connect()" failed when we are currently connecting', function(done) {
+  test('"connect()" failed when we are currently connecting', function (done) {
     const testConnectionController = new ConnectionController(
       new StatusView(mockExtensionContext),
       mockStorageController
@@ -232,7 +230,7 @@ suite('Connection Controller Test Suite', () => {
     sinon.replace(vscode.window, 'showErrorMessage', fakeVscodeErrorMessage);
 
     testConnectionController
-      .addNewConnectionAndConnect(testDatabaseURI)
+      .addNewConnectionAndConnect(TEST_DATABASE_URI)
       .then((connectSucceeded) => {
         assert(
           connectSucceeded === false,
@@ -247,7 +245,7 @@ suite('Connection Controller Test Suite', () => {
       .then(done, done);
   });
 
-  test('"connect()" failed when we are currently disconnecting', function(done) {
+  test('"connect()" failed when we are currently disconnecting', function (done) {
     const testConnectionController = new ConnectionController(
       new StatusView(mockExtensionContext),
       mockStorageController
@@ -259,7 +257,7 @@ suite('Connection Controller Test Suite', () => {
     sinon.replace(vscode.window, 'showErrorMessage', fakeVscodeErrorMessage);
 
     testConnectionController
-      .addNewConnectionAndConnect(testDatabaseURI)
+      .addNewConnectionAndConnect(TEST_DATABASE_URI)
       .then((connectSucceeded) => {
         assert(
           connectSucceeded === false,
@@ -274,7 +272,7 @@ suite('Connection Controller Test Suite', () => {
       .then(done, done);
   });
 
-  test('"disconnect()" fails when we are currently connecting', function(done) {
+  test('"disconnect()" fails when we are currently connecting', function (done) {
     const testConnectionController = new ConnectionController(
       new StatusView(mockExtensionContext),
       mockStorageController
@@ -302,7 +300,7 @@ suite('Connection Controller Test Suite', () => {
       .then(done, done);
   });
 
-  test('"disconnect()" fails when we are currently disconnecting', function(done) {
+  test('"disconnect()" fails when we are currently disconnecting', function (done) {
     const testConnectionController = new ConnectionController(
       new StatusView(mockExtensionContext),
       mockStorageController
@@ -330,7 +328,7 @@ suite('Connection Controller Test Suite', () => {
       .then(done, done);
   });
 
-  test('"connect()" should fire a CONNECTIONS_DID_CHANGE event', function(done) {
+  test('"connect()" should fire a CONNECTIONS_DID_CHANGE event', function (done) {
     const testConnectionController = new ConnectionController(
       new StatusView(mockExtensionContext),
       mockStorageController
@@ -346,9 +344,9 @@ suite('Connection Controller Test Suite', () => {
     );
 
     testConnectionController
-      .addNewConnectionAndConnect(testDatabaseURI)
+      .addNewConnectionAndConnect(TEST_DATABASE_URI)
       .then(() => {
-        setTimeout(function() {
+        setTimeout(function () {
           assert(
             didFireConnectionEvent === true,
             'Expected connection event to be fired.'
@@ -359,7 +357,7 @@ suite('Connection Controller Test Suite', () => {
   });
 
   const expectedTimesToFire = 3;
-  test(`"connect()" then "disconnect()" should fire the connections did change event ${expectedTimesToFire} times`, function(done) {
+  test(`"connect()" then "disconnect()" should fire the connections did change event ${expectedTimesToFire} times`, function (done) {
     const testConnectionController = new ConnectionController(
       new StatusView(mockExtensionContext),
       mockStorageController
@@ -375,10 +373,10 @@ suite('Connection Controller Test Suite', () => {
     );
 
     testConnectionController
-      .addNewConnectionAndConnect(testDatabaseURI)
+      .addNewConnectionAndConnect(TEST_DATABASE_URI)
       .then(() => {
         testConnectionController.disconnect().then(() => {
-          setTimeout(function() {
+          setTimeout(function () {
             assert(
               connectionEventFiredCount === expectedTimesToFire,
               `Expected connection event to be fired ${expectedTimesToFire} times, got ${connectionEventFiredCount}.`
@@ -389,7 +387,7 @@ suite('Connection Controller Test Suite', () => {
       });
   });
 
-  test('when there are no existing connections in the store and the connection controller loads connections', function() {
+  test('when there are no existing connections in the store and the connection controller loads connections', function () {
     const testExtensionContext = new TestExtensionContext();
     const testStorageController = new StorageController(testExtensionContext);
 
@@ -402,12 +400,12 @@ suite('Connection Controller Test Suite', () => {
     assert(
       Object.keys(testConnectionController.getConnections()).length === 0,
       `Expected connections to be 0 found ${
-        Object.keys(testConnectionController.getConnections()).length
+      Object.keys(testConnectionController.getConnections()).length
       }`
     );
   });
 
-  test('The connection model loads both global and workspace stored connection models', function() {
+  test('The connection model loads both global and workspace stored connection models', function () {
     const testExtensionContext = new TestExtensionContext();
     // Set existing connections.
     testExtensionContext.globalState.update(
@@ -437,7 +435,7 @@ suite('Connection Controller Test Suite', () => {
     assert(
       Object.keys(connections).length === 4,
       `Expected 4 connection configurations found ${
-        Object.keys(testConnectionController.getConnections()).length
+      Object.keys(testConnectionController.getConnections()).length
       }`
     );
     assert(
@@ -446,17 +444,17 @@ suite('Connection Controller Test Suite', () => {
     );
     assert(
       Object.keys(connections).includes('testWorkspaceConnectionModel2') ===
-        true,
+      true,
       "Expected connection configurations to include 'testWorkspaceConnectionModel2'"
     );
     assert(
       connections.testGlobalConnectionModel2.hostname ===
-        'testglobalconnectionmodel2driverurl',
+      'testglobalconnectionmodel2driverurl',
       "Expected connection configuration to include hostname 'testglobalconnectionmodel2driverurl'"
     );
   });
 
-  test('When a connection is added it is saved to the global store', async function() {
+  test('When a connection is added it is saved to the global store', async function () {
     const testExtensionContext = new TestExtensionContext();
     const testStorageController = new StorageController(testExtensionContext);
 
@@ -471,7 +469,9 @@ suite('Connection Controller Test Suite', () => {
       .getConfiguration('mdb.connectionSaving')
       .update('defaultConnectionSavingLocation', DefaultSavingLocations.Global);
 
-    await testConnectionController.addNewConnectionAndConnect(testDatabaseURI);
+    await testConnectionController.addNewConnectionAndConnect(
+      TEST_DATABASE_URI
+    );
 
     const globalStoreConnections = testStorageController.get(
       StorageVariables.GLOBAL_CONNECTION_STRINGS
@@ -479,7 +479,7 @@ suite('Connection Controller Test Suite', () => {
     assert(
       Object.keys(globalStoreConnections).length === 1,
       `Expected global store connections to have 1 connection found ${
-        Object.keys(globalStoreConnections).length
+      Object.keys(globalStoreConnections).length
       }`
     );
     assert(
@@ -498,7 +498,7 @@ suite('Connection Controller Test Suite', () => {
     );
   });
 
-  test('When a connection is added it is saved to the workspace store', async function() {
+  test('When a connection is added it is saved to the workspace store', async function () {
     const testExtensionContext = new TestExtensionContext();
     const testStorageController = new StorageController(testExtensionContext);
 
@@ -516,7 +516,9 @@ suite('Connection Controller Test Suite', () => {
         DefaultSavingLocations.Workspace
       );
 
-    await testConnectionController.addNewConnectionAndConnect(testDatabaseURI);
+    await testConnectionController.addNewConnectionAndConnect(
+      TEST_DATABASE_URI
+    );
 
     const workspaceStoreConnections = testStorageController.get(
       StorageVariables.WORKSPACE_CONNECTION_STRINGS,
@@ -526,7 +528,7 @@ suite('Connection Controller Test Suite', () => {
     assert(
       Object.keys(workspaceStoreConnections).length === 1,
       `Expected workspace store connections to have 1 connection found ${
-        Object.keys(workspaceStoreConnections).length
+      Object.keys(workspaceStoreConnections).length
       }`
     );
     assert(
@@ -545,7 +547,7 @@ suite('Connection Controller Test Suite', () => {
     );
   });
 
-  test('A saved connection can be loaded and connected to', function(done) {
+  test('A saved connection can be loaded and connected to', function (done) {
     const testExtensionContext = new TestExtensionContext();
     const testStorageController = new StorageController(testExtensionContext);
 
@@ -564,7 +566,7 @@ suite('Connection Controller Test Suite', () => {
       )
       .then(() => {
         testConnectionController
-          .addNewConnectionAndConnect(testDatabaseURI)
+          .addNewConnectionAndConnect(TEST_DATABASE_URI)
           .then(() => {
             const workspaceStoreConnections = testStorageController.get(
               StorageVariables.WORKSPACE_CONNECTION_STRINGS,
@@ -573,7 +575,7 @@ suite('Connection Controller Test Suite', () => {
             assert(
               Object.keys(workspaceStoreConnections).length === 1,
               `Expected workspace store connections to have 1 connection found ${
-                Object.keys(workspaceStoreConnections).length
+              Object.keys(workspaceStoreConnections).length
               }`
             );
 
@@ -581,7 +583,7 @@ suite('Connection Controller Test Suite', () => {
               testConnectionController.clearAllConnections();
               assert(
                 testConnectionController.getConnectionInstanceIds().length ===
-                  0,
+                0,
                 'Expected no connection configs.'
               );
 
@@ -589,9 +591,9 @@ suite('Connection Controller Test Suite', () => {
               testConnectionController.loadSavedConnections();
               assert(
                 testConnectionController.getConnectionInstanceIds().length ===
-                  1,
+                1,
                 `Expected 1 connection config, found ${
-                  testConnectionController.getConnectionInstanceIds().length
+                testConnectionController.getConnectionInstanceIds().length
                 }.`
               );
 
@@ -616,7 +618,7 @@ suite('Connection Controller Test Suite', () => {
       });
   });
 
-  test('"getConnectionStringFromConnectionId" returns the driver uri of a connection', function(done) {
+  test('"getConnectionStringFromConnectionId" returns the driver uri of a connection', function (done) {
     const testExtensionContext = new TestExtensionContext();
     const testStorageController = new StorageController(testExtensionContext);
 
@@ -631,7 +633,7 @@ suite('Connection Controller Test Suite', () => {
       'mongodb://localhost:27018/?readPreference=primary&appname=mongodb-vscode%200.0.1&ssl=false';
 
     testConnectionController
-      .addNewConnectionAndConnect(testDatabaseURI)
+      .addNewConnectionAndConnect(TEST_DATABASE_URI)
       .then(() => {
         const testDriverUri = testConnectionController.getConnectionStringFromConnectionId(
           'localhost:27018'
@@ -645,7 +647,7 @@ suite('Connection Controller Test Suite', () => {
       .then(done, done);
   });
 
-  test('When a connection is added and the user has set it to not save on default it is not saved', function(done) {
+  test('When a connection is added and the user has set it to not save on default it is not saved', function (done) {
     const testExtensionContext = new TestExtensionContext();
     const testStorageController = new StorageController(testExtensionContext);
 
@@ -664,7 +666,7 @@ suite('Connection Controller Test Suite', () => {
       )
       .then(() => {
         testConnectionController
-          .addNewConnectionAndConnect(testDatabaseURI)
+          .addNewConnectionAndConnect(TEST_DATABASE_URI)
           .then(() => {
             const objectString = JSON.stringify(undefined);
             const globalStoreConnections = testStorageController.get(
@@ -691,7 +693,7 @@ suite('Connection Controller Test Suite', () => {
       }, done);
   });
 
-  test('When a connection is removed it is also removed from workspace storage', function(done) {
+  test('When a connection is removed it is also removed from workspace storage', function (done) {
     const testExtensionContext = new TestExtensionContext();
     const testStorageController = new StorageController(testExtensionContext);
 
@@ -710,7 +712,7 @@ suite('Connection Controller Test Suite', () => {
       )
       .then(() => {
         testConnectionController
-          .addNewConnectionAndConnect(testDatabaseURI)
+          .addNewConnectionAndConnect(TEST_DATABASE_URI)
           .then(() => {
             const workspaceStoreConnections = testStorageController.get(
               StorageVariables.WORKSPACE_CONNECTION_STRINGS,
@@ -720,7 +722,7 @@ suite('Connection Controller Test Suite', () => {
             assert(
               Object.keys(workspaceStoreConnections).length === 1,
               `Expected workspace store connections to have 1 connection found ${
-                Object.keys(workspaceStoreConnections).length
+              Object.keys(workspaceStoreConnections).length
               }`
             );
 
@@ -735,7 +737,7 @@ suite('Connection Controller Test Suite', () => {
             assert(
               Object.keys(postWorkspaceStoreConnections).length === 0,
               `Expected workspace store connections to have 0 connections found ${
-                Object.keys(postWorkspaceStoreConnections).length
+              Object.keys(postWorkspaceStoreConnections).length
               }`
             );
           })
@@ -743,7 +745,7 @@ suite('Connection Controller Test Suite', () => {
       });
   });
 
-  test('When a connection is removed it is also removed from global storage', async function() {
+  test('When a connection is removed it is also removed from global storage', async function () {
     const testExtensionContext = new TestExtensionContext();
     const testStorageController = new StorageController(testExtensionContext);
 
@@ -758,7 +760,9 @@ suite('Connection Controller Test Suite', () => {
       .getConfiguration('mdb.connectionSaving')
       .update('defaultConnectionSavingLocation', DefaultSavingLocations.Global);
 
-    await testConnectionController.addNewConnectionAndConnect(testDatabaseURI);
+    await testConnectionController.addNewConnectionAndConnect(
+      TEST_DATABASE_URI
+    );
     const globalStoreConnections = testStorageController.get(
       StorageVariables.GLOBAL_CONNECTION_STRINGS
     );
@@ -766,7 +770,7 @@ suite('Connection Controller Test Suite', () => {
     assert(
       Object.keys(globalStoreConnections).length === 1,
       `Expected workspace store connections to have 1 connection found ${
-        Object.keys(globalStoreConnections).length
+      Object.keys(globalStoreConnections).length
       }`
     );
 
@@ -778,7 +782,7 @@ suite('Connection Controller Test Suite', () => {
     assert(
       Object.keys(postGlobalStoreConnections).length === 0,
       `Expected global store connections to have 0 connections found ${
-        Object.keys(postGlobalStoreConnections).length
+      Object.keys(postGlobalStoreConnections).length
       }`
     );
   });

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import { afterEach } from 'mocha';
-const sinon = require('sinon');
+import * as sinon from 'sinon';
 
 import ConnectionController, {
   DataServiceEventTypes
@@ -399,9 +399,7 @@ suite('Connection Controller Test Suite', () => {
     testConnectionController.loadSavedConnections();
     assert(
       Object.keys(testConnectionController.getConnections()).length === 0,
-      `Expected connections to be 0 found ${
-      Object.keys(testConnectionController.getConnections()).length
-      }`
+      `Expected connections to be 0 found ${Object.keys(testConnectionController.getConnections()).length}`
     );
   });
 
@@ -434,9 +432,7 @@ suite('Connection Controller Test Suite', () => {
     const connections = testConnectionController.getConnections();
     assert(
       Object.keys(connections).length === 4,
-      `Expected 4 connection configurations found ${
-      Object.keys(testConnectionController.getConnections()).length
-      }`
+      `Expected 4 connection configurations found ${Object.keys(testConnectionController.getConnections()).length}`
     );
     assert(
       Object.keys(connections).includes('testGlobalConnectionModel2') === true,
@@ -478,9 +474,7 @@ suite('Connection Controller Test Suite', () => {
     );
     assert(
       Object.keys(globalStoreConnections).length === 1,
-      `Expected global store connections to have 1 connection found ${
-      Object.keys(globalStoreConnections).length
-      }`
+      `Expected global store connections to have 1 connection found ${Object.keys(globalStoreConnections).length}`
     );
     assert(
       Object.keys(globalStoreConnections).includes(testDatabaseInstanceId),
@@ -527,9 +521,7 @@ suite('Connection Controller Test Suite', () => {
 
     assert(
       Object.keys(workspaceStoreConnections).length === 1,
-      `Expected workspace store connections to have 1 connection found ${
-      Object.keys(workspaceStoreConnections).length
-      }`
+      `Expected workspace store connections to have 1 connection found ${Object.keys(workspaceStoreConnections).length}`
     );
     assert(
       Object.keys(workspaceStoreConnections).includes(testDatabaseInstanceId),
@@ -574,9 +566,7 @@ suite('Connection Controller Test Suite', () => {
             );
             assert(
               Object.keys(workspaceStoreConnections).length === 1,
-              `Expected workspace store connections to have 1 connection found ${
-              Object.keys(workspaceStoreConnections).length
-              }`
+              `Expected workspace store connections to have 1 connection found ${Object.keys(workspaceStoreConnections).length}`
             );
 
             testConnectionController.disconnect().then(() => {
@@ -592,9 +582,7 @@ suite('Connection Controller Test Suite', () => {
               assert(
                 testConnectionController.getConnectionInstanceIds().length ===
                 1,
-                `Expected 1 connection config, found ${
-                testConnectionController.getConnectionInstanceIds().length
-                }.`
+                `Expected 1 connection config, found ${testConnectionController.getConnectionInstanceIds().length}.`
               );
 
               testConnectionController
@@ -721,9 +709,7 @@ suite('Connection Controller Test Suite', () => {
 
             assert(
               Object.keys(workspaceStoreConnections).length === 1,
-              `Expected workspace store connections to have 1 connection found ${
-              Object.keys(workspaceStoreConnections).length
-              }`
+              `Expected workspace store connections to have 1 connection found ${Object.keys(workspaceStoreConnections).length}`
             );
 
             testConnectionController.removeConnectionConfig(
@@ -736,9 +722,7 @@ suite('Connection Controller Test Suite', () => {
             );
             assert(
               Object.keys(postWorkspaceStoreConnections).length === 0,
-              `Expected workspace store connections to have 0 connections found ${
-              Object.keys(postWorkspaceStoreConnections).length
-              }`
+              `Expected workspace store connections to have 0 connections found ${Object.keys(postWorkspaceStoreConnections).length}`
             );
           })
           .then(done, done);
@@ -769,9 +753,7 @@ suite('Connection Controller Test Suite', () => {
 
     assert(
       Object.keys(globalStoreConnections).length === 1,
-      `Expected workspace store connections to have 1 connection found ${
-      Object.keys(globalStoreConnections).length
-      }`
+      `Expected workspace store connections to have 1 connection found ${Object.keys(globalStoreConnections).length}`
     );
 
     testConnectionController.removeConnectionConfig(testDatabaseInstanceId);
@@ -781,9 +763,7 @@ suite('Connection Controller Test Suite', () => {
     );
     assert(
       Object.keys(postGlobalStoreConnections).length === 0,
-      `Expected global store connections to have 0 connections found ${
-      Object.keys(postGlobalStoreConnections).length
-      }`
+      `Expected global store connections to have 0 connections found ${Object.keys(postGlobalStoreConnections).length}`
     );
   });
 });

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -33,7 +33,7 @@ suite('Connection Controller Test Suite', () => {
     sinon.restore();
   });
 
-  test('it connects to mongodb', function (done) {
+  test('it connects to mongodb', (done) => {
     const testConnectionController = new ConnectionController(
       new StatusView(mockExtensionContext),
       mockStorageController
@@ -59,7 +59,7 @@ suite('Connection Controller Test Suite', () => {
       .then(done, done);
   });
 
-  test('"disconnect()" disconnects from the active connection', function (done) {
+  test('"disconnect()" disconnects from the active connection', (done) => {
     const testConnectionController = new ConnectionController(
       new StatusView(mockExtensionContext),
       mockStorageController
@@ -98,7 +98,7 @@ suite('Connection Controller Test Suite', () => {
       });
   });
 
-  test('when the extension is deactivated, the active connection is disconnected', function (done) {
+  test('when the extension is deactivated, the active connection is disconnected', (done) => {
     const testConnectionController = new ConnectionController(
       new StatusView(mockExtensionContext),
       mockStorageController
@@ -159,7 +159,7 @@ suite('Connection Controller Test Suite', () => {
       .then(done, done);
   });
 
-  test('when adding a new connection it disconnects from the current connection', function (done) {
+  test('when adding a new connection it disconnects from the current connection', (done) => {
     const testConnectionController = new ConnectionController(
       new StatusView(mockExtensionContext),
       mockStorageController
@@ -183,12 +183,11 @@ suite('Connection Controller Test Suite', () => {
       .then(done, done);
   });
 
-  test('when adding a new connection it disconnects from the current connection', function (done) {
+  test('when adding a new connection it disconnects from the current connection', (done) => {
     const testConnectionController = new ConnectionController(
       new StatusView(mockExtensionContext),
       mockStorageController
     );
-    this.timeout(2000);
 
     testConnectionController
       .addNewConnectionAndConnect(TEST_DATABASE_URI)
@@ -218,7 +217,7 @@ suite('Connection Controller Test Suite', () => {
       });
   });
 
-  test('"connect()" failed when we are currently connecting', function (done) {
+  test('"connect()" failed when we are currently connecting', (done) => {
     const testConnectionController = new ConnectionController(
       new StatusView(mockExtensionContext),
       mockStorageController
@@ -245,7 +244,7 @@ suite('Connection Controller Test Suite', () => {
       .then(done, done);
   });
 
-  test('"connect()" failed when we are currently disconnecting', function (done) {
+  test('"connect()" failed when we are currently disconnecting', (done) => {
     const testConnectionController = new ConnectionController(
       new StatusView(mockExtensionContext),
       mockStorageController
@@ -272,7 +271,7 @@ suite('Connection Controller Test Suite', () => {
       .then(done, done);
   });
 
-  test('"disconnect()" fails when we are currently connecting', function (done) {
+  test('"disconnect()" fails when we are currently connecting', (done) => {
     const testConnectionController = new ConnectionController(
       new StatusView(mockExtensionContext),
       mockStorageController
@@ -300,7 +299,7 @@ suite('Connection Controller Test Suite', () => {
       .then(done, done);
   });
 
-  test('"disconnect()" fails when we are currently disconnecting', function (done) {
+  test('"disconnect()" fails when we are currently disconnecting', (done) => {
     const testConnectionController = new ConnectionController(
       new StatusView(mockExtensionContext),
       mockStorageController
@@ -328,7 +327,7 @@ suite('Connection Controller Test Suite', () => {
       .then(done, done);
   });
 
-  test('"connect()" should fire a CONNECTIONS_DID_CHANGE event', function (done) {
+  test('"connect()" should fire a CONNECTIONS_DID_CHANGE event', (done) => {
     const testConnectionController = new ConnectionController(
       new StatusView(mockExtensionContext),
       mockStorageController
@@ -346,7 +345,7 @@ suite('Connection Controller Test Suite', () => {
     testConnectionController
       .addNewConnectionAndConnect(TEST_DATABASE_URI)
       .then(() => {
-        setTimeout(function () {
+        setTimeout(() => {
           assert(
             didFireConnectionEvent === true,
             'Expected connection event to be fired.'
@@ -357,7 +356,7 @@ suite('Connection Controller Test Suite', () => {
   });
 
   const expectedTimesToFire = 3;
-  test(`"connect()" then "disconnect()" should fire the connections did change event ${expectedTimesToFire} times`, function (done) {
+  test(`"connect()" then "disconnect()" should fire the connections did change event ${expectedTimesToFire} times`, (done) => {
     const testConnectionController = new ConnectionController(
       new StatusView(mockExtensionContext),
       mockStorageController
@@ -376,7 +375,7 @@ suite('Connection Controller Test Suite', () => {
       .addNewConnectionAndConnect(TEST_DATABASE_URI)
       .then(() => {
         testConnectionController.disconnect().then(() => {
-          setTimeout(function () {
+          setTimeout(() => {
             assert(
               connectionEventFiredCount === expectedTimesToFire,
               `Expected connection event to be fired ${expectedTimesToFire} times, got ${connectionEventFiredCount}.`
@@ -387,7 +386,7 @@ suite('Connection Controller Test Suite', () => {
       });
   });
 
-  test('when there are no existing connections in the store and the connection controller loads connections', function () {
+  test('when there are no existing connections in the store and the connection controller loads connections', () => {
     const testExtensionContext = new TestExtensionContext();
     const testStorageController = new StorageController(testExtensionContext);
 
@@ -403,7 +402,7 @@ suite('Connection Controller Test Suite', () => {
     );
   });
 
-  test('The connection model loads both global and workspace stored connection models', function () {
+  test('The connection model loads both global and workspace stored connection models', () => {
     const testExtensionContext = new TestExtensionContext();
     // Set existing connections.
     testExtensionContext.globalState.update(
@@ -450,7 +449,7 @@ suite('Connection Controller Test Suite', () => {
     );
   });
 
-  test('When a connection is added it is saved to the global store', async function () {
+  test('When a connection is added it is saved to the global store', async () => {
     const testExtensionContext = new TestExtensionContext();
     const testStorageController = new StorageController(testExtensionContext);
 
@@ -492,7 +491,7 @@ suite('Connection Controller Test Suite', () => {
     );
   });
 
-  test('When a connection is added it is saved to the workspace store', async function () {
+  test('When a connection is added it is saved to the workspace store', async () => {
     const testExtensionContext = new TestExtensionContext();
     const testStorageController = new StorageController(testExtensionContext);
 
@@ -539,7 +538,7 @@ suite('Connection Controller Test Suite', () => {
     );
   });
 
-  test('A saved connection can be loaded and connected to', function (done) {
+  test('A saved connection can be loaded and connected to', (done) => {
     const testExtensionContext = new TestExtensionContext();
     const testStorageController = new StorageController(testExtensionContext);
 
@@ -606,7 +605,7 @@ suite('Connection Controller Test Suite', () => {
       });
   });
 
-  test('"getConnectionStringFromConnectionId" returns the driver uri of a connection', function (done) {
+  test('"getConnectionStringFromConnectionId" returns the driver uri of a connection', (done) => {
     const testExtensionContext = new TestExtensionContext();
     const testStorageController = new StorageController(testExtensionContext);
 
@@ -635,7 +634,7 @@ suite('Connection Controller Test Suite', () => {
       .then(done, done);
   });
 
-  test('When a connection is added and the user has set it to not save on default it is not saved', function (done) {
+  test('When a connection is added and the user has set it to not save on default it is not saved', (done) => {
     const testExtensionContext = new TestExtensionContext();
     const testStorageController = new StorageController(testExtensionContext);
 
@@ -681,7 +680,7 @@ suite('Connection Controller Test Suite', () => {
       }, done);
   });
 
-  test('When a connection is removed it is also removed from workspace storage', function (done) {
+  test('When a connection is removed it is also removed from workspace storage', (done) => {
     const testExtensionContext = new TestExtensionContext();
     const testStorageController = new StorageController(testExtensionContext);
 
@@ -729,7 +728,7 @@ suite('Connection Controller Test Suite', () => {
       });
   });
 
-  test('When a connection is removed it is also removed from global storage', async function () {
+  test('When a connection is removed it is also removed from global storage', async () => {
     const testExtensionContext = new TestExtensionContext();
     const testStorageController = new StorageController(testExtensionContext);
 

--- a/src/test/suite/dbTestHelper.ts
+++ b/src/test/suite/dbTestHelper.ts
@@ -1,5 +1,5 @@
-const Connection = require('mongodb-connection-model/lib/model');
-const DataService = require('mongodb-data-service');
+import * as Connection from 'mongodb-connection-model/lib/model';
+import * as DataService from 'mongodb-data-service';
 
 export const TEST_DATABASE_URI = 'mongodb://localhost:27018';
 
@@ -65,7 +65,7 @@ export const seedDataAndCreateDataService = (
   });
 };
 
-export const cleanup = (): Promise<void> => {
+export const cleanupTestDB = (): Promise<void> => {
   return new Promise((resolve, reject) => {
     const newConnection = new DataService(testDatabaseConnectionModel);
     newConnection.connect((connectError: Error | undefined) => {

--- a/src/test/suite/dbTestHelper.ts
+++ b/src/test/suite/dbTestHelper.ts
@@ -1,0 +1,86 @@
+const Connection = require('mongodb-connection-model/lib/model');
+const DataService = require('mongodb-data-service');
+
+export const TEST_DATABASE_URI = 'mongodb://localhost:27018';
+
+export const TEST_DB_NAME = 'vscodeTestDatabaseAA';
+
+let testDatabaseConnectionModel;
+
+// Note: be sure to disconnect from the dataservice to free up connections.
+export const seedDataAndCreateDataService = (
+  collectionName: string,
+  documentsArray: any[]
+): Promise<any> => {
+  return new Promise((resolve, reject) => {
+    if (testDatabaseConnectionModel) {
+      const newConnection = new DataService(testDatabaseConnectionModel);
+      newConnection.connect((connectError: Error | undefined) => {
+        if (connectError) {
+          return reject(connectError);
+        }
+
+        newConnection.insertMany(
+          `${TEST_DB_NAME}.${collectionName}`,
+          documentsArray,
+          {},
+          (insertManyError: Error | undefined) => {
+            if (insertManyError) {
+              return reject(insertManyError);
+            }
+            return resolve(newConnection);
+          }
+        );
+      });
+    } else {
+      Connection.from(
+        TEST_DATABASE_URI,
+        (connectionModelError: Error | undefined, newConnectionConfig: any) => {
+          if (connectionModelError) {
+            return reject(connectionModelError);
+          }
+
+          testDatabaseConnectionModel = newConnectionConfig;
+          const newConnection = new DataService(newConnectionConfig);
+          newConnection.connect((connectError: Error | undefined) => {
+            if (connectError) {
+              return reject(connectError);
+            }
+
+            newConnection.insertMany(
+              `${TEST_DB_NAME}.${collectionName}`,
+              documentsArray,
+              {},
+              (insertManyError: Error | undefined) => {
+                if (insertManyError) {
+                  return reject(insertManyError);
+                }
+
+                return resolve(newConnection);
+              }
+            );
+          });
+        });
+    }
+  });
+};
+
+export const cleanup = (): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    const newConnection = new DataService(testDatabaseConnectionModel);
+    newConnection.connect((connectError: Error | undefined) => {
+      if (connectError) {
+        return reject(connectError);
+      }
+
+      newConnection.dropDatabase(TEST_DB_NAME,
+        (dropError: Error | undefined) => {
+          if (dropError) {
+            return reject(dropError);
+          }
+          newConnection.disconnect(() => resolve());
+        }
+      );
+    });
+  });
+};

--- a/src/test/suite/dbTestHelper.ts
+++ b/src/test/suite/dbTestHelper.ts
@@ -1,5 +1,5 @@
-import * as Connection from 'mongodb-connection-model/lib/model';
-import * as DataService from 'mongodb-data-service';
+import Connection = require('mongodb-connection-model/lib/model');
+import DataService = require('mongodb-data-service');
 
 export const TEST_DATABASE_URI = 'mongodb://localhost:27018';
 
@@ -60,7 +60,8 @@ export const seedDataAndCreateDataService = (
               }
             );
           });
-        });
+        }
+      );
     }
   });
 };
@@ -73,7 +74,8 @@ export const cleanupTestDB = (): Promise<void> => {
         return reject(connectError);
       }
 
-      newConnection.dropDatabase(TEST_DB_NAME,
+      newConnection.dropDatabase(
+        TEST_DB_NAME,
         (dropError: Error | undefined) => {
           if (dropError) {
             return reject(dropError);

--- a/src/test/suite/editors/collectionDocumentsProvider.test.ts
+++ b/src/test/suite/editors/collectionDocumentsProvider.test.ts
@@ -22,7 +22,7 @@ const mockDocumentsAsJsonString = `[
 ]`;
 
 suite('Collection Documents Provider Test Suite', () => {
-  afterEach(function () {
+  afterEach(() => {
     sinon.restore();
   });
 

--- a/src/test/suite/editors/collectionDocumentsProvider.test.ts
+++ b/src/test/suite/editors/collectionDocumentsProvider.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import { afterEach } from 'mocha';
-const sinon = require('sinon');
+import * as sinon from 'sinon';
 
 import CollectionDocumentsProvider from '../../../editors/collectionDocumentsProvider';
 import ConnectionController from '../../../connectionController';

--- a/src/test/suite/editors/editorsController.test.ts
+++ b/src/test/suite/editors/editorsController.test.ts
@@ -1,11 +1,8 @@
 import * as assert from 'assert';
-import * as vscode from 'vscode';
 
 import { EditorsController } from '../../../editors';
 
 suite('Editors Controller Test Suite', () => {
-  vscode.window.showInformationMessage('Starting tests...');
-
   test('getViewCollectionDocumentsUri builds a uri from the namespace and connection info', function () {
     const testOpId = '100011011101110011';
     const testNamespace = 'myFavoriteNamespace';

--- a/src/test/suite/editors/editorsController.test.ts
+++ b/src/test/suite/editors/editorsController.test.ts
@@ -3,7 +3,7 @@ import * as assert from 'assert';
 import { EditorsController } from '../../../editors';
 
 suite('Editors Controller Test Suite', () => {
-  test('getViewCollectionDocumentsUri builds a uri from the namespace and connection info', function () {
+  test('getViewCollectionDocumentsUri builds a uri from the namespace and connection info', () => {
     const testOpId = '100011011101110011';
     const testNamespace = 'myFavoriteNamespace';
     const testConnectionId = 'alienSateliteConnection';

--- a/src/test/suite/explorer/collectionTreeItem.test.ts
+++ b/src/test/suite/explorer/collectionTreeItem.test.ts
@@ -6,11 +6,21 @@ import CollectionTreeItem from '../../../explorer/collectionTreeItem';
 import { CollectionTypes } from '../../../explorer/documentListTreeItem';
 
 suite('CollectionTreeItem Test Suite', () => {
-  test('its context value should be in the package json', function() {
+  test('its context value should be in the package json', function () {
     let registeredCommandInPackageJson = false;
 
+    const testCollectionTreeItem = new CollectionTreeItem(
+      {
+        name: 'mock_collection_name_1',
+        type: CollectionTypes.collection
+      },
+      'mock_db_name',
+      'imaginary data service',
+      false
+    );
+
     contributes.menus['view/item/context'].forEach((contextItem) => {
-      if (contextItem.when.includes(CollectionTreeItem.contextValue)) {
+      if (contextItem.when.includes(testCollectionTreeItem.contextValue)) {
         registeredCommandInPackageJson = true;
       }
     });
@@ -21,7 +31,7 @@ suite('CollectionTreeItem Test Suite', () => {
     );
   });
 
-  test('when expanded shows a documents folder and schema folder', function(done) {
+  test('when expanded shows a documents folder and schema folder', function (done) {
     const testCollectionTreeItem = new CollectionTreeItem(
       {
         name: 'mock_collection_name_1',

--- a/src/test/suite/explorer/collectionTreeItem.test.ts
+++ b/src/test/suite/explorer/collectionTreeItem.test.ts
@@ -1,7 +1,6 @@
 import * as assert from 'assert';
-import path = require('path');
 
-const { contributes } = require(path.resolve(__dirname, '../../../../package.json'));
+const { contributes } = require('../../../../package.json');
 
 import CollectionTreeItem from '../../../explorer/collectionTreeItem';
 import { CollectionTypes } from '../../../explorer/documentListTreeItem';

--- a/src/test/suite/explorer/collectionTreeItem.test.ts
+++ b/src/test/suite/explorer/collectionTreeItem.test.ts
@@ -6,10 +6,10 @@ import CollectionTreeItem from '../../../explorer/collectionTreeItem';
 import { CollectionTypes } from '../../../explorer/documentListTreeItem';
 
 suite('CollectionTreeItem Test Suite', () => {
-  test('its context value should be in the package json', function () {
+  test('its context value should be in the package json', function() {
     let registeredCommandInPackageJson = false;
 
-    contributes.menus['view/item/context'].forEach(contextItem => {
+    contributes.menus['view/item/context'].forEach((contextItem) => {
       if (contextItem.when.includes(CollectionTreeItem.contextValue)) {
         registeredCommandInPackageJson = true;
       }
@@ -21,7 +21,7 @@ suite('CollectionTreeItem Test Suite', () => {
     );
   });
 
-  test('when expanded shows a documents folder and schema folder', function (done) {
+  test('when expanded shows a documents folder and schema folder', function(done) {
     const testCollectionTreeItem = new CollectionTreeItem(
       {
         name: 'mock_collection_name_1',
@@ -34,7 +34,7 @@ suite('CollectionTreeItem Test Suite', () => {
 
     testCollectionTreeItem
       .getChildren()
-      .then(children => {
+      .then((children) => {
         assert(
           children.length === 2,
           `Expected 2 children to be returned, found ${children.length}`

--- a/src/test/suite/explorer/collectionTreeItem.test.ts
+++ b/src/test/suite/explorer/collectionTreeItem.test.ts
@@ -6,7 +6,7 @@ import CollectionTreeItem from '../../../explorer/collectionTreeItem';
 import { CollectionTypes } from '../../../explorer/documentListTreeItem';
 
 suite('CollectionTreeItem Test Suite', () => {
-  test('its context value should be in the package json', function () {
+  test('its context value should be in the package json', () => {
     let registeredCommandInPackageJson = false;
 
     const testCollectionTreeItem = new CollectionTreeItem(
@@ -31,7 +31,7 @@ suite('CollectionTreeItem Test Suite', () => {
     );
   });
 
-  test('when expanded shows a documents folder and schema folder', function (done) {
+  test('when expanded shows a documents folder and schema folder', (done) => {
     const testCollectionTreeItem = new CollectionTreeItem(
       {
         name: 'mock_collection_name_1',

--- a/src/test/suite/explorer/collectionTreeItem.test.ts
+++ b/src/test/suite/explorer/collectionTreeItem.test.ts
@@ -1,225 +1,54 @@
 import * as assert from 'assert';
-import * as vscode from 'vscode';
+import path = require('path');
 
-import CollectionTreeItem, {
-  CollectionTypes,
-  MAX_DOCUMENTS_VISIBLE
-} from '../../../explorer/collectionTreeItem';
+const { contributes } = require(path.resolve(__dirname, '../../../../package.json'));
 
-import { DataServiceStub, mockDocuments } from '../stubs';
+import CollectionTreeItem from '../../../explorer/collectionTreeItem';
+import { CollectionTypes } from '../../../explorer/documentListTreeItem';
 
 suite('CollectionTreeItem Test Suite', () => {
-  vscode.window.showInformationMessage('Starting tests...');
+  test('its context value should be in the package json', function () {
+    let registeredCommandInPackageJson = false;
 
-  test('when the "show more" click handler function is called it increases the amount of documents to show by 10', function () {
-    const testCollectionTreeItem = new CollectionTreeItem(
-      'collectionName',
-      'databaseName',
-      'not_real_dataservice',
-      false,
-      [],
-      MAX_DOCUMENTS_VISIBLE
-    );
+    contributes.menus['view/item/context'].forEach(contextItem => {
+      if (contextItem.when.includes(CollectionTreeItem.contextValue)) {
+        registeredCommandInPackageJson = true;
+      }
+    });
 
-    const maxDocumentsToShow = testCollectionTreeItem.getMaxDocumentsToShow();
     assert(
-      maxDocumentsToShow === 10,
-      `Expected max documents to show to be 20, found ${maxDocumentsToShow}.`
-    );
-
-    testCollectionTreeItem.onShowMoreClicked();
-
-    const newMaxDocumentsToShow = testCollectionTreeItem.getMaxDocumentsToShow();
-    assert(
-      newMaxDocumentsToShow === 20,
-      `Expected max documents to show to be 20, found ${newMaxDocumentsToShow}.`
+      registeredCommandInPackageJson,
+      'Expected collection tree item to be registered with a command in package json'
     );
   });
 
-  test('when not expanded it does not show documents', function (done) {
-    const testCollectionTreeItem = new CollectionTreeItem(
-      { name: 'mock_collection_name', type: CollectionTypes.collection },
-      'mock_db_name',
-      new DataServiceStub(),
-      false,
-      [],
-      MAX_DOCUMENTS_VISIBLE
-    );
-
-    testCollectionTreeItem
-      .getChildren()
-      .then(collections => {
-        assert(
-          collections.length === 0,
-          `Expected no collections to be returned, found ${collections.length}`
-        );
-      })
-      .then(done, done);
-  });
-
-  test('when expanded shows the documents of a collection in tree', function (done) {
+  test('when expanded shows a documents folder and schema folder', function (done) {
     const testCollectionTreeItem = new CollectionTreeItem(
       {
         name: 'mock_collection_name_1',
         type: CollectionTypes.collection
       },
       'mock_db_name',
-      new DataServiceStub(),
-      false,
-      [],
-      MAX_DOCUMENTS_VISIBLE
+      'imaginary data service',
+      false
     );
-    testCollectionTreeItem.onDidExpand();
 
     testCollectionTreeItem
       .getChildren()
-      .then(documents => {
+      .then(children => {
         assert(
-          documents.length === 11,
-          `Expected 11 documents to be returned, found ${documents.length}`
+          children.length === 2,
+          `Expected 2 children to be returned, found ${children.length}`
         );
         assert(
-          documents[1].label === `"${mockDocuments[1]._id}"`,
-          `Expected a tree item child with the label document name ${mockDocuments[1]._id} found ${documents[1].label}`
-        );
-      })
-      .then(done, done);
-  });
-
-  test('it should show a show more item when there are more documents to show', function (done) {
-    const testCollectionTreeItem = new CollectionTreeItem(
-      {
-        name: 'mock_collection_name_2',
-        type: CollectionTypes.collection
-      },
-      'mock_db_name',
-      new DataServiceStub(),
-      false,
-      [],
-      MAX_DOCUMENTS_VISIBLE
-    );
-    testCollectionTreeItem.onDidExpand();
-
-    testCollectionTreeItem
-      .getChildren()
-      .then(documents => {
-        assert(
-          documents.length === 11,
-          `Expected 11 documents to be returned, found ${documents.length}`
+          children[0].label === 'Documents',
+          `Expected first child tree item to be named Documents found ${children[0].label}`
         );
         assert(
-          documents[10].label === 'Show more...',
-          `Expected a tree item child with the label "show more..." found ${documents[10].label}`
+          children[1].label === 'Schema',
+          `Expected the second child tree item to be named Schema found ${children[1].label}`
         );
       })
       .then(done, done);
-  });
-
-  test('it should show more documents after the show more click handler is called', function (done) {
-    const testCollectionTreeItem = new CollectionTreeItem(
-      {
-        name: 'mock_collection_name_3',
-        type: CollectionTypes.collection
-      },
-      'mock_db_name',
-      new DataServiceStub(),
-      false,
-      [],
-      MAX_DOCUMENTS_VISIBLE
-    );
-
-    testCollectionTreeItem.onDidExpand();
-    testCollectionTreeItem.onShowMoreClicked();
-
-    testCollectionTreeItem
-      .getChildren()
-      .then(documents => {
-        assert(
-          documents.length === 21,
-          `Expected 21 documents to be returned, found ${documents.length}`
-        );
-        assert(
-          documents[19].label === `"${mockDocuments[19]._id}"`,
-          `Expected a document tree item with the label ${mockDocuments[19]._id}, found ${documents[19].label}`
-        );
-        assert(
-          documents[20].label === 'Show more...',
-          `Expected a tree item child with the label "show more..." found ${documents[10].label}`
-        );
-      })
-      .then(done, done);
-  });
-
-  test('it should not show a show more item when there not are more documents to show', function (done) {
-    const testCollectionTreeItem = new CollectionTreeItem(
-      {
-        name: 'mock_collection_name_4',
-        type: CollectionTypes.collection
-      },
-      'mock_db_name',
-      new DataServiceStub(),
-      false,
-      [],
-      MAX_DOCUMENTS_VISIBLE
-    );
-
-    testCollectionTreeItem.onDidExpand();
-
-    // Increase the max to 30 ish.
-    testCollectionTreeItem.onShowMoreClicked();
-    testCollectionTreeItem.onShowMoreClicked();
-
-    testCollectionTreeItem
-      .getChildren()
-      .then(documents => {
-        assert(
-          documents.length === 25,
-          `Expected 25 documents to be returned, found ${documents.length}`
-        );
-        assert(
-          documents[documents.length - 1].label !== 'Show more...',
-          'Expected the last tree item to not have the label "show more..."'
-        );
-      })
-      .then(done, done);
-  });
-
-  test('a view should show an icon, a collection should not', function () {
-    const testCollectionViewTreeItem = new CollectionTreeItem({
-      name: 'mock_collection_name_4',
-      type: CollectionTypes.view
-    }, 'mock_db_name', new DataServiceStub(), false, [], MAX_DOCUMENTS_VISIBLE);
-
-    const viewIconPath: any = testCollectionViewTreeItem.iconPath;
-    assert(
-      viewIconPath.light.includes('view.svg'),
-      'Expected icon path to point to an svg by the name "view" with a light mode'
-    );
-    assert(
-      viewIconPath.dark.includes('view.svg'),
-      'Expected icon path to point to an svg by the name "view" a dark mode'
-    );
-
-    const testCollectionTreeItem = new CollectionTreeItem(
-      {
-        name: 'mock_collection_name_4',
-        type: CollectionTypes.collection
-      },
-      'mock_db_name',
-      new DataServiceStub(),
-      false,
-      [],
-      MAX_DOCUMENTS_VISIBLE
-    );
-
-    const collectionIconPath: any = testCollectionTreeItem.iconPath;
-    assert(
-      collectionIconPath.light.includes('collection.svg'),
-      'Expected icon path to point to an svg by the name "collection" with a light mode'
-    );
-    assert(
-      collectionIconPath.dark.includes('collection.svg'),
-      'Expected icon path to point to an svg by the name "collection" with a light mode'
-    );
   });
 });

--- a/src/test/suite/explorer/connectionTreeItem.test.ts
+++ b/src/test/suite/explorer/connectionTreeItem.test.ts
@@ -1,0 +1,33 @@
+import * as assert from 'assert';
+import path = require('path');
+
+const { contributes } = require(path.resolve(__dirname, '../../../../package.json'));
+
+import {
+  ConnectionItemContextValues
+} from '../../../explorer/connectionTreeItem';
+
+suite('ConnectionTreeItem Test Suite', () => {
+  test('its context value should be in the package json', function () {
+    let connectedRegisteredCommandInPackageJson = false;
+    let disconnectedRegisteredCommandInPackageJson = false;
+
+    contributes.menus['view/item/context'].forEach(contextItem => {
+      if (contextItem.when.includes(ConnectionItemContextValues.connected)) {
+        connectedRegisteredCommandInPackageJson = true;
+      }
+      if (contextItem.when.includes(ConnectionItemContextValues.disconnected)) {
+        disconnectedRegisteredCommandInPackageJson = true;
+      }
+    });
+
+    assert(
+      connectedRegisteredCommandInPackageJson,
+      'Expected connected connection tree item to be registered with a command in package json'
+    );
+    assert(
+      disconnectedRegisteredCommandInPackageJson,
+      'Expected disconnected connection tree item to be registered with a command in package json'
+    );
+  });
+});

--- a/src/test/suite/explorer/connectionTreeItem.test.ts
+++ b/src/test/suite/explorer/connectionTreeItem.test.ts
@@ -1,7 +1,6 @@
 import * as assert from 'assert';
-import path = require('path');
 
-const { contributes } = require(path.resolve(__dirname, '../../../../package.json'));
+const { contributes } = require('../../../../package.json');
 
 import {
   ConnectionItemContextValues

--- a/src/test/suite/explorer/connectionTreeItem.test.ts
+++ b/src/test/suite/explorer/connectionTreeItem.test.ts
@@ -2,16 +2,14 @@ import * as assert from 'assert';
 
 const { contributes } = require('../../../../package.json');
 
-import {
-  ConnectionItemContextValues
-} from '../../../explorer/connectionTreeItem';
+import { ConnectionItemContextValues } from '../../../explorer/connectionTreeItem';
 
 suite('ConnectionTreeItem Test Suite', () => {
-  test('its context value should be in the package json', function () {
+  test('its context value should be in the package json', function() {
     let connectedRegisteredCommandInPackageJson = false;
     let disconnectedRegisteredCommandInPackageJson = false;
 
-    contributes.menus['view/item/context'].forEach(contextItem => {
+    contributes.menus['view/item/context'].forEach((contextItem) => {
       if (contextItem.when.includes(ConnectionItemContextValues.connected)) {
         connectedRegisteredCommandInPackageJson = true;
       }

--- a/src/test/suite/explorer/databaseTreeItem.test.ts
+++ b/src/test/suite/explorer/databaseTreeItem.test.ts
@@ -7,11 +7,18 @@ import { DataServiceStub, mockDatabaseNames, mockDatabases } from '../stubs';
 import { CollectionTreeItem } from '../../../explorer';
 
 suite('DatabaseTreeItem Test Suite', () => {
-  test('its context value should be in the package json', function() {
+  test('its context value should be in the package json', function () {
     let databaseRegisteredCommandInPackageJson = false;
 
+    const testDatabaseTreeItem = new DatabaseTreeItem(
+      mockDatabaseNames[1],
+      new DataServiceStub(),
+      false,
+      {}
+    );
+
     contributes.menus['view/item/context'].forEach((contextItem) => {
-      if (contextItem.when.includes(DatabaseTreeItem.contextValue)) {
+      if (contextItem.when.includes(testDatabaseTreeItem.contextValue)) {
         databaseRegisteredCommandInPackageJson = true;
       }
     });
@@ -22,7 +29,7 @@ suite('DatabaseTreeItem Test Suite', () => {
     );
   });
 
-  test('when not expanded it does not show collections', function(done) {
+  test('when not expanded it does not show collections', function (done) {
     const testDatabaseTreeItem = new DatabaseTreeItem(
       mockDatabaseNames[1],
       new DataServiceStub(),
@@ -41,7 +48,7 @@ suite('DatabaseTreeItem Test Suite', () => {
       .then(done, done);
   });
 
-  test('when expanded shows the collections of a database in tree', function(done) {
+  test('when expanded shows the collections of a database in tree', function (done) {
     const testDatabaseTreeItem = new DatabaseTreeItem(
       mockDatabaseNames[1],
       new DataServiceStub(),
@@ -61,16 +68,14 @@ suite('DatabaseTreeItem Test Suite', () => {
 
         assert(
           collections[1].label ===
-            mockDatabases[mockDatabaseNames[1]].collections[1].name,
-          `Expected a tree item child with the label collection name ${
-            mockDatabases[mockDatabaseNames[1]].collections[1].name
-          } found ${collections[1].label}`
+          mockDatabases[mockDatabaseNames[1]].collections[1].name,
+          `Expected a tree item child with the label collection name ${mockDatabases[mockDatabaseNames[1]].collections[1].name} found ${collections[1].label}`
         );
       })
       .then(done, done);
   });
 
-  test('when expanded and collapsed its collections cache their expanded documents', function(done) {
+  test('when expanded and collapsed its collections cache their expanded documents', function (done) {
     const testDatabaseTreeItem = new DatabaseTreeItem(
       mockDatabaseNames[1],
       new DataServiceStub(),

--- a/src/test/suite/explorer/databaseTreeItem.test.ts
+++ b/src/test/suite/explorer/databaseTreeItem.test.ts
@@ -6,12 +6,11 @@ import DatabaseTreeItem from '../../../explorer/databaseTreeItem';
 import { DataServiceStub, mockDatabaseNames, mockDatabases } from '../stubs';
 import { CollectionTreeItem } from '../../../explorer';
 
-
 suite('DatabaseTreeItem Test Suite', () => {
-  test('its context value should be in the package json', function () {
+  test('its context value should be in the package json', function() {
     let databaseRegisteredCommandInPackageJson = false;
 
-    contributes.menus['view/item/context'].forEach(contextItem => {
+    contributes.menus['view/item/context'].forEach((contextItem) => {
       if (contextItem.when.includes(DatabaseTreeItem.contextValue)) {
         databaseRegisteredCommandInPackageJson = true;
       }
@@ -23,7 +22,7 @@ suite('DatabaseTreeItem Test Suite', () => {
     );
   });
 
-  test('when not expanded it does not show collections', function (done) {
+  test('when not expanded it does not show collections', function(done) {
     const testDatabaseTreeItem = new DatabaseTreeItem(
       mockDatabaseNames[1],
       new DataServiceStub(),
@@ -42,7 +41,7 @@ suite('DatabaseTreeItem Test Suite', () => {
       .then(done, done);
   });
 
-  test('when expanded shows the collections of a database in tree', function (done) {
+  test('when expanded shows the collections of a database in tree', function(done) {
     const testDatabaseTreeItem = new DatabaseTreeItem(
       mockDatabaseNames[1],
       new DataServiceStub(),
@@ -62,14 +61,16 @@ suite('DatabaseTreeItem Test Suite', () => {
 
         assert(
           collections[1].label ===
-          mockDatabases[mockDatabaseNames[1]].collections[1].name,
-          `Expected a tree item child with the label collection name ${mockDatabases[mockDatabaseNames[1]].collections[1].name} found ${collections[1].label}`
+            mockDatabases[mockDatabaseNames[1]].collections[1].name,
+          `Expected a tree item child with the label collection name ${
+            mockDatabases[mockDatabaseNames[1]].collections[1].name
+          } found ${collections[1].label}`
         );
       })
       .then(done, done);
   });
 
-  test('when expanded and collapsed its collections cache their expanded documents', function (done) {
+  test('when expanded and collapsed its collections cache their expanded documents', function(done) {
     const testDatabaseTreeItem = new DatabaseTreeItem(
       mockDatabaseNames[1],
       new DataServiceStub(),
@@ -79,59 +80,62 @@ suite('DatabaseTreeItem Test Suite', () => {
 
     testDatabaseTreeItem.onDidExpand();
 
-    testDatabaseTreeItem.getChildren().then((collectionTreeItems: CollectionTreeItem[]) => {
-      assert(
-        collectionTreeItems[1].isExpanded === false,
-        'Expected collection tree item not to be expanded on default.'
-      );
-
-      collectionTreeItems[1].onDidExpand();
-      const documentListItem = collectionTreeItems[1].getDocumentListChild();
-      documentListItem.onDidExpand();
-      documentListItem.onShowMoreClicked();
-
-      documentListItem.getChildren().then((documents: any[]) => {
-        const amountOfDocs = documents.length;
-        const expectedDocs = 21;
+    testDatabaseTreeItem
+      .getChildren()
+      .then((collectionTreeItems: CollectionTreeItem[]) => {
         assert(
-          expectedDocs === amountOfDocs,
-          `Expected ${expectedDocs} documents, recieved ${amountOfDocs}`
+          collectionTreeItems[1].isExpanded === false,
+          'Expected collection tree item not to be expanded on default.'
         );
 
-        testDatabaseTreeItem.onDidCollapse();
-        testDatabaseTreeItem
-          .getChildren()
-          .then((postCollapseCollectionTreeItems) => {
-            assert(
-              postCollapseCollectionTreeItems.length === 0,
-              `Expected the database tree to return no children when collapsed, found ${collectionTreeItems.length}`
-            );
+        collectionTreeItems[1].onDidExpand();
+        const documentListItem = collectionTreeItems[1].getDocumentListChild();
+        documentListItem.onDidExpand();
+        documentListItem.onShowMoreClicked();
 
-            testDatabaseTreeItem.onDidExpand();
-            testDatabaseTreeItem
-              .getChildren()
-              .then((newCollectionTreeItems) => {
-                assert(
-                  newCollectionTreeItems[1].isExpanded === true,
-                  'Expected collection tree item to be expanded from cache.'
-                );
+        documentListItem.getChildren().then((documents: any[]) => {
+          const amountOfDocs = documents.length;
+          const expectedDocs = 21;
+          assert(
+            expectedDocs === amountOfDocs,
+            `Expected ${expectedDocs} documents, recieved ${amountOfDocs}`
+          );
 
-                newCollectionTreeItems[1]
-                  .getDocumentListChild()
-                  .getChildren()
-                  .then((documentsPostCollapseExpand) => {
-                    // It should cache that we activated show more.
-                    const amountOfCachedDocs = documentsPostCollapseExpand.length;
-                    const expectedCachedDocs = 21;
-                    assert(
-                      amountOfCachedDocs === expectedCachedDocs,
-                      `Expected a cached ${expectedCachedDocs} documents to be returned, found ${amountOfCachedDocs}`
-                    );
-                  })
-                  .then(done, done);
-              });
-          });
+          testDatabaseTreeItem.onDidCollapse();
+          testDatabaseTreeItem
+            .getChildren()
+            .then((postCollapseCollectionTreeItems) => {
+              assert(
+                postCollapseCollectionTreeItems.length === 0,
+                `Expected the database tree to return no children when collapsed, found ${collectionTreeItems.length}`
+              );
+
+              testDatabaseTreeItem.onDidExpand();
+              testDatabaseTreeItem
+                .getChildren()
+                .then((newCollectionTreeItems) => {
+                  assert(
+                    newCollectionTreeItems[1].isExpanded === true,
+                    'Expected collection tree item to be expanded from cache.'
+                  );
+
+                  newCollectionTreeItems[1]
+                    .getDocumentListChild()
+                    .getChildren()
+                    .then((documentsPostCollapseExpand) => {
+                      // It should cache that we activated show more.
+                      const amountOfCachedDocs =
+                        documentsPostCollapseExpand.length;
+                      const expectedCachedDocs = 21;
+                      assert(
+                        amountOfCachedDocs === expectedCachedDocs,
+                        `Expected a cached ${expectedCachedDocs} documents to be returned, found ${amountOfCachedDocs}`
+                      );
+                    })
+                    .then(done, done);
+                });
+            });
+        });
       });
-    });
   });
 });

--- a/src/test/suite/explorer/databaseTreeItem.test.ts
+++ b/src/test/suite/explorer/databaseTreeItem.test.ts
@@ -7,7 +7,7 @@ import { DataServiceStub, mockDatabaseNames, mockDatabases } from '../stubs';
 import { CollectionTreeItem } from '../../../explorer';
 
 suite('DatabaseTreeItem Test Suite', () => {
-  test('its context value should be in the package json', function () {
+  test('its context value should be in the package json', () => {
     let databaseRegisteredCommandInPackageJson = false;
 
     const testDatabaseTreeItem = new DatabaseTreeItem(
@@ -29,7 +29,7 @@ suite('DatabaseTreeItem Test Suite', () => {
     );
   });
 
-  test('when not expanded it does not show collections', function (done) {
+  test('when not expanded it does not show collections', (done) => {
     const testDatabaseTreeItem = new DatabaseTreeItem(
       mockDatabaseNames[1],
       new DataServiceStub(),
@@ -48,7 +48,7 @@ suite('DatabaseTreeItem Test Suite', () => {
       .then(done, done);
   });
 
-  test('when expanded shows the collections of a database in tree', function (done) {
+  test('when expanded shows the collections of a database in tree', (done) => {
     const testDatabaseTreeItem = new DatabaseTreeItem(
       mockDatabaseNames[1],
       new DataServiceStub(),
@@ -75,7 +75,7 @@ suite('DatabaseTreeItem Test Suite', () => {
       .then(done, done);
   });
 
-  test('when expanded and collapsed its collections cache their expanded documents', function (done) {
+  test('when expanded and collapsed its collections cache their expanded documents', (done) => {
     const testDatabaseTreeItem = new DatabaseTreeItem(
       mockDatabaseNames[1],
       new DataServiceStub(),

--- a/src/test/suite/explorer/databaseTreeItem.test.ts
+++ b/src/test/suite/explorer/databaseTreeItem.test.ts
@@ -1,11 +1,11 @@
 import * as assert from 'assert';
-import path = require('path');
+
+const { contributes } = require('../../../../package.json');
 
 import DatabaseTreeItem from '../../../explorer/databaseTreeItem';
 import { DataServiceStub, mockDatabaseNames, mockDatabases } from '../stubs';
 import { CollectionTreeItem } from '../../../explorer';
 
-const { contributes } = require(path.resolve(__dirname, '../../../../package.json'));
 
 suite('DatabaseTreeItem Test Suite', () => {
   test('its context value should be in the package json', function () {
@@ -91,9 +91,11 @@ suite('DatabaseTreeItem Test Suite', () => {
       documentListItem.onShowMoreClicked();
 
       documentListItem.getChildren().then((documents: any[]) => {
+        const amountOfDocs = documents.length;
+        const expectedDocs = 21;
         assert(
-          documents.length === 21,
-          `Expected 21 documents, recieved ${documents.length}`
+          expectedDocs === amountOfDocs,
+          `Expected ${expectedDocs} documents, recieved ${amountOfDocs}`
         );
 
         testDatabaseTreeItem.onDidCollapse();
@@ -115,12 +117,15 @@ suite('DatabaseTreeItem Test Suite', () => {
                 );
 
                 newCollectionTreeItems[1]
+                  .getDocumentListChild()
                   .getChildren()
                   .then((documentsPostCollapseExpand) => {
                     // It should cache that we activated show more.
+                    const amountOfCachedDocs = documentsPostCollapseExpand.length;
+                    const expectedCachedDocs = 21;
                     assert(
-                      documentsPostCollapseExpand.length === 21,
-                      `Expected a cached 21 documents to be returned, found ${documents.length}`
+                      amountOfCachedDocs === expectedCachedDocs,
+                      `Expected a cached ${expectedCachedDocs} documents to be returned, found ${amountOfCachedDocs}`
                     );
                   })
                   .then(done, done);

--- a/src/test/suite/explorer/documentListTreeItem.test.ts
+++ b/src/test/suite/explorer/documentListTreeItem.test.ts
@@ -12,9 +12,18 @@ import { DataServiceStub, mockDocuments } from '../stubs';
 suite('DocumentListTreeItem Test Suite', () => {
   test('its context value should be in the package json', function () {
     let documentListRegisteredCommandInPackageJson = false;
+    const testDocumentListTreeItem = new DocumentListTreeItem(
+      'collectionName',
+      'databaseName',
+      CollectionTypes.collection,
+      'not_real_dataservice',
+      false,
+      MAX_DOCUMENTS_VISIBLE,
+      null
+    );
 
     contributes.menus['view/item/context'].forEach((contextItem) => {
-      if (contextItem.when.includes(DocumentListTreeItem.contextValue)) {
+      if (contextItem.when.includes(testDocumentListTreeItem.contextValue)) {
         documentListRegisteredCommandInPackageJson = true;
       }
     });

--- a/src/test/suite/explorer/documentListTreeItem.test.ts
+++ b/src/test/suite/explorer/documentListTreeItem.test.ts
@@ -1,0 +1,238 @@
+import * as assert from 'assert';
+const path = require('path');
+
+const { contributes } = require(path.resolve(__dirname, '../../../../package.json'));
+
+import DocumentListTreeItem, {
+  CollectionTypes,
+  MAX_DOCUMENTS_VISIBLE
+} from '../../../explorer/documentListTreeItem';
+
+import { DataServiceStub, mockDocuments } from '../stubs';
+
+suite('DocumentListTreeItem Test Suite', () => {
+  test('its context value should be in the package json', function () {
+    let documentListRegisteredCommandInPackageJson = false;
+
+    contributes.menus['view/item/context'].forEach(contextItem => {
+      if (contextItem.when.includes(DocumentListTreeItem.contextValue)) {
+        documentListRegisteredCommandInPackageJson = true;
+      }
+    });
+
+    assert(
+      documentListRegisteredCommandInPackageJson,
+      'Expected document list tree item to be registered with a command in package json'
+    );
+  });
+
+  test('when the "show more" click handler function is called it increases the amount of documents to show by 10', function () {
+    const testDocumentListTreeItem = new DocumentListTreeItem(
+      'collectionName',
+      'databaseName',
+      CollectionTypes.collection,
+      'not_real_dataservice',
+      false,
+      MAX_DOCUMENTS_VISIBLE,
+      null
+    );
+
+    const maxDocumentsToShow = testDocumentListTreeItem.getMaxDocumentsToShow();
+    assert(
+      maxDocumentsToShow === 10,
+      `Expected max documents to show to be 20, found ${maxDocumentsToShow}.`
+    );
+
+    testDocumentListTreeItem.onShowMoreClicked();
+
+    const newMaxDocumentsToShow = testDocumentListTreeItem.getMaxDocumentsToShow();
+    assert(
+      newMaxDocumentsToShow === 20,
+      `Expected max documents to show to be 20, found ${newMaxDocumentsToShow}.`
+    );
+  });
+
+  test('when not expanded it does not show documents', function (done) {
+    const testDocumentListTreeItem = new DocumentListTreeItem(
+      'mock_collection_name',
+      'mock_db_name',
+      CollectionTypes.collection,
+      new DataServiceStub(),
+      false,
+      MAX_DOCUMENTS_VISIBLE,
+      null
+    );
+
+    testDocumentListTreeItem
+      .getChildren()
+      .then(collections => {
+        assert(
+          collections.length === 0,
+          `Expected no collections to be returned, found ${collections.length}`
+        );
+      })
+      .then(done, done);
+  });
+
+  test('when expanded shows the documents of a collection in tree', function (done) {
+    const testDocumentListTreeItem = new DocumentListTreeItem(
+      'mock_collection_name_1',
+      'mock_db_name',
+      CollectionTypes.collection,
+      new DataServiceStub(),
+      false,
+      MAX_DOCUMENTS_VISIBLE,
+      null
+    );
+    testDocumentListTreeItem.onDidExpand();
+
+    testDocumentListTreeItem
+      .getChildren()
+      .then(documents => {
+        assert(
+          documents.length === 11,
+          `Expected 11 documents to be returned, found ${documents.length}`
+        );
+        assert(
+          documents[1].label === `"${mockDocuments[1]._id}"`,
+          `Expected a tree item child with the label document name ${mockDocuments[1]._id} found ${documents[1].label}`
+        );
+      })
+      .then(done, done);
+  });
+
+  test('it should show a show more item when there are more documents to show', function (done) {
+    const testDocumentListTreeItem = new DocumentListTreeItem(
+      'mock_collection_name_2',
+      'mock_db_name',
+      CollectionTypes.collection,
+
+      new DataServiceStub(),
+      false,
+      MAX_DOCUMENTS_VISIBLE,
+      null
+    );
+    testDocumentListTreeItem.onDidExpand();
+
+    testDocumentListTreeItem
+      .getChildren()
+      .then(documents => {
+        assert(
+          documents.length === 11,
+          `Expected 11 documents to be returned, found ${documents.length}`
+        );
+        assert(
+          documents[10].label === 'Show more...',
+          `Expected a tree item child with the label "show more..." found ${documents[10].label}`
+        );
+      })
+      .then(done, done);
+  });
+
+  test('it should show more documents after the show more click handler is called', function (done) {
+    const testDocumentListTreeItem = new DocumentListTreeItem(
+      'mock_collection_name_3',
+      'mock_db_name',
+      CollectionTypes.collection,
+      new DataServiceStub(),
+      false,
+      MAX_DOCUMENTS_VISIBLE,
+      null
+    );
+
+    testDocumentListTreeItem.onDidExpand();
+    testDocumentListTreeItem.onShowMoreClicked();
+
+    testDocumentListTreeItem
+      .getChildren()
+      .then(documents => {
+        assert(
+          documents.length === 21,
+          `Expected 21 documents to be returned, found ${documents.length}`
+        );
+        assert(
+          documents[19].label === `"${mockDocuments[19]._id}"`,
+          `Expected a document tree item with the label ${mockDocuments[19]._id}, found ${documents[19].label}`
+        );
+        assert(
+          documents[20].label === 'Show more...',
+          `Expected a tree item child with the label "show more..." found ${documents[10].label}`
+        );
+      })
+      .then(done, done);
+  });
+
+  test('it should not show a show more item when there not are more documents to show', function (done) {
+    const testDocumentListTreeItem = new DocumentListTreeItem(
+      'mock_collection_name_4',
+      'mock_db_name',
+      CollectionTypes.collection,
+      new DataServiceStub(),
+      false,
+      MAX_DOCUMENTS_VISIBLE,
+      null
+    );
+
+    testDocumentListTreeItem.onDidExpand();
+
+    // Increase the max to 30 ish.
+    testDocumentListTreeItem.onShowMoreClicked();
+    testDocumentListTreeItem.onShowMoreClicked();
+
+    testDocumentListTreeItem
+      .getChildren()
+      .then(documents => {
+        assert(
+          documents.length === 25,
+          `Expected 25 documents to be returned, found ${documents.length}`
+        );
+        assert(
+          documents[documents.length - 1].label !== 'Show more...',
+          'Expected the last tree item to not have the label "show more..."'
+        );
+      })
+      .then(done, done);
+  });
+
+  test('a view should show a different icon from a collection', function () {
+    const testCollectionViewTreeItem = new DocumentListTreeItem(
+      'mock_collection_name_4',
+      'mock_db_name',
+      CollectionTypes.view,
+      new DataServiceStub(),
+      false,
+      MAX_DOCUMENTS_VISIBLE,
+      null
+    );
+
+    const viewIconPath: any = testCollectionViewTreeItem.iconPath;
+    assert(
+      viewIconPath.light.includes('view.svg'),
+      'Expected icon path to point to an svg by the name "view" with a light mode'
+    );
+    assert(
+      viewIconPath.dark.includes('view.svg'),
+      'Expected icon path to point to an svg by the name "view" a dark mode'
+    );
+
+    const testDocumentListTreeItem = new DocumentListTreeItem(
+      'mock_collection_name_4',
+      'mock_db_name',
+      CollectionTypes.collection,
+      new DataServiceStub(),
+      false,
+      MAX_DOCUMENTS_VISIBLE,
+      null
+    );
+
+    const collectionIconPath: any = testDocumentListTreeItem.iconPath;
+    assert(
+      collectionIconPath.light.includes('collection.svg'),
+      'Expected icon path to point to an svg by the name "collection" with a light mode'
+    );
+    assert(
+      collectionIconPath.dark.includes('collection.svg'),
+      'Expected icon path to point to an svg by the name "collection" with a light mode'
+    );
+  });
+});

--- a/src/test/suite/explorer/documentListTreeItem.test.ts
+++ b/src/test/suite/explorer/documentListTreeItem.test.ts
@@ -13,7 +13,7 @@ suite('DocumentListTreeItem Test Suite', () => {
   test('its context value should be in the package json', function () {
     let documentListRegisteredCommandInPackageJson = false;
 
-    contributes.menus['view/item/context'].forEach(contextItem => {
+    contributes.menus['view/item/context'].forEach((contextItem) => {
       if (contextItem.when.includes(DocumentListTreeItem.contextValue)) {
         documentListRegisteredCommandInPackageJson = true;
       }
@@ -64,7 +64,7 @@ suite('DocumentListTreeItem Test Suite', () => {
 
     testDocumentListTreeItem
       .getChildren()
-      .then(collections => {
+      .then((collections) => {
         assert(
           collections.length === 0,
           `Expected no collections to be returned, found ${collections.length}`
@@ -87,7 +87,7 @@ suite('DocumentListTreeItem Test Suite', () => {
 
     testDocumentListTreeItem
       .getChildren()
-      .then(documents => {
+      .then((documents) => {
         assert(
           documents.length === 11,
           `Expected 11 documents to be returned, found ${documents.length}`
@@ -115,7 +115,7 @@ suite('DocumentListTreeItem Test Suite', () => {
 
     testDocumentListTreeItem
       .getChildren()
-      .then(documents => {
+      .then((documents) => {
         assert(
           documents.length === 11,
           `Expected 11 documents to be returned, found ${documents.length}`
@@ -144,7 +144,7 @@ suite('DocumentListTreeItem Test Suite', () => {
 
     testDocumentListTreeItem
       .getChildren()
-      .then(documents => {
+      .then((documents) => {
         assert(
           documents.length === 21,
           `Expected 21 documents to be returned, found ${documents.length}`
@@ -180,7 +180,7 @@ suite('DocumentListTreeItem Test Suite', () => {
 
     testDocumentListTreeItem
       .getChildren()
-      .then(documents => {
+      .then((documents) => {
         assert(
           documents.length === 25,
           `Expected 25 documents to be returned, found ${documents.length}`

--- a/src/test/suite/explorer/documentListTreeItem.test.ts
+++ b/src/test/suite/explorer/documentListTreeItem.test.ts
@@ -10,7 +10,7 @@ import DocumentListTreeItem, {
 import { DataServiceStub, mockDocuments } from '../stubs';
 
 suite('DocumentListTreeItem Test Suite', () => {
-  test('its context value should be in the package json', function () {
+  test('its context value should be in the package json', () => {
     let documentListRegisteredCommandInPackageJson = false;
     const testDocumentListTreeItem = new DocumentListTreeItem(
       'collectionName',
@@ -34,7 +34,7 @@ suite('DocumentListTreeItem Test Suite', () => {
     );
   });
 
-  test('when the "show more" click handler function is called it increases the amount of documents to show by 10', function () {
+  test('when the "show more" click handler is called => it increases the amount of documents to show by 10', () => {
     const testDocumentListTreeItem = new DocumentListTreeItem(
       'collectionName',
       'databaseName',
@@ -60,7 +60,7 @@ suite('DocumentListTreeItem Test Suite', () => {
     );
   });
 
-  test('when not expanded it does not show documents', function (done) {
+  test('when not expanded it does not show documents', (done) => {
     const testDocumentListTreeItem = new DocumentListTreeItem(
       'mock_collection_name',
       'mock_db_name',
@@ -82,7 +82,7 @@ suite('DocumentListTreeItem Test Suite', () => {
       .then(done, done);
   });
 
-  test('when expanded shows the documents of a collection in tree', function (done) {
+  test('when expanded shows the documents of a collection in tree', (done) => {
     const testDocumentListTreeItem = new DocumentListTreeItem(
       'mock_collection_name_1',
       'mock_db_name',
@@ -109,7 +109,7 @@ suite('DocumentListTreeItem Test Suite', () => {
       .then(done, done);
   });
 
-  test('it should show a show more item when there are more documents to show', function (done) {
+  test('it should show a show more item when there are more documents to show', (done) => {
     const testDocumentListTreeItem = new DocumentListTreeItem(
       'mock_collection_name_2',
       'mock_db_name',
@@ -137,7 +137,7 @@ suite('DocumentListTreeItem Test Suite', () => {
       .then(done, done);
   });
 
-  test('it should show more documents after the show more click handler is called', function (done) {
+  test('it should show more documents after the show more click handler is called', (done) => {
     const testDocumentListTreeItem = new DocumentListTreeItem(
       'mock_collection_name_3',
       'mock_db_name',
@@ -170,7 +170,7 @@ suite('DocumentListTreeItem Test Suite', () => {
       .then(done, done);
   });
 
-  test('it should not show a show more item when there not are more documents to show', function (done) {
+  test('it should not show a show more item when there not are more documents to show', (done) => {
     const testDocumentListTreeItem = new DocumentListTreeItem(
       'mock_collection_name_4',
       'mock_db_name',
@@ -202,7 +202,7 @@ suite('DocumentListTreeItem Test Suite', () => {
       .then(done, done);
   });
 
-  test('a view should show a different icon from a collection', function () {
+  test('a view should show a different icon from a collection', () => {
     const testCollectionViewTreeItem = new DocumentListTreeItem(
       'mock_collection_name_4',
       'mock_db_name',

--- a/src/test/suite/explorer/documentListTreeItem.test.ts
+++ b/src/test/suite/explorer/documentListTreeItem.test.ts
@@ -1,7 +1,6 @@
 import * as assert from 'assert';
-const path = require('path');
 
-const { contributes } = require(path.resolve(__dirname, '../../../../package.json'));
+const { contributes } = require('../../../../package.json');
 
 import DocumentListTreeItem, {
   CollectionTypes,

--- a/src/test/suite/explorer/documentTreeItem.test.ts
+++ b/src/test/suite/explorer/documentTreeItem.test.ts
@@ -3,7 +3,7 @@ import * as assert from 'assert';
 import DocumentTreeItem from '../../../explorer/documentTreeItem';
 
 suite('DocumentTreeItem Test Suite', () => {
-  test('it makes the document _id the label of the document tree item', function () {
+  test('it makes the document _id the label of the document tree item', function() {
     const mockDocument = {
       _id: 'mock_document_id'
     };
@@ -17,7 +17,7 @@ suite('DocumentTreeItem Test Suite', () => {
     );
   });
 
-  test('when the document has an object _id, it is stringified into the tree item label', function () {
+  test('when the document has an object _id, it is stringified into the tree item label', function() {
     const mockDocument = {
       _id: {
         someIdField: 'mock_document_id',
@@ -36,7 +36,7 @@ suite('DocumentTreeItem Test Suite', () => {
     );
   });
 
-  test('when the document does not have an _id, its label is the supplied index', function () {
+  test('when the document does not have an _id, its label is the supplied index', function() {
     const mockDocument = {
       noIdField: true
     };

--- a/src/test/suite/explorer/documentTreeItem.test.ts
+++ b/src/test/suite/explorer/documentTreeItem.test.ts
@@ -1,11 +1,8 @@
 import * as assert from 'assert';
-import * as vscode from 'vscode';
 
 import DocumentTreeItem from '../../../explorer/documentTreeItem';
 
 suite('DocumentTreeItem Test Suite', () => {
-  vscode.window.showInformationMessage('Starting tests...');
-
   test('it makes the document _id the label of the document tree item', function () {
     const mockDocument = {
       _id: 'mock_document_id'

--- a/src/test/suite/explorer/explorerController.test.ts
+++ b/src/test/suite/explorer/explorerController.test.ts
@@ -2,18 +2,15 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 import { beforeEach, afterEach } from 'mocha';
 
-import ConnectionController from '../../../connectionController';
 import { DefaultSavingLocations } from '../../../storage/storageController';
-import { StorageController } from '../../../storage';
+
+import { TEST_DATABASE_URI } from '../dbTestHelper';
 import { mdbTestExtension } from '../stubbableMdbExtension';
 
-const testDatabaseURI = 'mongodb://localhost:27018';
 const testDatabaseURI2WithTimeout =
   'mongodb://shouldfail?connectTimeoutMS=1000&serverSelectionTimeoutMS=500';
 
-suite('Explorer Controller Test Suite', function() {
-  vscode.window.showInformationMessage('Starting tests...');
-
+suite('Explorer Controller Test Suite', function () {
   beforeEach(async () => {
     // Don't save connections on default.
     await vscode.workspace
@@ -35,7 +32,7 @@ suite('Explorer Controller Test Suite', function() {
     mdbTestExtension.testExtensionController._connectionController.clearAllConnections();
   });
 
-  test('should have a connections root', function(done) {
+  test('should have a connections root', function (done) {
     const testExplorerController =
       mdbTestExtension.testExtensionController._explorerController;
 
@@ -57,7 +54,7 @@ suite('Explorer Controller Test Suite', function() {
       .then(done, done);
   });
 
-  test('it updates the connections to account for a change in the connection controller', function(done) {
+  test('it updates the connections to account for a change in the connection controller', function (done) {
     const testConnectionController =
       mdbTestExtension.testExtensionController._connectionController;
     const testExplorerController =
@@ -88,7 +85,7 @@ suite('Explorer Controller Test Suite', function() {
     });
   });
 
-  test('when a connection is added and connected it is added to the tree and expanded', function(done) {
+  test('when a connection is added and connected it is added to the tree and expanded', function (done) {
     const testConnectionController =
       mdbTestExtension.testExtensionController._connectionController;
     const testExplorerController =
@@ -97,7 +94,7 @@ suite('Explorer Controller Test Suite', function() {
     const treeController = testExplorerController.getTreeController();
 
     testConnectionController
-      .addNewConnectionAndConnect(testDatabaseURI)
+      .addNewConnectionAndConnect(TEST_DATABASE_URI)
       .then((succesfullyConnected) => {
         assert(
           succesfullyConnected === true,
@@ -141,7 +138,7 @@ suite('Explorer Controller Test Suite', function() {
       });
   });
 
-  test('only the active connection is displayed as connected in the tree', function(done) {
+  test('only the active connection is displayed as connected in the tree', function (done) {
     const testConnectionController =
       mdbTestExtension.testExtensionController._connectionController;
     const testExplorerController =
@@ -150,7 +147,7 @@ suite('Explorer Controller Test Suite', function() {
     const treeController = testExplorerController.getTreeController();
 
     testConnectionController
-      .addNewConnectionAndConnect(testDatabaseURI)
+      .addNewConnectionAndConnect(TEST_DATABASE_URI)
       .then((succesfullyConnected) => {
         assert(
           succesfullyConnected === true,
@@ -170,8 +167,8 @@ suite('Explorer Controller Test Suite', function() {
         testConnectionController
           .addNewConnectionAndConnect(testDatabaseURI2WithTimeout)
           .then(
-            () => {},
-            () => {} /* Silent fail (should fail) */
+            () => { },
+            () => { } /* Silent fail (should fail) */
           );
 
         setTimeout(() => {
@@ -212,7 +209,7 @@ suite('Explorer Controller Test Suite', function() {
       });
   });
 
-  test('shows the databases of connected connection in tree', function(done) {
+  test('shows the databases of connected connection in tree', function (done) {
     const testConnectionController =
       mdbTestExtension.testExtensionController._connectionController;
     const testExplorerController =
@@ -221,7 +218,7 @@ suite('Explorer Controller Test Suite', function() {
     const treeController = testExplorerController.getTreeController();
 
     testConnectionController
-      .addNewConnectionAndConnect(testDatabaseURI)
+      .addNewConnectionAndConnect(TEST_DATABASE_URI)
       .then(() => {
         treeController.getChildren().then((treeControllerChildren) => {
           treeControllerChildren[0].getChildren().then((connectionsItems) => {
@@ -248,7 +245,7 @@ suite('Explorer Controller Test Suite', function() {
       });
   });
 
-  test('caches the expanded state of databases in the tree when a connection is expanded or collapsed', function(done) {
+  test('caches the expanded state of databases in the tree when a connection is expanded or collapsed', function (done) {
     const testConnectionController =
       mdbTestExtension.testExtensionController._connectionController;
     const testExplorerController =
@@ -257,7 +254,7 @@ suite('Explorer Controller Test Suite', function() {
     const treeController = testExplorerController.getTreeController();
 
     testConnectionController
-      .addNewConnectionAndConnect(testDatabaseURI)
+      .addNewConnectionAndConnect(TEST_DATABASE_URI)
       .then(() => {
         treeController.getChildren().then((rootTreeItem) => {
           const connectionsTreeItem = rootTreeItem[0];

--- a/src/test/suite/explorer/explorerController.test.ts
+++ b/src/test/suite/explorer/explorerController.test.ts
@@ -10,7 +10,7 @@ import { mdbTestExtension } from '../stubbableMdbExtension';
 const testDatabaseURI2WithTimeout =
   'mongodb://shouldfail?connectTimeoutMS=500&serverSelectionTimeoutMS=500';
 
-suite('Explorer Controller Test Suite', function () {
+suite('Explorer Controller Test Suite', () => {
   beforeEach(async () => {
     // Don't save connections on default.
     await vscode.workspace
@@ -32,7 +32,7 @@ suite('Explorer Controller Test Suite', function () {
     mdbTestExtension.testExtensionController._connectionController.clearAllConnections();
   });
 
-  test('should have a connections root', function (done) {
+  test('should have a connections root', (done) => {
     const testExplorerController =
       mdbTestExtension.testExtensionController._explorerController;
 
@@ -54,7 +54,7 @@ suite('Explorer Controller Test Suite', function () {
       .then(done, done);
   });
 
-  test('it updates the connections to account for a change in the connection controller', function (done) {
+  test('it updates the connections to account for a change in the connection controller', (done) => {
     const testConnectionController =
       mdbTestExtension.testExtensionController._connectionController;
     const testExplorerController =
@@ -85,7 +85,7 @@ suite('Explorer Controller Test Suite', function () {
     });
   });
 
-  test('when a connection is added and connected it is added to the tree and expanded', function (done) {
+  test('when a connection is added and connected it is added to the tree and expanded', (done) => {
     const testConnectionController =
       mdbTestExtension.testExtensionController._connectionController;
     const testExplorerController =
@@ -138,7 +138,7 @@ suite('Explorer Controller Test Suite', function () {
       });
   });
 
-  test('only the active connection is displayed as connected in the tree', function (done) {
+  test('only the active connection is displayed as connected in the tree', (done) => {
     const testConnectionController =
       mdbTestExtension.testExtensionController._connectionController;
     const testExplorerController =
@@ -209,7 +209,7 @@ suite('Explorer Controller Test Suite', function () {
       });
   });
 
-  test('shows the databases of connected connection in tree', function (done) {
+  test('shows the databases of connected connection in tree', (done) => {
     const testConnectionController =
       mdbTestExtension.testExtensionController._connectionController;
     const testExplorerController =
@@ -245,7 +245,7 @@ suite('Explorer Controller Test Suite', function () {
       });
   });
 
-  test('caches the expanded state of databases in the tree when a connection is expanded or collapsed', function (done) {
+  test('caches the expanded state of databases in the tree when a connection is expanded or collapsed', (done) => {
     const testConnectionController =
       mdbTestExtension.testExtensionController._connectionController;
     const testExplorerController =

--- a/src/test/suite/explorer/explorerController.test.ts
+++ b/src/test/suite/explorer/explorerController.test.ts
@@ -8,7 +8,7 @@ import { TEST_DATABASE_URI } from '../dbTestHelper';
 import { mdbTestExtension } from '../stubbableMdbExtension';
 
 const testDatabaseURI2WithTimeout =
-  'mongodb://shouldfail?connectTimeoutMS=1000&serverSelectionTimeoutMS=500';
+  'mongodb://shouldfail?connectTimeoutMS=500&serverSelectionTimeoutMS=500';
 
 suite('Explorer Controller Test Suite', function () {
   beforeEach(async () => {

--- a/src/test/suite/explorer/fieldTreeItems.test.ts
+++ b/src/test/suite/explorer/fieldTreeItems.test.ts
@@ -15,13 +15,12 @@ suite('FieldTreeItem Test Suite', () => {
   });
 
   test('field name is pulled from the name of a field', function (done) {
-    seedDataAndCreateDataService(
-      'pie',
-      [{
+    seedDataAndCreateDataService('pie', [
+      {
         _id: 1,
         blueberryPie: 'yes'
-      }]
-    ).then(dataService => {
+      }
+    ]).then((dataService) => {
       const testSchemaTreeItem = new SchemaTreeItem(
         'pie',
         TEST_DB_NAME,
@@ -48,14 +47,14 @@ suite('FieldTreeItem Test Suite', () => {
             schemaFields[1].fieldName === 'blueberryPie',
             `Expected field name to be "blueberryPie" recieved ${schemaFields[0].label}`
           );
-        }).then(done, done);
+        })
+        .then(done, done);
     });
   });
 
   test('it shows dropdowns for nested subdocuments', function (done) {
-    seedDataAndCreateDataService(
-      'gryffindor',
-      [{
+    seedDataAndCreateDataService('gryffindor', [
+      {
         _id: 1,
         alwaysDocument: {
           nestedSubDocument: {
@@ -63,7 +62,8 @@ suite('FieldTreeItem Test Suite', () => {
             harry: 'potter'
           }
         }
-      }, {
+      },
+      {
         _id: 2,
         alwaysDocument: {
           nestedSubDocument: {
@@ -71,8 +71,8 @@ suite('FieldTreeItem Test Suite', () => {
             hermione: 'granger'
           }
         }
-      }]
-    ).then(dataService => {
+      }
+    ]).then((dataService) => {
       const testSchemaTreeItem = new SchemaTreeItem(
         'gryffindor',
         TEST_DB_NAME,
@@ -84,23 +84,23 @@ suite('FieldTreeItem Test Suite', () => {
 
       testSchemaTreeItem.onDidExpand();
 
-      testSchemaTreeItem
-        .getChildren()
-        .then((schemaFields) => {
-          dataService.disconnect();
-          assert(
-            schemaFields.length === 2,
-            `Expected 2 schema tree items to be returned, recieved ${schemaFields.length}`
-          );
-          assert(
-            !fieldIsExpandable(schemaFields[0].field),
-            'Expected _id field not to have expandable state'
-          );
-          assert(
-            fieldIsExpandable(schemaFields[1].field),
-            'Expected field to have expandable state'
-          );
-          schemaFields[1].getChildren().then(subdocuments => {
+      testSchemaTreeItem.getChildren().then((schemaFields) => {
+        dataService.disconnect();
+        assert(
+          schemaFields.length === 2,
+          `Expected 2 schema tree items to be returned, recieved ${schemaFields.length}`
+        );
+        assert(
+          !fieldIsExpandable(schemaFields[0].field),
+          'Expected _id field not to have expandable state'
+        );
+        assert(
+          fieldIsExpandable(schemaFields[1].field),
+          'Expected field to have expandable state'
+        );
+        schemaFields[1]
+          .getChildren()
+          .then((subdocuments) => {
             assert(
               subdocuments.length === 1,
               `Expected subdocument to have 1 field found ${subdocuments.length}`
@@ -109,28 +109,32 @@ suite('FieldTreeItem Test Suite', () => {
               fieldIsExpandable(subdocuments[0].field),
               'Expected subdocument to be expandable'
             );
-            subdocuments[0].getChildren().then(nestedSubDocument => {
-              assert(
-                nestedSubDocument.length === 3,
-                'Expected nested subdocument to have 3 fields'
-              );
-            }).then(done, done);
-          }).catch(done);
-        });
+            subdocuments[0]
+              .getChildren()
+              .then((nestedSubDocument) => {
+                assert(
+                  nestedSubDocument.length === 3,
+                  'Expected nested subdocument to have 3 fields'
+                );
+              })
+              .then(done, done);
+          })
+          .catch(done);
+      });
     });
   });
 
   test('it shows dropdowns for arrays', function (done) {
-    seedDataAndCreateDataService(
-      'gryffindor',
-      [{
+    seedDataAndCreateDataService('gryffindor', [
+      {
         _id: 1,
         testingArray: ['okay', 'nice']
-      }, {
+      },
+      {
         _id: 2,
         testingArray: ['dobby']
-      }]
-    ).then(dataService => {
+      }
+    ]).then((dataService) => {
       const testSchemaTreeItem = new SchemaTreeItem(
         'gryffindor',
         TEST_DB_NAME,
@@ -142,19 +146,19 @@ suite('FieldTreeItem Test Suite', () => {
 
       testSchemaTreeItem.onDidExpand();
 
-      testSchemaTreeItem
-        .getChildren()
-        .then((schemaFields) => {
-          dataService.disconnect();
-          assert(
-            schemaFields.length === 2,
-            `Expected 2 schema tree items to be returned, recieved ${schemaFields.length}`
-          );
-          assert(
-            fieldIsExpandable(schemaFields[1].field),
-            'Expected field to have expandable state'
-          );
-          schemaFields[1].getChildren().then(arrayFieldContainer => {
+      testSchemaTreeItem.getChildren().then((schemaFields) => {
+        dataService.disconnect();
+        assert(
+          schemaFields.length === 2,
+          `Expected 2 schema tree items to be returned, recieved ${schemaFields.length}`
+        );
+        assert(
+          fieldIsExpandable(schemaFields[1].field),
+          'Expected field to have expandable state'
+        );
+        schemaFields[1]
+          .getChildren()
+          .then((arrayFieldContainer) => {
             assert(
               arrayFieldContainer.length === 1,
               `Expected array field to have 1 field found ${arrayFieldContainer.length}`
@@ -163,38 +167,46 @@ suite('FieldTreeItem Test Suite', () => {
               fieldIsExpandable(arrayFieldContainer[0].field),
               'Expected array field container to be expandable'
             );
-            arrayFieldContainer[0].getChildren().then(arrayFields => {
-              assert(
-                arrayFields.length === 1,
-                `Expected array field fields to have 1 field found ${arrayFields.length}`
-              );
-              assert(
-                !fieldIsExpandable(arrayFields[0].field),
-                'Expected string field in array not to be expandable'
-              );
-            }).then(done, done);
-          }).catch(done);
-        });
+            arrayFieldContainer[0]
+              .getChildren()
+              .then((arrayFields) => {
+                assert(
+                  arrayFields.length === 1,
+                  `Expected array field fields to have 1 field found ${arrayFields.length}`
+                );
+                assert(
+                  !fieldIsExpandable(arrayFields[0].field),
+                  'Expected string field in array not to be expandable'
+                );
+              })
+              .then(done, done);
+          })
+          .catch(done);
+      });
     });
   });
 
   test('it shows dropdowns and fields for document fields in arrays', function (done) {
-    seedDataAndCreateDataService(
-      'beach',
-      [{
+    seedDataAndCreateDataService('beach', [
+      {
         _id: 1,
-        testingArray: [{
-          color: 'orange',
-          sunset: false
-        }]
-      }, {
+        testingArray: [
+          {
+            color: 'orange',
+            sunset: false
+          }
+        ]
+      },
+      {
         _id: 2,
-        testingArray: [{
-          color: 'violet',
-          sunset: true
-        }]
-      }]
-    ).then(dataService => {
+        testingArray: [
+          {
+            color: 'violet',
+            sunset: true
+          }
+        ]
+      }
+    ]).then((dataService) => {
       const testSchemaTreeItem = new SchemaTreeItem(
         'beach',
         TEST_DB_NAME,
@@ -206,26 +218,26 @@ suite('FieldTreeItem Test Suite', () => {
 
       testSchemaTreeItem.onDidExpand();
 
-      testSchemaTreeItem
-        .getChildren()
-        .then((schemaFields) => {
-          dataService.disconnect();
+      testSchemaTreeItem.getChildren().then((schemaFields) => {
+        dataService.disconnect();
 
-          schemaFields[1].getChildren().then(arrayFieldContainer => {
+        schemaFields[1].getChildren().then((arrayFieldContainer) => {
+          assert(
+            arrayFieldContainer.length === 1,
+            `Expected array fields to have length 1 found ${arrayFieldContainer.length}`
+          );
+          arrayFieldContainer[0].getChildren().then((nestedSubDocuments) => {
             assert(
-              arrayFieldContainer.length === 1,
-              `Expected array fields to have length 1 found ${arrayFieldContainer.length}`
+              nestedSubDocuments.length === 1,
+              `Expected array field fields to have 1 field found ${nestedSubDocuments.length}`
             );
-            arrayFieldContainer[0].getChildren().then(nestedSubDocuments => {
-              assert(
-                nestedSubDocuments.length === 1,
-                `Expected array field fields to have 1 field found ${nestedSubDocuments.length}`
-              );
-              assert(
-                fieldIsExpandable(nestedSubDocuments[0].field),
-                'Expected subdocument in array to be expandable'
-              );
-              nestedSubDocuments[0].getChildren().then(subdocFields => {
+            assert(
+              fieldIsExpandable(nestedSubDocuments[0].field),
+              'Expected subdocument in array to be expandable'
+            );
+            nestedSubDocuments[0]
+              .getChildren()
+              .then((subdocFields) => {
                 assert(
                   subdocFields.length === 2,
                   `Expected subdocument in array field to have 2 fields found ${subdocFields.length}`
@@ -238,10 +250,11 @@ suite('FieldTreeItem Test Suite', () => {
                   !fieldIsExpandable(subdocFields[1].field),
                   'Expected subdocument boolean field to not be expandable'
                 );
-              }).then(done, done);
-            });
+              })
+              .then(done, done);
           });
         });
+      });
     });
   });
 });

--- a/src/test/suite/explorer/fieldTreeItems.test.ts
+++ b/src/test/suite/explorer/fieldTreeItems.test.ts
@@ -88,7 +88,6 @@ suite('FieldTreeItem Test Suite', () => {
         .getChildren()
         .then((schemaFields) => {
           dataService.disconnect();
-          console.log('first fields', schemaFields);
           assert(
             schemaFields.length === 2,
             `Expected 2 schema tree items to be returned, recieved ${schemaFields.length}`
@@ -101,23 +100,23 @@ suite('FieldTreeItem Test Suite', () => {
             fieldIsExpandable(schemaFields[1].field),
             'Expected field to have expandable state'
           );
-          console.log('subdocument field ', schemaFields[1].field);
-          const subdocument = schemaFields[1].getChildren();
-          console.log('subdocument', subdocument);
-          assert(
-            subdocument.length === 1,
-            `Expected subdocument to have 1 field found ${subdocument.length}`
-          );
-          assert(
-            fieldIsExpandable(subdocument.field),
-            'Expected subdocument to be expandable'
-          );
-          const nestedSubDocument = subdocument.getChildren();
-          assert(
-            nestedSubDocument.length === 3,
-            'Expected nested subdocument to have 3 fields'
-          );
-        }).then(done, done);
+          schemaFields[1].getChildren().then(subdocuments => {
+            assert(
+              subdocuments.length === 1,
+              `Expected subdocument to have 1 field found ${subdocuments.length}`
+            );
+            assert(
+              fieldIsExpandable(subdocuments[0].field),
+              'Expected subdocument to be expandable'
+            );
+            subdocuments[0].getChildren().then(nestedSubDocument => {
+              assert(
+                nestedSubDocument.length === 3,
+                'Expected nested subdocument to have 3 fields'
+              );
+            }).then(done, done);
+          }).catch(done);
+        });
     });
   });
 
@@ -155,25 +154,27 @@ suite('FieldTreeItem Test Suite', () => {
             fieldIsExpandable(schemaFields[1].field),
             'Expected field to have expandable state'
           );
-          const arrayFieldContainer = schemaFields[1].getChildren();
-          assert(
-            arrayFieldContainer.length === 1,
-            `Expected array field to have 1 field found ${arrayFieldContainer.length}`
-          );
-          assert(
-            fieldIsExpandable(arrayFieldContainer.field),
-            'Expected array field container to be expandable'
-          );
-          const arrayField = arrayFieldContainer.getChildren();
-          assert(
-            arrayField.length === 1,
-            `Expected array field fields to have 1 field found ${arrayField.length}`
-          );
-          assert(
-            !fieldIsExpandable(arrayField.field),
-            'Expected string field in array not to be expandable'
-          );
-        }).then(done, done);
+          schemaFields[1].getChildren().then(arrayFieldContainer => {
+            assert(
+              arrayFieldContainer.length === 1,
+              `Expected array field to have 1 field found ${arrayFieldContainer.length}`
+            );
+            assert(
+              fieldIsExpandable(arrayFieldContainer[0].field),
+              'Expected array field container to be expandable'
+            );
+            arrayFieldContainer[0].getChildren().then(arrayFields => {
+              assert(
+                arrayFields.length === 1,
+                `Expected array field fields to have 1 field found ${arrayFields.length}`
+              );
+              assert(
+                !fieldIsExpandable(arrayFields[0].field),
+                'Expected string field in array not to be expandable'
+              );
+            }).then(done, done);
+          }).catch(done);
+        });
     });
   });
 
@@ -184,7 +185,7 @@ suite('FieldTreeItem Test Suite', () => {
         _id: 1,
         testingArray: [{
           color: 'orange',
-          sunset: true
+          sunset: false
         }]
       }, {
         _id: 2,
@@ -210,36 +211,37 @@ suite('FieldTreeItem Test Suite', () => {
         .then((schemaFields) => {
           dataService.disconnect();
 
-          console.log('schemaFields[1]', schemaFields[1]);
-          const arrayFieldContainer = schemaFields[1].getChildren();
-          console.log('arrayFieldContainer', arrayFieldContainer);
-          assert(
-            arrayFieldContainer.length === 1,
-            `Expected array fields to have length 1 found ${arrayFieldContainer.length}`
-          );
-          const nestedSubDocument = arrayFieldContainer.getChildren();
-          assert(
-            nestedSubDocument.length === 1,
-            `Expected array field fields to have 1 field found ${nestedSubDocument.length}`
-          );
-          const subdocFields = nestedSubDocument.getChildren();
-          assert(
-            fieldIsExpandable(subdocFields.field),
-            'Expected subdocument in array to be expandable'
-          );
-          assert(
-            subdocFields.length === 2,
-            `Expected subdocument in array field to have 2 fields found ${subdocFields.length}`
-          );
-          assert(
-            subdocFields[1].label === 'sunset',
-            'Expected subdocument field to have correct label'
-          );
-          assert(
-            !fieldIsExpandable(subdocFields[1].field),
-            'Expected subdocument boolean field to not be expandable'
-          );
-        }).then(done, done);
+          schemaFields[1].getChildren().then(arrayFieldContainer => {
+            assert(
+              arrayFieldContainer.length === 1,
+              `Expected array fields to have length 1 found ${arrayFieldContainer.length}`
+            );
+            arrayFieldContainer[0].getChildren().then(nestedSubDocuments => {
+              assert(
+                nestedSubDocuments.length === 1,
+                `Expected array field fields to have 1 field found ${nestedSubDocuments.length}`
+              );
+              assert(
+                fieldIsExpandable(nestedSubDocuments[0].field),
+                'Expected subdocument in array to be expandable'
+              );
+              nestedSubDocuments[0].getChildren().then(subdocFields => {
+                assert(
+                  subdocFields.length === 2,
+                  `Expected subdocument in array field to have 2 fields found ${subdocFields.length}`
+                );
+                assert(
+                  subdocFields[1].label === 'sunset',
+                  'Expected subdocument field to have correct label'
+                );
+                assert(
+                  !fieldIsExpandable(subdocFields[1].field),
+                  'Expected subdocument boolean field to not be expandable'
+                );
+              }).then(done, done);
+            });
+          });
+        });
     });
   });
 });

--- a/src/test/suite/explorer/fieldTreeItems.test.ts
+++ b/src/test/suite/explorer/fieldTreeItems.test.ts
@@ -14,7 +14,7 @@ suite('FieldTreeItem Test Suite', () => {
     await cleanupTestDB();
   });
 
-  test('field name is pulled from the name of a field', function (done) {
+  test('field name is pulled from the name of a field', (done) => {
     seedDataAndCreateDataService('pie', [
       {
         _id: 1,
@@ -52,7 +52,7 @@ suite('FieldTreeItem Test Suite', () => {
     });
   });
 
-  test('it shows dropdowns for nested subdocuments', function (done) {
+  test('it shows dropdowns for nested subdocuments', (done) => {
     seedDataAndCreateDataService('gryffindor', [
       {
         _id: 1,
@@ -124,7 +124,7 @@ suite('FieldTreeItem Test Suite', () => {
     });
   });
 
-  test('it shows dropdowns for arrays', function (done) {
+  test('it shows dropdowns for arrays', (done) => {
     seedDataAndCreateDataService('gryffindor', [
       {
         _id: 1,
@@ -186,7 +186,7 @@ suite('FieldTreeItem Test Suite', () => {
     });
   });
 
-  test('it shows dropdowns and fields for document fields in arrays', function (done) {
+  test('it shows dropdowns and fields for document fields in arrays', (done) => {
     seedDataAndCreateDataService('beach', [
       {
         _id: 1,

--- a/src/test/suite/explorer/fieldTreeItems.test.ts
+++ b/src/test/suite/explorer/fieldTreeItems.test.ts
@@ -1,4 +1,245 @@
+import * as assert from 'assert';
+import { afterEach } from 'mocha';
+
+import {
+  seedDataAndCreateDataService,
+  cleanupTestDB,
+  TEST_DB_NAME
+} from '../dbTestHelper';
+import { fieldIsExpandable } from '../../../explorer/fieldTreeItem';
+import SchemaTreeItem from '../../../explorer/schemaTreeItem';
 
 suite('FieldTreeItem Test Suite', () => {
+  afterEach(async () => {
+    await cleanupTestDB();
+  });
 
+  test('field name is pulled from the name of a field', function (done) {
+    seedDataAndCreateDataService(
+      'pie',
+      [{
+        _id: 1,
+        blueberryPie: 'yes'
+      }]
+    ).then(dataService => {
+      const testSchemaTreeItem = new SchemaTreeItem(
+        'pie',
+        TEST_DB_NAME,
+        dataService,
+        true,
+        false,
+        null
+      );
+
+      testSchemaTreeItem
+        .getChildren()
+        .then((schemaFields) => {
+          dataService.disconnect();
+
+          assert(
+            schemaFields[0].label === '_id',
+            `Expected field name to be "_id" recieved ${schemaFields[0].label}`
+          );
+          assert(
+            schemaFields[1].label === 'blueberryPie',
+            `Expected field name to be "blueberryPie" recieved ${schemaFields[0].label}`
+          );
+          assert(
+            schemaFields[1].fieldName === 'blueberryPie',
+            `Expected field name to be "blueberryPie" recieved ${schemaFields[0].label}`
+          );
+        }).then(done, done);
+    });
+  });
+
+  test('it shows dropdowns for nested subdocuments', function (done) {
+    seedDataAndCreateDataService(
+      'gryffindor',
+      [{
+        _id: 1,
+        alwaysDocument: {
+          nestedSubDocument: {
+            magic: true,
+            harry: 'potter'
+          }
+        }
+      }, {
+        _id: 2,
+        alwaysDocument: {
+          nestedSubDocument: {
+            magic: true,
+            hermione: 'granger'
+          }
+        }
+      }]
+    ).then(dataService => {
+      const testSchemaTreeItem = new SchemaTreeItem(
+        'gryffindor',
+        TEST_DB_NAME,
+        dataService,
+        false,
+        false,
+        null
+      );
+
+      testSchemaTreeItem.onDidExpand();
+
+      testSchemaTreeItem
+        .getChildren()
+        .then((schemaFields) => {
+          dataService.disconnect();
+          console.log('first fields', schemaFields);
+          assert(
+            schemaFields.length === 2,
+            `Expected 2 schema tree items to be returned, recieved ${schemaFields.length}`
+          );
+          assert(
+            !fieldIsExpandable(schemaFields[0].field),
+            'Expected _id field not to have expandable state'
+          );
+          assert(
+            fieldIsExpandable(schemaFields[1].field),
+            'Expected field to have expandable state'
+          );
+          console.log('subdocument field ', schemaFields[1].field);
+          const subdocument = schemaFields[1].getChildren();
+          console.log('subdocument', subdocument);
+          assert(
+            subdocument.length === 1,
+            `Expected subdocument to have 1 field found ${subdocument.length}`
+          );
+          assert(
+            fieldIsExpandable(subdocument.field),
+            'Expected subdocument to be expandable'
+          );
+          const nestedSubDocument = subdocument.getChildren();
+          assert(
+            nestedSubDocument.length === 3,
+            'Expected nested subdocument to have 3 fields'
+          );
+        }).then(done, done);
+    });
+  });
+
+  test('it shows dropdowns for arrays', function (done) {
+    seedDataAndCreateDataService(
+      'gryffindor',
+      [{
+        _id: 1,
+        testingArray: ['okay', 'nice']
+      }, {
+        _id: 2,
+        testingArray: ['dobby']
+      }]
+    ).then(dataService => {
+      const testSchemaTreeItem = new SchemaTreeItem(
+        'gryffindor',
+        TEST_DB_NAME,
+        dataService,
+        false,
+        false,
+        null
+      );
+
+      testSchemaTreeItem.onDidExpand();
+
+      testSchemaTreeItem
+        .getChildren()
+        .then((schemaFields) => {
+          dataService.disconnect();
+          assert(
+            schemaFields.length === 2,
+            `Expected 2 schema tree items to be returned, recieved ${schemaFields.length}`
+          );
+          assert(
+            fieldIsExpandable(schemaFields[1].field),
+            'Expected field to have expandable state'
+          );
+          const arrayFieldContainer = schemaFields[1].getChildren();
+          assert(
+            arrayFieldContainer.length === 1,
+            `Expected array field to have 1 field found ${arrayFieldContainer.length}`
+          );
+          assert(
+            fieldIsExpandable(arrayFieldContainer.field),
+            'Expected array field container to be expandable'
+          );
+          const arrayField = arrayFieldContainer.getChildren();
+          assert(
+            arrayField.length === 1,
+            `Expected array field fields to have 1 field found ${arrayField.length}`
+          );
+          assert(
+            !fieldIsExpandable(arrayField.field),
+            'Expected string field in array not to be expandable'
+          );
+        }).then(done, done);
+    });
+  });
+
+  test('it shows dropdowns and fields for document fields in arrays', function (done) {
+    seedDataAndCreateDataService(
+      'beach',
+      [{
+        _id: 1,
+        testingArray: [{
+          color: 'orange',
+          sunset: true
+        }]
+      }, {
+        _id: 2,
+        testingArray: [{
+          color: 'violet',
+          sunset: true
+        }]
+      }]
+    ).then(dataService => {
+      const testSchemaTreeItem = new SchemaTreeItem(
+        'beach',
+        TEST_DB_NAME,
+        dataService,
+        false,
+        false,
+        null
+      );
+
+      testSchemaTreeItem.onDidExpand();
+
+      testSchemaTreeItem
+        .getChildren()
+        .then((schemaFields) => {
+          dataService.disconnect();
+
+          console.log('schemaFields[1]', schemaFields[1]);
+          const arrayFieldContainer = schemaFields[1].getChildren();
+          console.log('arrayFieldContainer', arrayFieldContainer);
+          assert(
+            arrayFieldContainer.length === 1,
+            `Expected array fields to have length 1 found ${arrayFieldContainer.length}`
+          );
+          const nestedSubDocument = arrayFieldContainer.getChildren();
+          assert(
+            nestedSubDocument.length === 1,
+            `Expected array field fields to have 1 field found ${nestedSubDocument.length}`
+          );
+          const subdocFields = nestedSubDocument.getChildren();
+          assert(
+            fieldIsExpandable(subdocFields.field),
+            'Expected subdocument in array to be expandable'
+          );
+          assert(
+            subdocFields.length === 2,
+            `Expected subdocument in array field to have 2 fields found ${subdocFields.length}`
+          );
+          assert(
+            subdocFields[1].label === 'sunset',
+            'Expected subdocument field to have correct label'
+          );
+          assert(
+            !fieldIsExpandable(subdocFields[1].field),
+            'Expected subdocument boolean field to not be expandable'
+          );
+        }).then(done, done);
+    });
+  });
 });

--- a/src/test/suite/explorer/fieldTreeItems.test.ts
+++ b/src/test/suite/explorer/fieldTreeItems.test.ts
@@ -1,0 +1,4 @@
+
+suite('FieldTreeItem Test Suite', () => {
+
+});

--- a/src/test/suite/explorer/schemaTreeItem.test.ts
+++ b/src/test/suite/explorer/schemaTreeItem.test.ts
@@ -1,0 +1,161 @@
+import * as assert from 'assert';
+import path = require('path');
+import { afterEach } from 'mocha';
+
+import SchemaTreeItem from '../../../explorer/schemaTreeItem';
+import { fieldIsExpandable } from '../../../explorer/fieldTreeItem';
+import {
+  seedDataAndCreateDataService,
+  cleanup,
+  TEST_DB_NAME
+} from '../dbTestHelper';
+
+const { contributes } = require(path.resolve(__dirname, '../../../../package.json'));
+
+suite('SchemaTreeItem Test Suite', () => {
+  test('its context value should be in the package json', function () {
+    let schemaRegisteredCommandInPackageJson = false;
+
+    contributes.menus['view/item/context'].forEach(contextItem => {
+      if (contextItem.when.includes(SchemaTreeItem.contextValue)) {
+        schemaRegisteredCommandInPackageJson = true;
+      }
+    });
+
+    assert(
+      schemaRegisteredCommandInPackageJson,
+      'Expected schema tree item to be registered with a command in package json'
+    );
+  });
+
+  suite('Schema Tree', () => {
+    afterEach(() => cleanup());
+
+    test('when not expanded it has not yet pulled the schema', function (done) {
+      seedDataAndCreateDataService(
+        'favoritePiesIWantToEatRightNow',
+        [{
+          _id: 10,
+          someField: 'applePie'
+        }]
+      ).then(dataService => {
+        const testSchemaTreeItem = new SchemaTreeItem(
+          'favoritePiesIWantToEatRightNow',
+          TEST_DB_NAME,
+          dataService,
+          false,
+          false,
+          null
+        );
+
+        testSchemaTreeItem
+          .getChildren()
+          .then(async (schemaFields) => {
+            await dataService.disconnect();
+
+            assert(
+              schemaFields.length === 0,
+              `Expected no schema tree items to be returned, recieved ${schemaFields.length}`
+            );
+          })
+          .then(done, done);
+      });
+    });
+
+    test('when expanded shows the fields of a schema', function (done) {
+      seedDataAndCreateDataService(
+        'favoritePiesIWantToEatRightNow',
+        [{
+          _id: 1,
+          nameOfTastyPie: 'applePie'
+        }]
+      ).then(dataService => {
+        const testSchemaTreeItem = new SchemaTreeItem(
+          'favoritePiesIWantToEatRightNow',
+          TEST_DB_NAME,
+          dataService,
+          false,
+          false,
+          null
+        );
+
+        testSchemaTreeItem.onDidExpand();
+
+        testSchemaTreeItem
+          .getChildren()
+          .then(async (schemaFields) => {
+            await dataService.disconnect();
+
+            assert(
+              schemaFields.length === 2,
+              `Expected 2 schema tree items to be returned, recieved ${schemaFields.length}`
+            );
+            assert(
+              schemaFields[0].label === '_id',
+              `Expected label of schema tree item to be the field name, recieved ${schemaFields[0].label}`
+            );
+            assert(
+              schemaFields[1].label === 'nameOfTastyPie',
+              `Expected label of schema tree item to be the field name, recieved ${schemaFields[1].label}`
+            );
+          })
+          .then(done, done);
+      });
+    });
+
+    test('it only shows a dropdown for fields which are always documents', function (done) {
+      seedDataAndCreateDataService(
+        'favoritePiesIWantToEatRightNow',
+        [{
+          _id: 1,
+          alwaysDocument: {
+            fieldName: 'nice'
+          },
+          notAlwaysADocument: {
+            sureImADocument: 'hmmmm'
+          }
+        }, {
+          _id: 2,
+          alwaysDocument: {
+            fieldName: 'nice'
+          },
+          notAlwaysADocument: 'A spy!'
+        }]
+      ).then(dataService => {
+        const testSchemaTreeItem = new SchemaTreeItem(
+          'favoritePiesIWantToEatRightNow',
+          TEST_DB_NAME,
+          dataService,
+          false,
+          false,
+          null
+        );
+
+        testSchemaTreeItem.onDidExpand();
+
+        testSchemaTreeItem
+          .getChildren()
+          .then(async (schemaFields) => {
+            await dataService.disconnect();
+
+            assert(
+              schemaFields.length === 3,
+              `Expected 3 schema tree items to be returned, recieved ${schemaFields.length}`
+            );
+            assert(
+              fieldIsExpandable(schemaFields[1].field),
+              'Expected field to have expandable state'
+            );
+            assert(
+              fieldIsExpandable(schemaFields[2].field) === false,
+              'Expected field to have none expandable state'
+            );
+          })
+          .then(done, done);
+      });
+    });
+  });
+
+  // to test:
+  // - failing parse schema?
+});

--- a/src/test/suite/explorer/schemaTreeItem.test.ts
+++ b/src/test/suite/explorer/schemaTreeItem.test.ts
@@ -14,11 +14,11 @@ import {
 } from '../dbTestHelper';
 
 suite('SchemaTreeItem Test Suite', () => {
-  afterEach(function () {
+  afterEach(() => {
     sinon.restore();
   });
 
-  test('when the "show more" click handler function is called it sets the schema to show more fields', function () {
+  test('when the "show more" click handler function is called it sets the schema to show more fields', () => {
     const testSchemaTreeItem = new SchemaTreeItem(
       'favoritePiesIWantToEatRightNow',
       TEST_DB_NAME,
@@ -46,7 +46,7 @@ suite('SchemaTreeItem Test Suite', () => {
     );
   });
 
-  test('it should show a show more item when there are more fields to show', function (done) {
+  test('it should show a show more item when there are more fields to show', (done) => {
     const amountOfFieldsExpected = FIELDS_TO_SHOW;
     const mockDocWithTwentyFields = {};
     for (let i = 0; i < 20; i++) {
@@ -83,7 +83,7 @@ suite('SchemaTreeItem Test Suite', () => {
       .then(done, done);
   });
 
-  test('it should show more fields after the show more click handler is called', function (done) {
+  test('it should show more fields after the show more click handler is called', (done) => {
     const mockDocWithThirtyFields = {};
     for (let i = 0; i < 30; i++) {
       mockDocWithThirtyFields[`${i}`] = 'some value';
@@ -116,7 +116,7 @@ suite('SchemaTreeItem Test Suite', () => {
       .then(done, done);
   });
 
-  test('When schema parsing fails it displays an error message', function (done) {
+  test('When schema parsing fails it displays an error message', (done) => {
     const fakeVscodeErrorMessage = sinon.fake();
     sinon.replace(vscode.window, 'showErrorMessage', fakeVscodeErrorMessage);
 
@@ -153,7 +153,7 @@ suite('SchemaTreeItem Test Suite', () => {
       await cleanupTestDB();
     });
 
-    test('when not expanded it has not yet pulled the schema', function (done) {
+    test('when not expanded it has not yet pulled the schema', (done) => {
       seedDataAndCreateDataService('favoritePiesIWantToEatRightNow', [
         {
           _id: 10,
@@ -183,7 +183,7 @@ suite('SchemaTreeItem Test Suite', () => {
       });
     });
 
-    test('when expanded shows the fields of a schema', function (done) {
+    test('when expanded shows the fields of a schema', (done) => {
       seedDataAndCreateDataService('favoritePiesIWantToEatRightNow', [
         {
           _id: 1,
@@ -222,7 +222,7 @@ suite('SchemaTreeItem Test Suite', () => {
       });
     });
 
-    test('it only shows a dropdown for fields which are always documents - and not for polymorphic', function (done) {
+    test('it only shows a dropdown for fields which are always documents - and not for polymorphic', (done) => {
       seedDataAndCreateDataService('favoritePiesIWantToEatRightNow', [
         {
           _id: 1,

--- a/src/test/suite/explorer/schemaTreeItem.test.ts
+++ b/src/test/suite/explorer/schemaTreeItem.test.ts
@@ -3,7 +3,9 @@ import * as vscode from 'vscode';
 import { afterEach } from 'mocha';
 import * as sinon from 'sinon';
 
-import SchemaTreeItem, { FIELDS_TO_SHOW } from '../../../explorer/schemaTreeItem';
+import SchemaTreeItem, {
+  FIELDS_TO_SHOW
+} from '../../../explorer/schemaTreeItem';
 import { fieldIsExpandable } from '../../../explorer/fieldTreeItem';
 import {
   seedDataAndCreateDataService,
@@ -65,12 +67,13 @@ suite('SchemaTreeItem Test Suite', () => {
 
     testSchemaTreeItem
       .getChildren()
-      .then(schemaFields => {
+      .then((schemaFields) => {
         assert(FIELDS_TO_SHOW === 15, 'Expeted FIELDS_TO_SHOW to be 15');
 
         assert(
           schemaFields.length === amountOfFieldsExpected + 1,
-          `Expected ${amountOfFieldsExpected + 1} documents to be returned, found ${schemaFields.length}`
+          `Expected ${amountOfFieldsExpected +
+          1} documents to be returned, found ${schemaFields.length}`
         );
         assert(
           schemaFields[amountOfFieldsExpected].label === 'Show more fields...',
@@ -102,7 +105,7 @@ suite('SchemaTreeItem Test Suite', () => {
 
     testSchemaTreeItem
       .getChildren()
-      .then(schemaFields => {
+      .then((schemaFields) => {
         const amountOfFieldsExpected = 30;
 
         assert(
@@ -130,15 +133,19 @@ suite('SchemaTreeItem Test Suite', () => {
       null
     );
 
-    testSchemaTreeItem.getChildren().then(schemaFields => {
-      assert(schemaFields.length === 0);
-      assert(fakeVscodeErrorMessage.called);
-      const expectedMessage = 'Unable to parse schema: Unknown input type for `docs`. Must be an array, stream or MongoDB Cursor.';
-      assert(
-        fakeVscodeErrorMessage.firstArg === expectedMessage,
-        `Expected error message to be "${expectedMessage}" found "${fakeVscodeErrorMessage.firstArg}"`
-      );
-    }).then(done, done);
+    testSchemaTreeItem
+      .getChildren()
+      .then((schemaFields) => {
+        assert(schemaFields.length === 0);
+        assert(fakeVscodeErrorMessage.called);
+        const expectedMessage =
+          'Unable to parse schema: Unknown input type for `docs`. Must be an array, stream or MongoDB Cursor.';
+        assert(
+          fakeVscodeErrorMessage.firstArg === expectedMessage,
+          `Expected error message to be "${expectedMessage}" found "${fakeVscodeErrorMessage.firstArg}"`
+        );
+      })
+      .then(done, done);
   });
 
   suite('Live Database Tests', () => {
@@ -147,13 +154,12 @@ suite('SchemaTreeItem Test Suite', () => {
     });
 
     test('when not expanded it has not yet pulled the schema', function (done) {
-      seedDataAndCreateDataService(
-        'favoritePiesIWantToEatRightNow',
-        [{
+      seedDataAndCreateDataService('favoritePiesIWantToEatRightNow', [
+        {
           _id: 10,
           someField: 'applePie'
-        }]
-      ).then(dataService => {
+        }
+      ]).then((dataService) => {
         const testSchemaTreeItem = new SchemaTreeItem(
           'favoritePiesIWantToEatRightNow',
           TEST_DB_NAME,
@@ -165,25 +171,25 @@ suite('SchemaTreeItem Test Suite', () => {
 
         testSchemaTreeItem
           .getChildren()
-          .then(schemaFields => {
+          .then((schemaFields) => {
             dataService.disconnect();
 
             assert(
               schemaFields.length === 0,
               `Expected no schema tree items to be returned, recieved ${schemaFields.length}`
             );
-          }).then(done, done);
+          })
+          .then(done, done);
       });
     });
 
     test('when expanded shows the fields of a schema', function (done) {
-      seedDataAndCreateDataService(
-        'favoritePiesIWantToEatRightNow',
-        [{
+      seedDataAndCreateDataService('favoritePiesIWantToEatRightNow', [
+        {
           _id: 1,
           nameOfTastyPie: 'applePie'
-        }]
-      ).then(dataService => {
+        }
+      ]).then((dataService) => {
         const testSchemaTreeItem = new SchemaTreeItem(
           'favoritePiesIWantToEatRightNow',
           TEST_DB_NAME,
@@ -211,14 +217,14 @@ suite('SchemaTreeItem Test Suite', () => {
               schemaFields[1].label === 'nameOfTastyPie',
               `Expected label of schema tree item to be the field name, recieved ${schemaFields[1].label}`
             );
-          }).then(done, done);
+          })
+          .then(done, done);
       });
     });
 
     test('it only shows a dropdown for fields which are always documents - and not for polymorphic', function (done) {
-      seedDataAndCreateDataService(
-        'favoritePiesIWantToEatRightNow',
-        [{
+      seedDataAndCreateDataService('favoritePiesIWantToEatRightNow', [
+        {
           _id: 1,
           alwaysDocument: {
             fieldName: 'nice'
@@ -226,14 +232,15 @@ suite('SchemaTreeItem Test Suite', () => {
           notAlwaysADocument: {
             sureImADocument: 'hmmmm'
           }
-        }, {
+        },
+        {
           _id: 2,
           alwaysDocument: {
             fieldName: 'nice'
           },
           notAlwaysADocument: 'A spy!'
-        }]
-      ).then(dataService => {
+        }
+      ]).then((dataService) => {
         const testSchemaTreeItem = new SchemaTreeItem(
           'favoritePiesIWantToEatRightNow',
           TEST_DB_NAME,
@@ -261,7 +268,8 @@ suite('SchemaTreeItem Test Suite', () => {
               fieldIsExpandable(schemaFields[2].field) === false,
               'Expected field to have none expandable state'
             );
-          }).then(done, done);
+          })
+          .then(done, done);
       });
     });
   });

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -1,7 +1,7 @@
-import * as path from 'path';
 import * as Mocha from 'mocha';
 import * as glob from 'glob';
 import * as vscode from 'vscode';
+import path = require('path');
 
 import MDBExtensionController from '../../mdbExtensionController';
 import { TestExtensionContext } from './stubs';

--- a/src/test/suite/mdbExtensionController.test.ts
+++ b/src/test/suite/mdbExtensionController.test.ts
@@ -7,7 +7,7 @@ import { CollectionTreeItem } from '../../explorer';
 import { VIEW_COLLECTION_SCHEME } from '../../editors/collectionDocumentsProvider';
 import ConnectionTreeItem from '../../explorer/connectionTreeItem';
 import DatabaseTreeItem from '../../explorer/databaseTreeItem';
-import { CollectionTypes } from '../../explorer/collectionTreeItem';
+import { CollectionTypes } from '../../explorer/documentListTreeItem';
 import { mdbTestExtension } from './stubbableMdbExtension';
 import ConnectionController from '../../connectionController';
 import { StorageController } from '../../storage';
@@ -15,7 +15,7 @@ import { StorageController } from '../../storage';
 const testDatabaseURI = 'mongodb://localhost:27018';
 
 suite('MDBExtensionController Test Suite', () => {
-  afterEach(function() {
+  afterEach(function () {
     sinon.restore();
   });
 
@@ -157,7 +157,7 @@ suite('MDBExtensionController Test Suite', () => {
         );
         assert(
           mockRemoveMongoDBConnection.firstArg ===
-            'craving_for_pancakes_with_maple_syrup',
+          'craving_for_pancakes_with_maple_syrup',
           `Expected the mock connection controller to be called to remove the connection with the id "craving_for_pancakes_with_maple_syrup", found ${mockRemoveMongoDBConnection.firstArg}.`
         );
       })

--- a/src/test/suite/mdbExtensionController.test.ts
+++ b/src/test/suite/mdbExtensionController.test.ts
@@ -28,13 +28,12 @@ suite('MDBExtensionController Test Suite', () => {
 
     const textCollectionTree = new CollectionTreeItem(
       {
-        name: 'testColName'
+        name: 'testColName',
+        type: CollectionTypes.collection
       },
       'testDbName',
       {},
-      false,
-      [],
-      10
+      false
     );
 
     vscode.commands
@@ -232,9 +231,7 @@ suite('MDBExtensionController Test Suite', () => {
       },
       'airZebra',
       {},
-      false,
-      [],
-      5
+      false
     );
 
     const mockCopyToClipboard = sinon.fake.resolves();
@@ -282,7 +279,7 @@ suite('MDBExtensionController Test Suite', () => {
       .then(done, done);
   });
 
-  test('mdb.refreshCollection command should reset the cache on the collection tree item and call to refresh the explorer controller', (done) => {
+  test('mdb.refreshCollection command should reset the expanded state of its children and call to refresh the explorer controller', (done) => {
     const mockTreeItem = new CollectionTreeItem(
       {
         name: 'iSawACatThatLookedLikeALionToday',
@@ -290,12 +287,12 @@ suite('MDBExtensionController Test Suite', () => {
       },
       'airZebra',
       {},
-      false,
-      [],
-      5
+      false
     );
 
-    mockTreeItem._childrenCacheIsUpToDate = true;
+    // Set expanded.
+    mockTreeItem.getSchemaChild().isExpanded = true;
+    mockTreeItem.getDocumentListChild().isExpanded = true;
 
     const mockExplorerControllerRefresh = sinon.fake.resolves();
     sinon.replace(
@@ -308,8 +305,12 @@ suite('MDBExtensionController Test Suite', () => {
       .executeCommand('mdb.refreshCollection', mockTreeItem)
       .then(() => {
         assert(
-          mockTreeItem._childrenCacheIsUpToDate === false,
-          'Expected cache on tree item to be set to not up to date.'
+          mockTreeItem.getDocumentListChild().isExpanded === false,
+          'Expected document list on collection tree item to be reset to not expanded.'
+        );
+        assert(
+          mockTreeItem.getSchemaChild().isExpanded === false,
+          'Expected schema on collection tree item to be reset to not expanded.'
         );
         assert(
           mockExplorerControllerRefresh.called === true,
@@ -672,9 +673,7 @@ suite('MDBExtensionController Test Suite', () => {
           callback(null, true);
         }
       },
-      false,
-      [],
-      10
+      false
     );
 
     const mockInputBoxResolves = sinon.stub();
@@ -700,12 +699,10 @@ suite('MDBExtensionController Test Suite', () => {
       .addNewConnectionAndConnect(testDatabaseURI)
       .then(() => {
         const testCollectionTreeItem = new CollectionTreeItem(
-          { name: 'doesntExistColName' },
+          { name: 'doesntExistColName', type: CollectionTypes.collection },
           'doesntExistDBName',
           testConnectionController.getActiveConnection(),
-          false,
-          [],
-          10
+          false
         );
 
         const mockInputBoxResolves = sinon.stub();
@@ -738,12 +735,10 @@ suite('MDBExtensionController Test Suite', () => {
 
   test('mdb.dropCollection fails when the input doesnt match the collection name', (done) => {
     const testCollectionTreeItem = new CollectionTreeItem(
-      { name: 'orange' },
+      { name: 'orange', type: CollectionTypes.collection },
       'fruitsThatAreTasty',
       {},
-      false,
-      [],
-      10
+      false
     );
 
     const mockInputBoxResolves = sinon.stub();
@@ -763,12 +758,10 @@ suite('MDBExtensionController Test Suite', () => {
 
   test('mdb.dropCollection fails when the collection name input is empty', (done) => {
     const testCollectionTreeItem = new CollectionTreeItem(
-      { name: 'orange' },
+      { name: 'orange', type: CollectionTypes.view },
       'fruitsThatAreTasty',
       {},
-      false,
-      [],
-      10
+      false
     );
 
     const mockInputBoxResolves = sinon.stub();

--- a/src/test/suite/mdbExtensionController.test.ts
+++ b/src/test/suite/mdbExtensionController.test.ts
@@ -15,7 +15,7 @@ import { StorageController } from '../../storage';
 const testDatabaseURI = 'mongodb://localhost:27018';
 
 suite('MDBExtensionController Test Suite', () => {
-  afterEach(function () {
+  afterEach(() => {
     sinon.restore();
   });
 

--- a/src/test/suite/mdbExtensionController.test.ts
+++ b/src/test/suite/mdbExtensionController.test.ts
@@ -60,6 +60,47 @@ suite('MDBExtensionController Test Suite', () => {
       .then(done, done);
   });
 
+  test('mdb.viewCollectionDocuments command should also work with the documents list', (done) => {
+    const mockOpenTextDocument = sinon.fake.resolves('magna carta');
+    sinon.replace(vscode.workspace, 'openTextDocument', mockOpenTextDocument);
+
+    const mockShowTextDocument = sinon.fake.resolves();
+    sinon.replace(vscode.window, 'showTextDocument', mockShowTextDocument);
+
+    const textCollectionTree = new CollectionTreeItem(
+      {
+        name: 'testColName',
+        type: CollectionTypes.collection
+      },
+      'testDbName',
+      {},
+      false
+    );
+
+    vscode.commands
+      .executeCommand('mdb.viewCollectionDocuments', textCollectionTree)
+      .then(() => {
+        assert(
+          mockOpenTextDocument.firstArg.path.indexOf(
+            'Results: testDbName.testColName'
+          ) === 0
+        );
+        assert(mockOpenTextDocument.firstArg.path.includes('.json'));
+        assert(mockOpenTextDocument.firstArg.scheme === VIEW_COLLECTION_SCHEME);
+        assert(
+          mockOpenTextDocument.firstArg.query.includes(
+            'namespace=testDbName.testColName'
+          )
+        );
+
+        assert(
+          mockShowTextDocument.firstArg === 'magna carta',
+          'Expected it to call vscode to show the returned documents from the provider'
+        );
+      })
+      .then(done, done);
+  });
+
   test('mdb.addConnection command should call addMongoDBConnection on the connection controller', (done) => {
     const mockAddConnection = sinon.fake.resolves();
     sinon.replace(

--- a/src/test/suite/snippets/stageAutocompleter.test.ts
+++ b/src/test/suite/snippets/stageAutocompleter.test.ts
@@ -41,8 +41,6 @@ const STAGE_LABELS = [
 ];
 
 suite('Stage Autocompleter Test Suite', () => {
-  vscode.window.showInformationMessage('Starting tests...');
-
   test('checks that stage-autocompleter.json exists and includes JSON with prefix, body and description', () => {
     const properties: any = {};
 

--- a/src/test/suite/storage/storageController.test.ts
+++ b/src/test/suite/storage/storageController.test.ts
@@ -1,13 +1,10 @@
 import * as assert from 'assert';
-import * as vscode from 'vscode';
 
 import StorageController, { StorageVariables, StorageScope } from '../../../storage/storageController';
 
 import { TestExtensionContext } from '../stubs';
 
 suite('Storage Controller Test Suite', () => {
-  vscode.window.showInformationMessage('Starting tests...');
-
   test('getting a variable gets it from the global context store', function () {
     const testExtensionContext = new TestExtensionContext();
     testExtensionContext._globalState = {

--- a/src/test/suite/storage/storageController.test.ts
+++ b/src/test/suite/storage/storageController.test.ts
@@ -5,7 +5,7 @@ import StorageController, { StorageVariables, StorageScope } from '../../../stor
 import { TestExtensionContext } from '../stubs';
 
 suite('Storage Controller Test Suite', () => {
-  test('getting a variable gets it from the global context store', function () {
+  test('getting a variable gets it from the global context store', () => {
     const testExtensionContext = new TestExtensionContext();
     testExtensionContext._globalState = {
       [StorageVariables.GLOBAL_CONNECTION_STRINGS]: 'this_gonna_get_saved'
@@ -20,7 +20,7 @@ suite('Storage Controller Test Suite', () => {
     );
   });
 
-  test('getting a variable from the workspace state gets it from the workspace context store', function () {
+  test('getting a variable from the workspace state gets it from the workspace context store', () => {
     const testExtensionContext = new TestExtensionContext();
     testExtensionContext._workspaceState = {
       [StorageVariables.WORKSPACE_CONNECTION_STRINGS]: 'i_cant_believe_its_gonna_save_this'
@@ -36,7 +36,7 @@ suite('Storage Controller Test Suite', () => {
     );
   });
 
-  test('addNewConnectionToGlobalStore adds the connection to preexisting connections on the global store', function () {
+  test('addNewConnectionToGlobalStore adds the connection to preexisting connections on the global store', () => {
     const testExtensionContext = new TestExtensionContext();
     testExtensionContext._globalState = {
       [StorageVariables.GLOBAL_CONNECTION_STRINGS]: {
@@ -57,7 +57,7 @@ suite('Storage Controller Test Suite', () => {
     assert(updatedGlobalModels.new_conn === 'another_url_that_is_so_saved', 'Expected new connection data to exist.');
   });
 
-  test('addNewConnectionToWorkspaceStore adds the connection to preexisting connections on the workspace store', function () {
+  test('addNewConnectionToWorkspaceStore adds the connection to preexisting connections on the workspace store', () => {
     const testExtensionContext = new TestExtensionContext();
     testExtensionContext._workspaceState = {
       [StorageVariables.WORKSPACE_CONNECTION_STRINGS]: {


### PR DESCRIPTION
https://jira.mongodb.org/browse/VSCODE-57

This PR adds viewing a collection or view's schema in the tree view. Using https://github.com/mongodb-js/mongodb-schema we show all of the fields found in the sample `MAX_DOCUMENTS_VISIBLE` (10) documents pulled from the collection. When we find arrays or objects which have a type probability of 1 (they're not polymorphic in the sample) we show a dropdown for these items. For arrays, we show a dropdown which contains an `Array` dropdown which has items for all of the types found in the array.

Currently we're just showing the name of the fields, we'll be adding icons and maybe some better tooltips in https://jira.mongodb.org/browse/VSCODE-58 

We currently show the first 15 fields found in a collection, and hide the rest behind a `Show more fields...` selection item. There's a gif at the bottom on this. Do ya'll think 15 is a good number?
We aren't caching the expanded state of the schema yet, so when it's hidden then re-opened it loses its nested expansion state. I've added this to a future ticket https://jira.mongodb.org/browse/VSCODE-59

In this PR we also add types for the `Connection` model we are using in connection manager and `DataService`, I haven't yet piped them around fully but it's a start in getting rid of the `any`.

For testing I added `dbTestHelper` which has a few functions that should help with mocking and clearing up data a bit so we can fully test against a real database.

**Screenshots**
___
*Show more fields...*
![show more fields](https://user-images.githubusercontent.com/1791149/76312471-6f1cc780-62d3-11ea-92db-2fb1fca8bc93.gif)

*Showing an array of documents and string array.*
![array of docs and more](https://user-images.githubusercontent.com/1791149/76312492-7a6ff300-62d3-11ea-9b11-d470b24658c2.gif)

