### PR TITLE
VSCODE-59: Add schema actions and cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,11 +56,15 @@
   "activationEvents": [
     "onCommand:mdb.connect",
     "onCommand:mdb.connectWithURI",
+    "onCommand:mdb.createPlayground",
+    "onCommand:mdb.addConnection",
+    "onCommand:mdb.addConnectionWithURI",
     "onCommand:mdb.disconnect",
     "onCommand:mdb.removeConnection",
     "onCommand:mdb.openMongoDBShell",
     "onView:mongoDB",
-    "onLanguage:json"
+    "onLanguage:json",
+    "onLanguage:mongodb"
   ],
   "contributes": {
     "viewsContainers": {
@@ -157,7 +161,7 @@
       },
       {
         "command": "mdb.addDatabase",
-        "title": "Add Database",
+        "title": "Add Database...",
         "icon": {
           "light": "images/light/plus-circle.svg",
           "dark": "images/dark/plus-circle.svg"
@@ -189,7 +193,7 @@
       },
       {
         "command": "mdb.addCollection",
-        "title": "Add Collection",
+        "title": "Add Collection...",
         "icon": {
           "light": "images/light/plus-circle.svg",
           "dark": "images/dark/plus-circle.svg"
@@ -210,9 +214,23 @@
       {
         "command": "mdb.refreshCollection",
         "title": "Refresh"
+      },
+      {
+        "command": "mdb.refreshSchema",
+        "title": "Refresh"
       }
     ],
     "menus": {
+      "view/title": [
+        {
+          "command": "mdb.addConnection",
+          "when": "view == mongoDB"
+        },
+        {
+          "command": "mdb.addConnectionWithURI",
+          "when": "view == mongoDB"
+        }
+      ],
       "view/item/context": [
         {
           "command": "mdb.addConnection",
@@ -228,41 +246,49 @@
           "when": "view == mongoDB && viewItem == mdbConnectionsTreeItem"
         },
         {
-          "command": "mdb.connectToConnectionTreeItem",
-          "when": "view == mongoDB && viewItem == disconnectedConnectionTreeItem"
-        },
-        {
-          "command": "mdb.disconnectFromConnectionTreeItem",
-          "when": "view == mongoDB && viewItem == connectedConnectionTreeItem"
-        },
-        {
-          "command": "mdb.treeItemRemoveConnection",
-          "when": "view == mongoDB && viewItem == disconnectedConnectionTreeItem"
-        },
-        {
-          "command": "mdb.treeItemRemoveConnection",
-          "when": "view == mongoDB && viewItem == connectedConnectionTreeItem"
-        },
-        {
-          "command": "mdb.copyConnectionString",
-          "when": "view == mongoDB && viewItem == disconnectedConnectionTreeItem"
-        },
-        {
-          "command": "mdb.copyConnectionString",
-          "when": "view == mongoDB && viewItem == connectedConnectionTreeItem"
-        },
-        {
-          "command": "mdb.refreshConnection",
-          "when": "view == mongoDB && viewItem == connectedConnectionTreeItem"
-        },
-        {
           "command": "mdb.addDatabase",
           "when": "view == mongoDB && viewItem == connectedConnectionTreeItem",
           "group": "inline"
         },
         {
           "command": "mdb.addDatabase",
-          "when": "view == mongoDB && viewItem == connectedConnectionTreeItem"
+          "when": "view == mongoDB && viewItem == connectedConnectionTreeItem",
+          "group": "1@1"
+        },
+        {
+          "command": "mdb.refreshConnection",
+          "when": "view == mongoDB && viewItem == connectedConnectionTreeItem",
+          "group": "1@2"
+        },
+        {
+          "command": "mdb.copyConnectionString",
+          "when": "view == mongoDB && viewItem == connectedConnectionTreeItem",
+          "group": "2@1"
+        },
+        {
+          "command": "mdb.disconnectFromConnectionTreeItem",
+          "when": "view == mongoDB && viewItem == connectedConnectionTreeItem",
+          "group": "3@1"
+        },
+        {
+          "command": "mdb.treeItemRemoveConnection",
+          "when": "view == mongoDB && viewItem == connectedConnectionTreeItem",
+          "group": "3@2"
+        },
+        {
+          "command": "mdb.connectToConnectionTreeItem",
+          "when": "view == mongoDB && viewItem == disconnectedConnectionTreeItem",
+          "group": "1@1"
+        },
+        {
+          "command": "mdb.copyConnectionString",
+          "when": "view == mongoDB && viewItem == disconnectedConnectionTreeItem",
+          "group": "2@1"
+        },
+        {
+          "command": "mdb.treeItemRemoveConnection",
+          "when": "view == mongoDB && viewItem == disconnectedConnectionTreeItem",
+          "group": "3@1"
         },
         {
           "command": "mdb.addCollection",
@@ -271,39 +297,51 @@
         },
         {
           "command": "mdb.addCollection",
-          "when": "view == mongoDB && viewItem == databaseTreeItem"
-        },
-        {
-          "command": "mdb.dropDatabase",
-          "when": "view == mongoDB && viewItem == databaseTreeItem"
-        },
-        {
-          "command": "mdb.copyDatabaseName",
-          "when": "view == mongoDB && viewItem == databaseTreeItem"
+          "when": "view == mongoDB && viewItem == databaseTreeItem",
+          "group": "1@1"
         },
         {
           "command": "mdb.refreshDatabase",
-          "when": "view == mongoDB && viewItem == databaseTreeItem"
+          "when": "view == mongoDB && viewItem == databaseTreeItem",
+          "group": "1@2"
+        },
+        {
+          "command": "mdb.copyDatabaseName",
+          "when": "view == mongoDB && viewItem == databaseTreeItem",
+          "group": "2@1"
+        },
+        {
+          "command": "mdb.dropDatabase",
+          "when": "view == mongoDB && viewItem == databaseTreeItem",
+          "group": "3@1"
         },
         {
           "command": "mdb.viewCollectionDocuments",
-          "when": "view == mongoDB && viewItem == collectionTreeItem"
+          "when": "view == mongoDB && viewItem == collectionTreeItem",
+          "group": "1@1"
+        },
+        {
+          "command": "mdb.refreshCollection",
+          "when": "view == mongoDB && viewItem == collectionTreeItem",
+          "group": "1@2"
+        },
+        {
+          "command": "mdb.copyCollectionName",
+          "when": "view == mongoDB && viewItem == collectionTreeItem",
+          "group": "2@1"
+        },
+        {
+          "command": "mdb.dropCollection",
+          "when": "view == mongoDB && viewItem == collectionTreeItem",
+          "group": "3@1"
         },
         {
           "command": "mdb.viewCollectionDocuments",
           "when": "view == mongoDB && viewItem == documentListTreeItem"
         },
         {
-          "command": "mdb.dropCollection",
-          "when": "view == mongoDB && viewItem == collectionTreeItem"
-        },
-        {
-          "command": "mdb.copyCollectionName",
-          "when": "view == mongoDB && viewItem == collectionTreeItem"
-        },
-        {
-          "command": "mdb.refreshCollection",
-          "when": "view == mongoDB && viewItem == collectionTreeItem"
+          "command": "mdb.refreshSchema",
+          "when": "view == mongoDB && viewItem == schemaTreeItem"
         }
       ]
     },

--- a/src/explorer/collectionTreeItem.ts
+++ b/src/explorer/collectionTreeItem.ts
@@ -49,22 +49,22 @@ export default class CollectionTreeItem extends vscode.TreeItem
     this._documentListChild = existingDocumentListChild
       ? existingDocumentListChild
       : new DocumentListTreeItem(
-        this.collectionName,
-        this.databaseName,
-        this._type,
-        this._dataService,
-        false, // Collapsed.
-        MAX_DOCUMENTS_VISIBLE,
-        null // No existing cache.
-      );
+          this.collectionName,
+          this.databaseName,
+          this._type,
+          this._dataService,
+          false, // Collapsed.
+          MAX_DOCUMENTS_VISIBLE,
+          null // No existing cache.
+        );
     this._schemaChild = existingSchemaChild
       ? existingSchemaChild
       : new SchemaTreeItem(
-        this.collectionName,
-        this.databaseName,
-        this._dataService,
-        false // Collapsed.
-      );
+          this.collectionName,
+          this.databaseName,
+          this._dataService,
+          false // Collapsed.
+        );
   }
 
   get tooltip(): string {

--- a/src/explorer/collectionTreeItem.ts
+++ b/src/explorer/collectionTreeItem.ts
@@ -63,9 +63,7 @@ export default class CollectionTreeItem extends vscode.TreeItem
         this.collectionName,
         this.databaseName,
         this._dataService,
-        false, // Collapsed.
-        false, // Show more fields has not been clicked.
-        null // No existing cache.
+        false // Collapsed.
       );
   }
 
@@ -96,8 +94,7 @@ export default class CollectionTreeItem extends vscode.TreeItem
       this.databaseName,
       this._dataService,
       this._schemaChild.isExpanded,
-      this._schemaChild.hasClickedShowMoreFields,
-      this._schemaChild.getChildrenCache()
+      this._schemaChild
     );
     return Promise.resolve([this._documentListChild, this._schemaChild]);
   }
@@ -126,9 +123,7 @@ export default class CollectionTreeItem extends vscode.TreeItem
       this.collectionName,
       this.databaseName,
       this._dataService,
-      false, // Collapsed.
-      false, // Show more fields has not been clicked.
-      null // No existing cache.
+      false // Collapsed.
     );
   }
 

--- a/src/explorer/collectionTreeItem.ts
+++ b/src/explorer/collectionTreeItem.ts
@@ -49,22 +49,22 @@ export default class CollectionTreeItem extends vscode.TreeItem
     this._documentListChild = existingDocumentListChild
       ? existingDocumentListChild
       : new DocumentListTreeItem(
-          this.collectionName,
-          this.databaseName,
-          this._type,
-          this._dataService,
-          false, // Collapsed.
-          MAX_DOCUMENTS_VISIBLE,
-          null // No existing cache.
-        );
+        this.collectionName,
+        this.databaseName,
+        this._type,
+        this._dataService,
+        false, // Collapsed.
+        MAX_DOCUMENTS_VISIBLE,
+        null // No existing cache.
+      );
     this._schemaChild = existingSchemaChild
       ? existingSchemaChild
       : new SchemaTreeItem(
-          this.collectionName,
-          this.databaseName,
-          this._dataService,
-          false // Collapsed.
-        );
+        this.collectionName,
+        this.databaseName,
+        this._dataService,
+        false // Collapsed.
+      );
   }
 
   get tooltip(): string {

--- a/src/explorer/connectionTreeItem.ts
+++ b/src/explorer/connectionTreeItem.ts
@@ -72,7 +72,7 @@ export default class ConnectionTreeItem extends vscode.TreeItem
     if (
       this._connectionController.isConnecting() &&
       this._connectionController.getConnectingInstanceId() ===
-        this.connectionInstanceId
+      this.connectionInstanceId
     ) {
       return 'connecting...';
     }
@@ -142,8 +142,8 @@ export default class ConnectionTreeItem extends vscode.TreeItem
     | string
     | vscode.Uri
     | { light: string | vscode.Uri; dark: string | vscode.Uri } {
-    const LIGHT = path.join(__dirname, '..', '..', '..', 'images', 'light');
-    const DARK = path.join(__dirname, '..', '..', '..', 'images', 'dark');
+    const LIGHT = path.join(__dirname, '..', '..', 'images', 'light');
+    const DARK = path.join(__dirname, '..', '..', 'images', 'dark');
 
     if (
       this._connectionController.getActiveConnectionInstanceId() ===

--- a/src/explorer/databaseTreeItem.ts
+++ b/src/explorer/databaseTreeItem.ts
@@ -106,8 +106,8 @@ export default class DatabaseTreeItem extends vscode.TreeItem
     | string
     | vscode.Uri
     | { light: string | vscode.Uri; dark: string | vscode.Uri } {
-    const LIGHT = path.join(__dirname, '..', '..', '..', 'images', 'light');
-    const DARK = path.join(__dirname, '..', '..', '..', 'images', 'dark');
+    const LIGHT = path.join(__dirname, '..', '..', 'images', 'light');
+    const DARK = path.join(__dirname, '..', '..', 'images', 'dark');
 
     return {
       light: path.join(LIGHT, 'database.svg'),

--- a/src/explorer/documentListTreeItem.ts
+++ b/src/explorer/documentListTreeItem.ts
@@ -154,15 +154,19 @@ export default class DocumentListTreeItem extends vscode.TreeItem
     | string
     | vscode.Uri
     | { light: string | vscode.Uri; dark: string | vscode.Uri } {
-    return this._type === CollectionTypes.collection
-      ? {
-        light: path.join(__filename, '..', '..', '..', 'resources', 'light', 'collection.svg'),
-        dark: path.join(__filename, '..', '..', '..', 'resources', 'dark', 'collection.svg')
-      }
-      : {
-        light: path.join(__filename, '..', '..', '..', 'resources', 'light', 'view.svg'),
-        dark: path.join(__filename, '..', '..', '..', 'resources', 'dark', 'view.svg')
+    const LIGHT = path.join(__dirname, '..', '..', 'images', 'light');
+    const DARK = path.join(__dirname, '..', '..', 'images', 'dark');
+
+    if (this._type === CollectionTypes.collection) {
+      return {
+        light: path.join(LIGHT, 'collection.svg'),
+        dark: path.join(DARK, 'collection.svg')
       };
+    }
+    return {
+      light: path.join(LIGHT, 'view.svg'),
+      dark: path.join(DARK, 'view.svg')
+    };
   }
 
   onShowMoreClicked(): void {

--- a/src/explorer/fieldTreeItem.ts
+++ b/src/explorer/fieldTreeItem.ts
@@ -56,7 +56,11 @@ export default class FieldTreeItem extends vscode.TreeItem
 
   isExpanded: boolean;
 
-  constructor(field: SchemaFieldType, isExpanded: boolean, existingCache: { [fieldName: string]: FieldTreeItem }) {
+  constructor(
+    field: SchemaFieldType,
+    isExpanded: boolean,
+    existingCache: { [fieldName: string]: FieldTreeItem }
+  ) {
     super(field.name, getCollapsibleStateForField(field, isExpanded));
 
     this.field = field;
@@ -82,7 +86,10 @@ export default class FieldTreeItem extends vscode.TreeItem
     const pastChildrenCache = this._childrenCache;
     this._childrenCache = {};
 
-    if (this.field.bsonType === FieldTypes.document || this.field.type === FieldTypes.document) {
+    if (
+      this.field.bsonType === FieldTypes.document ||
+      this.field.type === FieldTypes.document
+    ) {
       let subDocumentFields;
       if (this.field.type === FieldTypes.document) {
         subDocumentFields = this.field.types[0].fields;
@@ -102,7 +109,7 @@ export default class FieldTreeItem extends vscode.TreeItem
             this._childrenCache[subField.name] = new FieldTreeItem(
               subField,
               false,
-              {},
+              {}
             );
           }
         });
@@ -123,7 +130,7 @@ export default class FieldTreeItem extends vscode.TreeItem
         this._childrenCache[arrayElement.name] = new FieldTreeItem(
           arrayElement,
           false,
-          {},
+          {}
         );
       }
     }

--- a/src/explorer/fieldTreeItem.ts
+++ b/src/explorer/fieldTreeItem.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import TreeItemParentInterface from './treeItemParentInterface';
 
 export enum FieldTypes {
   document = 'Document',
@@ -16,7 +17,7 @@ export type SchemaFieldType = {
   fields: SchemaFieldType[] | undefined;
 };
 
-export function fieldIsExpandable(field: SchemaFieldType): boolean {
+export const fieldIsExpandable = (field: SchemaFieldType): boolean => {
   return (
     field.probability === 1 &&
     (field.type === FieldTypes.document ||
@@ -24,37 +25,45 @@ export function fieldIsExpandable(field: SchemaFieldType): boolean {
       field.bsonType === FieldTypes.document ||
       field.bsonType === FieldTypes.array)
   );
-}
+};
 
-function getCollapsibleStateForField(
-  field: SchemaFieldType
-): vscode.TreeItemCollapsibleState {
+const getCollapsibleStateForField = (
+  field: SchemaFieldType,
+  isExpanded: boolean
+): vscode.TreeItemCollapsibleState => {
   if (!fieldIsExpandable(field)) {
     return vscode.TreeItemCollapsibleState.None;
   }
 
-  return vscode.TreeItemCollapsibleState.Collapsed;
-}
+  return isExpanded
+    ? vscode.TreeItemCollapsibleState.Expanded
+    : vscode.TreeItemCollapsibleState.Collapsed;
+};
 
 export default class FieldTreeItem extends vscode.TreeItem
-  implements vscode.TreeDataProvider<FieldTreeItem> {
+  implements vscode.TreeDataProvider<FieldTreeItem>, TreeItemParentInterface {
   // This is a flag which notes that when this tree element is updated,
   // the tree view does not have to fully update like it does with
   // asynchronous resources.
   doesNotRequireTreeUpdate = true;
 
+  private _childrenCache: { [fieldName: string]: FieldTreeItem } = {};
+
   field: SchemaFieldType;
+  fieldName: string;
 
   contextValue = 'fieldTreeItem';
 
-  fieldName: string;
+  isExpanded: boolean;
 
-  constructor(field: SchemaFieldType) {
-    super(field.name, getCollapsibleStateForField(field));
+  constructor(field: SchemaFieldType, isExpanded: boolean, existingCache: { [fieldName: string]: FieldTreeItem }) {
+    super(field.name, getCollapsibleStateForField(field, isExpanded));
 
     this.field = field;
-
     this.fieldName = field.name;
+
+    this.isExpanded = isExpanded;
+    this._childrenCache = existingCache;
   }
 
   get tooltip(): string {
@@ -70,40 +79,69 @@ export default class FieldTreeItem extends vscode.TreeItem
       return Promise.resolve([]);
     }
 
-    if (this.field.bsonType === FieldTypes.document) {
-      const subDocumentFields = this.field.fields;
-      return Promise.resolve(
-        subDocumentFields
-          ? subDocumentFields.map((subField) => new FieldTreeItem(subField))
-          : []
-      );
-    } else if (this.field.type === FieldTypes.document) {
-      const subDocumentFields = this.field.types[0].fields;
+    const pastChildrenCache = this._childrenCache;
+    this._childrenCache = {};
 
-      return Promise.resolve(
-        subDocumentFields
-          ? subDocumentFields.map((subField) => new FieldTreeItem(subField))
-          : []
-      );
+    if (this.field.bsonType === FieldTypes.document || this.field.type === FieldTypes.document) {
+      let subDocumentFields;
+      if (this.field.type === FieldTypes.document) {
+        subDocumentFields = this.field.types[0].fields;
+      } else if (this.field.bsonType === FieldTypes.document) {
+        subDocumentFields = this.field.fields;
+      }
+
+      if (subDocumentFields) {
+        subDocumentFields.forEach((subField) => {
+          if (pastChildrenCache[subField.name]) {
+            this._childrenCache[subField.name] = new FieldTreeItem(
+              subField,
+              pastChildrenCache[subField.name].isExpanded,
+              pastChildrenCache[subField.name].getChildrenCache()
+            );
+          } else {
+            this._childrenCache[subField.name] = new FieldTreeItem(
+              subField,
+              false,
+              {},
+            );
+          }
+        });
+      }
     } else if (
       this.field.type === FieldTypes.array ||
       this.field.bsonType === FieldTypes.array
     ) {
       const arrayElement = this.field.types[0];
 
-      return Promise.resolve([new FieldTreeItem(arrayElement)]);
+      if (pastChildrenCache[arrayElement.name]) {
+        this._childrenCache[arrayElement.name] = new FieldTreeItem(
+          arrayElement,
+          pastChildrenCache[arrayElement.name].isExpanded,
+          pastChildrenCache[arrayElement.name].getChildrenCache()
+        );
+      } else {
+        this._childrenCache[arrayElement.name] = new FieldTreeItem(
+          arrayElement,
+          false,
+          {},
+        );
+      }
     }
 
-    return Promise.resolve([]);
+    return Promise.resolve(Object.values(this._childrenCache));
   }
 
   onDidCollapse(): void {
-    // no-op until we add caching expanded state.
+    this.isExpanded = false;
   }
 
   onDidExpand(): Promise<boolean> {
-    // no-op until we add caching expanded state.
+    this.isExpanded = true;
 
     return Promise.resolve(true);
+  }
+
+  getChildrenCache(): { [fieldName: string]: FieldTreeItem } {
+    return this._childrenCache;
   }
 }

--- a/src/explorer/schemaTreeItem.ts
+++ b/src/explorer/schemaTreeItem.ts
@@ -91,7 +91,7 @@ export default class SchemaTreeItem extends vscode.TreeItem
   }
 
   getChildren(): Thenable<any[]> {
-    if (!this.isExpanded && !this.childrenCacheIsUpToDate) {
+    if (!this.isExpanded) {
       return Promise.resolve([]);
     }
 

--- a/src/explorer/schemaTreeItem.ts
+++ b/src/explorer/schemaTreeItem.ts
@@ -29,7 +29,7 @@ class ShowAllFieldsTreeItem extends vscode.TreeItem {
 export default class SchemaTreeItem extends vscode.TreeItem
   implements TreeItemParent, vscode.TreeDataProvider<SchemaTreeItem> {
   childrenCacheIsUpToDate: boolean;
-  private childrenCache: { [fieldName: string]: FieldTreeItem };
+  childrenCache: { [fieldName: string]: FieldTreeItem };
 
   contextValue = 'schemaTreeItem';
 
@@ -65,11 +65,13 @@ export default class SchemaTreeItem extends vscode.TreeItem
     this.isExpanded = isExpanded;
 
     if (cachedSchemaTreeItem) {
-      this.hasClickedShowMoreFields = cachedSchemaTreeItem.hasClickedShowMoreFields;
+      this.hasClickedShowMoreFields =
+        cachedSchemaTreeItem.hasClickedShowMoreFields;
       this.hasMoreFieldsToShow = cachedSchemaTreeItem.hasMoreFieldsToShow;
 
       this.childrenCache = cachedSchemaTreeItem.childrenCache;
-      this.childrenCacheIsUpToDate = cachedSchemaTreeItem.childrenCacheIsUpToDate;
+      this.childrenCacheIsUpToDate =
+        cachedSchemaTreeItem.childrenCacheIsUpToDate;
     } else {
       // No existing cache to pull from, default values.
       this.hasClickedShowMoreFields = false;
@@ -94,21 +96,30 @@ export default class SchemaTreeItem extends vscode.TreeItem
     }
 
     if (this.childrenCacheIsUpToDate) {
-      if (
-        !this.hasClickedShowMoreFields &&
-        this.hasMoreFieldsToShow
-      ) {
+      if (!this.hasClickedShowMoreFields && this.hasMoreFieldsToShow) {
         return Promise.resolve([
-          ...Object.values(this.childrenCache).map(fieldItem => new FieldTreeItem(
-            fieldItem.field,
-            fieldItem.isExpanded,
-            fieldItem.getChildrenCache()
-          )),
+          ...Object.values(this.childrenCache).map(
+            (cachedField) =>
+              new FieldTreeItem(
+                cachedField.field,
+                cachedField.isExpanded,
+                cachedField.getChildrenCache()
+              )
+          ),
           new ShowAllFieldsTreeItem(() => this.onShowMoreClicked())
         ]);
       }
 
-      return Promise.resolve(Object.values(this.childrenCache));
+      return Promise.resolve(
+        Object.values(this.childrenCache).map(
+          (cachedField) =>
+            new FieldTreeItem(
+              cachedField.field,
+              cachedField.isExpanded,
+              cachedField.getChildrenCache()
+            )
+        )
+      );
     }
 
     return new Promise((resolve, reject) => {
@@ -202,7 +213,9 @@ export default class SchemaTreeItem extends vscode.TreeItem
   }
 
   onShowMoreClicked(): void {
-    log.info(`show more schema fields clicked for namespace ${this.databaseName}.${this.collectionName}`);
+    log.info(
+      `show more schema fields clicked for namespace ${this.databaseName}.${this.collectionName}`
+    );
 
     this.childrenCacheIsUpToDate = false;
     this.hasClickedShowMoreFields = true;

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -13,6 +13,7 @@ import { createLogger } from './logging';
 import { StorageController } from './storage';
 import DatabaseTreeItem from './explorer/databaseTreeItem';
 import ConnectionTreeItem from './explorer/connectionTreeItem';
+import SchemaTreeItem from './explorer/schemaTreeItem';
 
 const log = createLogger('commands');
 
@@ -266,6 +267,13 @@ export default class MDBExtensionController implements vscode.Disposable {
       'mdb.refreshCollection',
       (collectionTreeItem: CollectionTreeItem): Promise<boolean> => {
         collectionTreeItem.resetCache();
+        return this._explorerController.refresh();
+      }
+    );
+    this.registerCommand(
+      'mdb.refreshSchema',
+      (schemaTreeItem: SchemaTreeItem): Promise<boolean> => {
+        schemaTreeItem.resetCache();
         return this._explorerController.refresh();
       }
     );

--- a/src/test/suite/explorer/databaseTreeItem.test.ts
+++ b/src/test/suite/explorer/databaseTreeItem.test.ts
@@ -1,10 +1,17 @@
+import * as vscode from 'vscode';
 import * as assert from 'assert';
+import { afterEach } from 'mocha';
 
 const { contributes } = require('../../../../package.json');
 
 import DatabaseTreeItem from '../../../explorer/databaseTreeItem';
 import { DataServiceStub, mockDatabaseNames, mockDatabases } from '../stubs';
 import { CollectionTreeItem } from '../../../explorer';
+import {
+  seedDataAndCreateDataService,
+  cleanupTestDB,
+  TEST_DB_NAME
+} from '../dbTestHelper';
 
 suite('DatabaseTreeItem Test Suite', () => {
   test('its context value should be in the package json', () => {
@@ -68,8 +75,10 @@ suite('DatabaseTreeItem Test Suite', () => {
 
         assert(
           collections[1].label ===
-          mockDatabases[mockDatabaseNames[1]].collections[1].name,
-          `Expected a tree item child with the label collection name ${mockDatabases[mockDatabaseNames[1]].collections[1].name} found ${collections[1].label}`
+            mockDatabases[mockDatabaseNames[1]].collections[1].name,
+          `Expected a tree item child with the label collection name ${
+            mockDatabases[mockDatabaseNames[1]].collections[1].name
+          } found ${collections[1].label}`
         );
       })
       .then(done, done);
@@ -142,5 +151,119 @@ suite('DatabaseTreeItem Test Suite', () => {
             });
         });
       });
+  });
+
+  suite('Live Database Tests', () => {
+    afterEach(async () => {
+      await cleanupTestDB();
+    });
+
+    test('schema is cached when a database is collapsed and expanded', (done) => {
+      const mockDocWithThirtyFields = {
+        _id: 32,
+        testerObject: {
+          aField: 1234567
+        }
+      };
+      for (let i = 0; i < 28; i++) {
+        mockDocWithThirtyFields[`field${i}`] = 'some value';
+      }
+
+      seedDataAndCreateDataService('ramenNoodles', [
+        mockDocWithThirtyFields
+      ]).then((dataService) => {
+        const testDatabaseTreeItem = new DatabaseTreeItem(
+          TEST_DB_NAME,
+          dataService,
+          true,
+          {}
+        );
+
+        testDatabaseTreeItem
+          .getChildren()
+          .then((collectionTreeItems: CollectionTreeItem[]) => {
+            assert(
+              collectionTreeItems[0].isExpanded === false,
+              'Expected collection tree item not to be expanded on default.'
+            );
+
+            collectionTreeItems[0].onDidExpand();
+            const schemaTreeItem = collectionTreeItems[0].getSchemaChild();
+            schemaTreeItem.onDidExpand();
+            schemaTreeItem.onShowMoreClicked();
+
+            schemaTreeItem.getChildren().then((fields: any[]) => {
+              const amountOfFields = fields.length;
+              const expectedFields = 30;
+              assert(
+                expectedFields === amountOfFields,
+                `Expected ${expectedFields} fields, recieved ${amountOfFields}`
+              );
+
+              assert(
+                !!schemaTreeItem.childrenCache.testerObject,
+                'Expected the subdocument field to be in the schema cache.'
+              );
+              // Expand the subdocument.
+              schemaTreeItem.childrenCache.testerObject.onDidExpand();
+
+              testDatabaseTreeItem.onDidCollapse();
+              testDatabaseTreeItem
+                .getChildren()
+                .then((postCollapseCollectionTreeItems) => {
+                  assert(
+                    postCollapseCollectionTreeItems.length === 0,
+                    `Expected the database tree to return no children when collapsed, found ${collectionTreeItems.length}`
+                  );
+
+                  testDatabaseTreeItem.onDidExpand();
+                  testDatabaseTreeItem
+                    .getChildren()
+                    .then((newCollectionTreeItems) => {
+                      dataService.disconnect();
+
+                      const postCollapseSchemaTreeItem = newCollectionTreeItems[0].getSchemaChild();
+                      assert(
+                        postCollapseSchemaTreeItem.isExpanded === true,
+                        'Expected collection tree item to be expanded from cache.'
+                      );
+
+                      postCollapseSchemaTreeItem
+                        .getChildren()
+                        .then((fieldsPostCollapseExpand) => {
+                          // It should cache that we activated show more.
+                          const amountOfCachedFields =
+                            fieldsPostCollapseExpand.length;
+                          const expectedCachedFields = 30;
+                          assert(
+                            amountOfCachedFields === expectedCachedFields,
+                            `Expected a cached ${expectedCachedFields} fields to be returned, found ${amountOfCachedFields}`
+                          );
+
+                          const testerObjectField = fieldsPostCollapseExpand.find(
+                            (field) => field.fieldName === 'testerObject'
+                          );
+
+                          assert(
+                            !!testerObjectField,
+                            'Expected the subdocument field to still be in the schema cache.'
+                          );
+                          assert(
+                            testerObjectField.isExpanded,
+                            'Expected the subdocument field to still be expanded.'
+                          );
+                          assert(
+                            testerObjectField.collapsibleState ===
+                              vscode.TreeItemCollapsibleState.Expanded,
+                            `Expected the subdocument field to have an expanded state (2), found ${postCollapseSchemaTreeItem.childrenCache.testerObject.collapsibleState}.`
+                          );
+                        })
+                        .then(done, done);
+                    }, done);
+                }, done);
+            }, done);
+          }, done);
+      });
+    });
   });
 });

--- a/src/test/suite/explorer/fieldTreeItems.test.ts
+++ b/src/test/suite/explorer/fieldTreeItems.test.ts
@@ -25,9 +25,7 @@ suite('FieldTreeItem Test Suite', () => {
         'pie',
         TEST_DB_NAME,
         dataService,
-        true,
-        false,
-        null
+        true
       );
 
       testSchemaTreeItem
@@ -77,9 +75,7 @@ suite('FieldTreeItem Test Suite', () => {
         'gryffindor',
         TEST_DB_NAME,
         dataService,
-        false,
-        false,
-        null
+        false
       );
 
       testSchemaTreeItem.onDidExpand();
@@ -139,9 +135,7 @@ suite('FieldTreeItem Test Suite', () => {
         'gryffindor',
         TEST_DB_NAME,
         dataService,
-        false,
-        false,
-        null
+        false
       );
 
       testSchemaTreeItem.onDidExpand();
@@ -211,9 +205,7 @@ suite('FieldTreeItem Test Suite', () => {
         'beach',
         TEST_DB_NAME,
         dataService,
-        false,
-        false,
-        null
+        false
       );
 
       testSchemaTreeItem.onDidExpand();

--- a/src/test/suite/explorer/schemaTreeItem.test.ts
+++ b/src/test/suite/explorer/schemaTreeItem.test.ts
@@ -26,9 +26,7 @@ suite('SchemaTreeItem Test Suite', () => {
       'cheesePizza',
       TEST_DB_NAME,
       {},
-      false,
-      false,
-      null
+      false
     );
 
     contributes.menus['view/item/context'].forEach((contextItem) => {
@@ -43,28 +41,25 @@ suite('SchemaTreeItem Test Suite', () => {
     );
   });
 
-
   test('when the "show more" click handler function is called it sets the schema to show more fields', () => {
     const testSchemaTreeItem = new SchemaTreeItem(
       'favoritePiesIWantToEatRightNow',
       TEST_DB_NAME,
       {},
-      false,
-      false,
-      null
+      false
     );
 
     assert(
       !testSchemaTreeItem.hasClickedShowMoreFields,
       'Expected "hasClickedShowMoreFields" to be false by default'
     );
-    testSchemaTreeItem._childrenCacheIsUpToDate = true;
+    testSchemaTreeItem.childrenCacheIsUpToDate = true;
 
     testSchemaTreeItem.onShowMoreClicked();
 
     assert(
-      !testSchemaTreeItem._childrenCacheIsUpToDate,
-      'Expected `_childrenCacheIsUpToDate` to be reset to false'
+      !testSchemaTreeItem.childrenCacheIsUpToDate,
+      'Expected `childrenCacheIsUpToDate` to be reset to false'
     );
     assert(
       testSchemaTreeItem.hasClickedShowMoreFields,
@@ -86,9 +81,7 @@ suite('SchemaTreeItem Test Suite', () => {
           callback(null, [mockDocWithTwentyFields]);
         }
       },
-      true,
-      false,
-      null
+      true
     );
 
     testSchemaTreeItem
@@ -99,7 +92,7 @@ suite('SchemaTreeItem Test Suite', () => {
         assert(
           schemaFields.length === amountOfFieldsExpected + 1,
           `Expected ${amountOfFieldsExpected +
-          1} documents to be returned, found ${schemaFields.length}`
+            1} documents to be returned, found ${schemaFields.length}`
         );
         assert(
           schemaFields[amountOfFieldsExpected].label === 'Show more fields...',
@@ -122,9 +115,7 @@ suite('SchemaTreeItem Test Suite', () => {
           callback(null, [mockDocWithThirtyFields]);
         }
       },
-      true,
-      false,
-      null
+      true
     );
 
     testSchemaTreeItem.onShowMoreClicked();
@@ -154,9 +145,7 @@ suite('SchemaTreeItem Test Suite', () => {
           callback(null, 'invalid schema to parse');
         }
       },
-      true,
-      false,
-      null
+      true
     );
 
     testSchemaTreeItem
@@ -190,9 +179,7 @@ suite('SchemaTreeItem Test Suite', () => {
           'favoritePiesIWantToEatRightNow',
           TEST_DB_NAME,
           dataService,
-          false,
-          false,
-          null
+          false
         );
 
         testSchemaTreeItem
@@ -220,9 +207,7 @@ suite('SchemaTreeItem Test Suite', () => {
           'favoritePiesIWantToEatRightNow',
           TEST_DB_NAME,
           dataService,
-          false,
-          false,
-          null
+          false
         );
 
         testSchemaTreeItem.onDidExpand();
@@ -271,9 +256,7 @@ suite('SchemaTreeItem Test Suite', () => {
           'favoritePiesIWantToEatRightNow',
           TEST_DB_NAME,
           dataService,
-          false,
-          false,
-          null
+          false
         );
 
         testSchemaTreeItem.onDidExpand();

--- a/src/test/suite/explorer/schemaTreeItem.test.ts
+++ b/src/test/suite/explorer/schemaTreeItem.test.ts
@@ -3,6 +3,8 @@ import * as vscode from 'vscode';
 import { afterEach } from 'mocha';
 import * as sinon from 'sinon';
 
+const { contributes } = require('../../../../package.json');
+
 import SchemaTreeItem, {
   FIELDS_TO_SHOW
 } from '../../../explorer/schemaTreeItem';
@@ -17,6 +19,30 @@ suite('SchemaTreeItem Test Suite', () => {
   afterEach(() => {
     sinon.restore();
   });
+
+  test('its context value should be in the package json', () => {
+    let schemaRegisteredCommandInPackageJson = false;
+    const testSchemaTreeItem = new SchemaTreeItem(
+      'cheesePizza',
+      TEST_DB_NAME,
+      {},
+      false,
+      false,
+      null
+    );
+
+    contributes.menus['view/item/context'].forEach((contextItem) => {
+      if (contextItem.when.includes(testSchemaTreeItem.contextValue)) {
+        schemaRegisteredCommandInPackageJson = true;
+      }
+    });
+
+    assert(
+      schemaRegisteredCommandInPackageJson,
+      'Expected schema tree item to be registered with a command in package json'
+    );
+  });
+
 
   test('when the "show more" click handler function is called it sets the schema to show more fields', () => {
     const testSchemaTreeItem = new SchemaTreeItem(

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -42,6 +42,7 @@ suite('Extension Test Suite', () => {
           'mdb.viewCollectionDocuments',
           'mdb.copyCollectionName',
           'mdb.refreshCollection',
+          'mdb.refreshSchema',
 
           // Editor commands.
           'mdb.codeLens.showMoreDocumentsClicked',

--- a/src/test/suite/mdbExtensionController.test.ts
+++ b/src/test/suite/mdbExtensionController.test.ts
@@ -11,6 +11,7 @@ import { CollectionTypes } from '../../explorer/documentListTreeItem';
 import { mdbTestExtension } from './stubbableMdbExtension';
 import ConnectionController from '../../connectionController';
 import { StorageController } from '../../storage';
+import SchemaTreeItem from '../../explorer/schemaTreeItem';
 
 const testDatabaseURI = 'mongodb://localhost:27018';
 
@@ -197,7 +198,7 @@ suite('MDBExtensionController Test Suite', () => {
         );
         assert(
           mockRemoveMongoDBConnection.firstArg ===
-          'craving_for_pancakes_with_maple_syrup',
+            'craving_for_pancakes_with_maple_syrup',
           `Expected the mock connection controller to be called to remove the connection with the id "craving_for_pancakes_with_maple_syrup", found ${mockRemoveMongoDBConnection.firstArg}.`
         );
       })
@@ -352,6 +353,39 @@ suite('MDBExtensionController Test Suite', () => {
         assert(
           mockTreeItem.getSchemaChild().isExpanded === false,
           'Expected schema on collection tree item to be reset to not expanded.'
+        );
+        assert(
+          mockExplorerControllerRefresh.called === true,
+          'Expected explorer controller refresh to be called.'
+        );
+      })
+      .then(done, done);
+  });
+
+  test('mdb.refreshSchema command should reset its cache and call to refresh the explorer controller', (done) => {
+    const mockTreeItem = new SchemaTreeItem(
+      'zebraWearwolf',
+      'giraffeVampire',
+      {},
+      false
+    );
+
+    // Set cached.
+    mockTreeItem.childrenCacheIsUpToDate = true;
+
+    const mockExplorerControllerRefresh = sinon.fake.resolves();
+    sinon.replace(
+      mdbTestExtension.testExtensionController._explorerController,
+      'refresh',
+      mockExplorerControllerRefresh
+    );
+
+    vscode.commands
+      .executeCommand('mdb.refreshSchema', mockTreeItem)
+      .then(() => {
+        assert(
+          mockTreeItem.childrenCacheIsUpToDate === false,
+          'Expected schema field cache to be not up to date.'
         );
         assert(
           mockExplorerControllerRefresh.called === true,


### PR DESCRIPTION
https://jira.mongodb.org/browse/VSCODE-59

This PR adds caching to the state of the tree view for schema. So that nested elements' collapsed states are preserved when a top level tree item is collapsed & expanded.

This PR also adds groups to the tree view to make the actions a bit more navigable and user friendly. And we have a refresh action on schema now, which reloads the schema and reset dropdown states. Ya'll think we could improve these groupings a bit? Open to suggestions.

On refresh we fetch all of the fields if the user already clicked the `show more fields` button.

**Screenshots**
___
*Caching of tree schema*
![cache](https://user-images.githubusercontent.com/1791149/76437479-ea58a900-63b9-11ea-8ac5-b245c5411f33.gif)

*Refresh action on schema*
![right click refresh action](https://user-images.githubusercontent.com/1791149/76437484-ecbb0300-63b9-11ea-9ac3-25b7ab781377.gif)

*Groups in tree view actions (those lines that separate the actions are the groups)*
![Screen Shot 2020-03-11 at 3 36 30 PM](https://user-images.githubusercontent.com/1791149/76437495-efb5f380-63b9-11ea-8bb5-95dba94ca451.png)
![Screen Shot 2020-03-11 at 3 37 40 PM](https://user-images.githubusercontent.com/1791149/76437497-f0e72080-63b9-11ea-926b-dad7861ec15f.png)
![Screen Shot 2020-03-11 at 3 36 21 PM](https://user-images.githubusercontent.com/1791149/76437501-f17fb700-63b9-11ea-87c4-838166162d78.png)
