### PR TITLE
VSCODE-72: create a new runtime instance for each evaluation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -272,40 +272,40 @@
       "integrity": "sha512-elh8S1OxmEGe8/wbr6ky//dHhV2ld6oZV8/M9lgozJsL/6Aqm8j5+ElquzoX9k9l3Q+dohuX/SIGR/kTRZHS4g=="
     },
     "@mongosh/async-rewriter": {
-      "version": "0.0.1-alpha.4",
-      "resolved": "https://registry.npmjs.org/@mongosh/async-rewriter/-/async-rewriter-0.0.1-alpha.4.tgz",
-      "integrity": "sha512-SOjNahEFjTvaUZaZsHZnWtnu35ZAMpFvRivuCFiSmQ5wpdLR01XhWoZxFOaY92OyHzfxI4SdjSMZjS35pXVNdQ==",
+      "version": "0.0.1-alpha.6",
+      "resolved": "https://registry.npmjs.org/@mongosh/async-rewriter/-/async-rewriter-0.0.1-alpha.6.tgz",
+      "integrity": "sha512-TDEiHPsb6XYSttm55NHCkQn0qjglriQUJLXqIObfcsYBwpbyX8gwBNOcb1czXjfw1HgHR5FQ6/RORCRqnIU1/w==",
       "requires": {
         "@babel/core": "^7.8.7"
       }
     },
     "@mongosh/browser-runtime-core": {
-      "version": "0.0.1-alpha.4",
-      "resolved": "https://registry.npmjs.org/@mongosh/browser-runtime-core/-/browser-runtime-core-0.0.1-alpha.4.tgz",
-      "integrity": "sha512-X6RpFNqsZ8bXei2dqWY0CHdYdB8VhxTBeZsroQDZCIe56NdvrTNJzVx9eh3IIHSJ+XGmFlCoTl09NVIBkJxgqg==",
+      "version": "0.0.1-alpha.6",
+      "resolved": "https://registry.npmjs.org/@mongosh/browser-runtime-core/-/browser-runtime-core-0.0.1-alpha.6.tgz",
+      "integrity": "sha512-2NtXNaVHqioYvoXNrU1NuuhrsLDTX48p0FY/hzx+SQYoNW56b6jwVtlID1GIE3suPqX9zotQ7JTRQgMrzPFnZQ==",
       "requires": {
-        "@mongosh/cli-repl": "^0.0.1-alpha.4",
-        "@mongosh/mapper": "^0.0.1-alpha.4",
-        "@mongosh/shell-api": "^0.0.1-alpha.4"
+        "@mongosh/cli-repl": "^0.0.1-alpha.6",
+        "@mongosh/mapper": "^0.0.1-alpha.6",
+        "@mongosh/shell-api": "^0.0.1-alpha.6"
       }
     },
     "@mongosh/browser-runtime-electron": {
-      "version": "0.0.1-alpha.4",
-      "resolved": "https://registry.npmjs.org/@mongosh/browser-runtime-electron/-/browser-runtime-electron-0.0.1-alpha.4.tgz",
-      "integrity": "sha512-3YSga3cglLr7ExusdrZq0xAWlx9Ha49YIuOOQMm2f2q/a9v9kQgzuAOEuuErX5CFpsPYejyzkd3mPlokRcTNmw==",
+      "version": "0.0.1-alpha.6",
+      "resolved": "https://registry.npmjs.org/@mongosh/browser-runtime-electron/-/browser-runtime-electron-0.0.1-alpha.6.tgz",
+      "integrity": "sha512-mL1mMOrQ1EkSTjtdaM9cIuVFhpbj+k1CfQMB69jv7albdU5Wix+HK9oNR0ZFyIlf/uphIpOXqcqj+KBy2bHBgA==",
       "requires": {
-        "@mongosh/browser-runtime-core": "^0.0.1-alpha.4"
+        "@mongosh/browser-runtime-core": "^0.0.1-alpha.6"
       }
     },
     "@mongosh/cli-repl": {
-      "version": "0.0.1-alpha.4",
-      "resolved": "https://registry.npmjs.org/@mongosh/cli-repl/-/cli-repl-0.0.1-alpha.4.tgz",
-      "integrity": "sha512-VLkZBEO6GuuP5nZY4WQHS70SfdlX6gBAdzxOXPSUlmVE7EChJzvH753haBEb3vazemQ/1Mk74JszdIMtQcgFdQ==",
+      "version": "0.0.1-alpha.6",
+      "resolved": "https://registry.npmjs.org/@mongosh/cli-repl/-/cli-repl-0.0.1-alpha.6.tgz",
+      "integrity": "sha512-SZfEg3ge6QC6XeDIq8LqVtst/HPmO97UvB6Lz69RIESwaGeggsr07jeNol0yn6Im8d4BF3BBLuNH+yFN9wu0Fg==",
       "requires": {
-        "@mongosh/i18n": "^0.0.1-alpha.4",
-        "@mongosh/mapper": "^0.0.1-alpha.4",
-        "@mongosh/service-provider-server": "^0.0.1-alpha.4",
-        "@mongosh/shell-api": "^0.0.1-alpha.4",
+        "@mongosh/i18n": "^0.0.1-alpha.6",
+        "@mongosh/mapper": "^0.0.1-alpha.6",
+        "@mongosh/service-provider-server": "^0.0.1-alpha.6",
+        "@mongosh/shell-api": "^0.0.1-alpha.6",
         "ansi-escape-sequences": "^5.1.2",
         "lodash.set": "^4.3.2",
         "minimist": "^1.2.0",
@@ -328,65 +328,45 @@
       }
     },
     "@mongosh/i18n": {
-      "version": "0.0.1-alpha.4",
-      "resolved": "https://registry.npmjs.org/@mongosh/i18n/-/i18n-0.0.1-alpha.4.tgz",
-      "integrity": "sha512-Pmc6U9EbKgoBydmjI13YMVN8WdPWI8hXmRydKCRiXpxp/5Jdj8Ns8MwIy7PGk9fHj4OXzg/niOakYDiZBT493w==",
+      "version": "0.0.1-alpha.6",
+      "resolved": "https://registry.npmjs.org/@mongosh/i18n/-/i18n-0.0.1-alpha.6.tgz",
+      "integrity": "sha512-EqgaqWFLPvifkkVMkjPPJzgK1IgNQrpHkoiCwmtcIXgkXMNX8Mo7uzs7LqMUqrSEWd4P2PHSf2CiBbJs0m8jfQ==",
       "requires": {
         "mustache": "^4.0.0"
       }
     },
     "@mongosh/mapper": {
-      "version": "0.0.1-alpha.4",
-      "resolved": "https://registry.npmjs.org/@mongosh/mapper/-/mapper-0.0.1-alpha.4.tgz",
-      "integrity": "sha512-AOLjgrodR7glMEW6Uurkj0n+P3NKqNuVCVYxsGXGFJfT8SoPbT+Gp+6Py3aStw+rL40N7PyAhs9Vwnh7TxaVtw==",
+      "version": "0.0.1-alpha.6",
+      "resolved": "https://registry.npmjs.org/@mongosh/mapper/-/mapper-0.0.1-alpha.6.tgz",
+      "integrity": "sha512-fziTPQpWe7/LEIodcqwdgaXgFMciUcSsy+lt2mforR/DfJzIrA5l8TOorHKJQ/Yv76SueeoDlwlbCoEw9Ee4Kg==",
       "requires": {
-        "@mongosh/async-rewriter": "^0.0.1-alpha.4",
-        "@mongosh/service-provider-core": "^0.0.1-alpha.4",
-        "@mongosh/shell-api": "^0.0.1-alpha.4",
+        "@mongosh/async-rewriter": "^0.0.1-alpha.6",
+        "@mongosh/service-provider-core": "^0.0.1-alpha.6",
+        "@mongosh/shell-api": "^0.0.1-alpha.6",
         "pretty-bytes": "^5.3.0",
         "text-table": "^0.2.0"
       }
     },
     "@mongosh/service-provider-core": {
-      "version": "0.0.1-alpha.4",
-      "resolved": "https://registry.npmjs.org/@mongosh/service-provider-core/-/service-provider-core-0.0.1-alpha.4.tgz",
-      "integrity": "sha512-DqBPCxv/34gVIGe2VDMYiXtGzz8nrI3xnbV239j37N+88AtW/65RY6/W4Yl1uG0OpO+A04qDaioJsjZfcWUDAA=="
+      "version": "0.0.1-alpha.6",
+      "resolved": "https://registry.npmjs.org/@mongosh/service-provider-core/-/service-provider-core-0.0.1-alpha.6.tgz",
+      "integrity": "sha512-Jsm3gdZ4gT1j6m52vfuPrhdCHmmTzwy3p2Talb/xgKZZWTmbOangG0pppyA7nBuhKGXqmOxCfgFvxROOWvxPzQ=="
     },
     "@mongosh/service-provider-server": {
-      "version": "0.0.1-alpha.4",
-      "resolved": "https://registry.npmjs.org/@mongosh/service-provider-server/-/service-provider-server-0.0.1-alpha.4.tgz",
-      "integrity": "sha512-CRdIwyOlZKGLIZ9v4onbwdNPqXG06FDZRdMvoWSvMwuzFqJJynM2lO9PXSt4/Qd4Tw0xq9LwKxe562+PxfeWog==",
+      "version": "0.0.1-alpha.6",
+      "resolved": "https://registry.npmjs.org/@mongosh/service-provider-server/-/service-provider-server-0.0.1-alpha.6.tgz",
+      "integrity": "sha512-L2O9PTEdpCYe7cOtLRxT0hSI9tCc9ZXgU+l3NS45a+BefGeJo53oEolv/UFDF/a+RezSz+8gOxDTF4/EVhH0Hg==",
       "requires": {
-        "@mongosh/service-provider-core": "^0.0.1-alpha.4",
+        "@mongosh/service-provider-core": "^0.0.1-alpha.6",
         "mongodb": "3.5.3 || ^3.5.5"
-      },
-      "dependencies": {
-        "bson": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.3.tgz",
-          "integrity": "sha512-TdiJxMVnodVS7r0BdL42y/pqC9cL2iKynVwA0Ho3qbsQYr428veL3l7BQyuqiw+Q5SqqoT0m4srSY/BlZ9AxXg=="
-        },
-        "mongodb": {
-          "version": "3.5.5",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.5.5.tgz",
-          "integrity": "sha512-GCjDxR3UOltDq00Zcpzql6dQo1sVry60OXJY3TDmFc2SWFY6c8Gn1Ardidc5jDirvJrx2GC3knGOImKphbSL3A==",
-          "requires": {
-            "bl": "^2.2.0",
-            "bson": "^1.1.1",
-            "denque": "^1.4.1",
-            "require_optional": "^1.0.1",
-            "safe-buffer": "^5.1.2",
-            "saslprep": "^1.0.0"
-          }
-        }
       }
     },
     "@mongosh/shell-api": {
-      "version": "0.0.1-alpha.4",
-      "resolved": "https://registry.npmjs.org/@mongosh/shell-api/-/shell-api-0.0.1-alpha.4.tgz",
-      "integrity": "sha512-10OCem6sy2dnW2XEPGC8w7E/3pJ1md8kujmfnnXnJTkTseMeY/gJPNcpdE1TV8VLqp6xe17kfFnbHePpjtA1vg==",
+      "version": "0.0.1-alpha.6",
+      "resolved": "https://registry.npmjs.org/@mongosh/shell-api/-/shell-api-0.0.1-alpha.6.tgz",
+      "integrity": "sha512-DRphnlpsRfP/Q0WZEyjizFRgeGX0SbyafKToAzgOqfFdhEzLsxaQDrqDT/cDhYw5j43TBvmnx5A8YTY7mR4W+w==",
       "requires": {
-        "@mongosh/i18n": "^0.0.1-alpha.4"
+        "@mongosh/i18n": "^0.0.1-alpha.6"
       }
     },
     "@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -137,8 +137,8 @@
         "title": "MongoDB: Create MongoDB Playground"
       },
       {
-        "command": "mdb.runDBHelpInPlayground",
-        "title": "MongoDB: Run db.help() in Playground"
+        "command": "mdb.showActiveConnectionInPlayground",
+        "title": "MongoDB: Show Active Connection In Playground"
       },
       {
         "command": "mdb.runAllPlaygroundBlocks",
@@ -439,8 +439,8 @@
     }
   },
   "dependencies": {
-    "@mongosh/browser-runtime-electron": "0.0.1-alpha.4",
-    "@mongosh/service-provider-server": "0.0.1-alpha.4",
+    "@mongosh/browser-runtime-electron": "0.0.1-alpha.6",
+    "@mongosh/service-provider-server": "0.0.1-alpha.6",
     "bson": "^4.0.3",
     "debug": "^4.1.1",
     "mongodb-connection-model": "^14.6.2",

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -34,7 +34,8 @@ function getConnectWebviewContent(): string {
 }
 
 export enum DataServiceEventTypes {
-  CONNECTIONS_DID_CHANGE = 'CONNECTIONS_DID_CHANGE'
+  CONNECTIONS_DID_CHANGE = 'CONNECTIONS_DID_CHANGE',
+  ACTIVE_CONNECTION_CHANGED = 'ACTIVE_CONNECTION_CHANGED'
 }
 
 export default class ConnectionController {
@@ -275,6 +276,7 @@ export default class ConnectionController {
         this._connecting = false;
         this._connectingConnectionId = null;
         this.eventEmitter.emit(DataServiceEventTypes.CONNECTIONS_DID_CHANGE);
+        this.eventEmitter.emit(DataServiceEventTypes.ACTIVE_CONNECTION_CHANGED, this.getActiveConnectionName());
 
         return resolve(true);
       });
@@ -356,6 +358,7 @@ export default class ConnectionController {
         this._statusView.hideMessage();
 
         this.eventEmitter.emit(DataServiceEventTypes.CONNECTIONS_DID_CHANGE);
+        this.eventEmitter.emit(DataServiceEventTypes.ACTIVE_CONNECTION_CHANGED);
 
         return resolve(true);
       });
@@ -498,6 +501,7 @@ export default class ConnectionController {
     this._savedConnections[connectionId].name = inputtedConnectionName;
 
     this.eventEmitter.emit(DataServiceEventTypes.CONNECTIONS_DID_CHANGE);
+    this.eventEmitter.emit(DataServiceEventTypes.ACTIVE_CONNECTION_CHANGED);
 
     return new Promise((resolve, reject) => {
       if (
@@ -562,6 +566,16 @@ export default class ConnectionController {
   public getSavedConnectionName(connectionId: string): string {
     return this._savedConnections[connectionId]
       ? this._savedConnections[connectionId].name
+      : '';
+  }
+
+  public getActiveConnectionName(): string {
+    if (!this._currentConnectionId) {
+      return '';
+    }
+
+    return this._savedConnections[this._currentConnectionId]
+      ? this._savedConnections[this._currentConnectionId].name
       : '';
   }
 

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -276,7 +276,7 @@ export default class ConnectionController {
         this._connecting = false;
         this._connectingConnectionId = null;
         this.eventEmitter.emit(DataServiceEventTypes.CONNECTIONS_DID_CHANGE);
-        this.eventEmitter.emit(DataServiceEventTypes.ACTIVE_CONNECTION_CHANGED, this.getActiveConnectionName());
+        this.eventEmitter.emit(DataServiceEventTypes.ACTIVE_CONNECTION_CHANGED);
 
         return resolve(true);
       });

--- a/src/editors/activeConnectionCodeLensProvider.ts
+++ b/src/editors/activeConnectionCodeLensProvider.ts
@@ -3,7 +3,6 @@ import * as vscode from 'vscode';
 export default class ActiveConnectionCodeLensProvider implements vscode.CodeLensProvider {
   private _codeLenses: vscode.CodeLens[] = [];
   private _connectionController: any;
-  private _activeConnectionName?: string;
   private _onDidChangeCodeLenses: vscode.EventEmitter<
     void
   > = new vscode.EventEmitter<void>();
@@ -18,8 +17,7 @@ export default class ActiveConnectionCodeLensProvider implements vscode.CodeLens
     });
   }
 
-  public setActiveConnectionName(name: string): void {
-    this._activeConnectionName = name;
+  public refresh(): void {
     this._onDidChangeCodeLenses.fire();
   }
 
@@ -36,7 +34,8 @@ export default class ActiveConnectionCodeLensProvider implements vscode.CodeLens
   }
 
   public resolveCodeLens?(codeLens: vscode.CodeLens): vscode.CodeLens {
-    const message = `Active connection is ${this._activeConnectionName}`;
+    const name = this._connectionController.getActiveConnectionName();
+    const message = `Currently connected to ${name}`;
 
     codeLens.command = {
       title: message,

--- a/src/editors/activeConnectionCodeLensProvider.ts
+++ b/src/editors/activeConnectionCodeLensProvider.ts
@@ -1,10 +1,9 @@
 import * as vscode from 'vscode';
 
-export default class ActiveDBCodeLensProvider implements vscode.CodeLensProvider {
+export default class ActiveConnectionCodeLensProvider implements vscode.CodeLensProvider {
   private _codeLenses: vscode.CodeLens[] = [];
   private _connectionController: any;
-  private _runtime: any;
-  private _activeDB?: string;
+  private _activeConnectionName?: string;
   private _onDidChangeCodeLenses: vscode.EventEmitter<
     void
   > = new vscode.EventEmitter<void>();
@@ -19,8 +18,8 @@ export default class ActiveDBCodeLensProvider implements vscode.CodeLensProvider
     });
   }
 
-  public setActiveDB(activeDB: string): void {
-    this._activeDB = activeDB;
+  public setActiveConnectionName(name: string): void {
+    this._activeConnectionName = name;
     this._onDidChangeCodeLenses.fire();
   }
 
@@ -37,9 +36,12 @@ export default class ActiveDBCodeLensProvider implements vscode.CodeLensProvider
   }
 
   public resolveCodeLens?(codeLens: vscode.CodeLens): vscode.CodeLens {
+    const message = `Active connection is ${this._activeConnectionName}`;
+
     codeLens.command = {
-      title: `Active db is ${this._activeDB}`,
-      command: "mdb.runDBHelpInPlayground"
+      title: message,
+      command: "mdb.showActiveConnectionInPlayground",
+      arguments: [message]
     };
 
     return codeLens;

--- a/src/editors/playgroundController.ts
+++ b/src/editors/playgroundController.ts
@@ -124,7 +124,9 @@ export default class PlaygroundController {
     if (this._connectionController) {
       this._connectionController.removeEventListener(
         DataServiceEventTypes.ACTIVE_CONNECTION_CHANGED,
-        () => { }
+        () => {
+          this.showActiveConnectionInPlayground('Playground disconnected');
+        }
       );
     }
   }

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -87,8 +87,8 @@ export default class MDBExtensionController implements vscode.Disposable {
     this.registerCommand('mdb.runAllPlaygroundBlocks', () =>
       this._playgroundController.runAllPlaygroundBlocks()
     );
-    this.registerCommand('mdb.runDBHelpInPlayground', () =>
-      this._playgroundController.runDBHelpInPlayground()
+    this.registerCommand('mdb.showActiveConnectionInPlayground', (message: string) =>
+      this._playgroundController.showActiveConnectionInPlayground(message)
     );
 
     this.registerEditorCommands();
@@ -355,5 +355,6 @@ export default class MDBExtensionController implements vscode.Disposable {
     // TODO: Cancel active queries/playgrounds.
     this._connectionController.disconnect();
     this._explorerController.deactivate();
+    this._playgroundController.deactivate();
   }
 }

--- a/src/templates/playgroundTemplate.ts
+++ b/src/templates/playgroundTemplate.ts
@@ -1,12 +1,15 @@
-const template: string = `//select the database to use.
+const template: string = `// Select the database to use
 use('test');
-//run a find command.
-db.my_collection.find({foo: 'bar'});
-//run an aggregation.
+
+// Run a find command
+db.myCollection.find({ foo: 'bar' });
+
+// Run an aggregation
 const agg = [
-  {$match: {foo: 'bar'}}
+  { $match: { foo: 'bar' } }
 ];
-db.my_collection.aggregate(agg);
+
+db.myCollection.aggregate(agg);
 `;
 
 export default template;

--- a/src/templates/playgroundTemplate.ts
+++ b/src/templates/playgroundTemplate.ts
@@ -1,10 +1,10 @@
-const template: string = `// Select the database to use
+const template: string = `// Select the database to use.
 use('test');
 
-// Run a find command
+// Run a find command.
 db.myCollection.find({ foo: 'bar' });
 
-// Run an aggregation
+// Run an aggregation.
 const agg = [
   { $match: { foo: 'bar' } }
 ];

--- a/src/test/suite/editors/activeDBCodeLensProvider.test.ts
+++ b/src/test/suite/editors/activeDBCodeLensProvider.test.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode';
 
 import ConnectionController from '../../../connectionController';
 import { StatusView } from '../../../views';
-import ActiveDBCodeLensProvider from '../../../editors/activeDBCodeLensProvider';
+import ActiveDBCodeLensProvider from '../../../editors/activeConnectionCodeLensProvider';
 import { TestExtensionContext, mockVSCodeTextDocument } from '../stubs';
 import { StorageController } from '../../../storage';
 

--- a/src/test/suite/editors/playgroundController.test.ts
+++ b/src/test/suite/editors/playgroundController.test.ts
@@ -3,6 +3,11 @@ import ConnectionController from '../../../connectionController';
 import { StatusView } from '../../../views';
 import { StorageController } from '../../../storage';
 import { TestExtensionContext } from '../stubs';
+import { ObjectId } from 'bson';
+import {
+  seedDataAndCreateDataService,
+  cleanupTestDB
+} from '../dbTestHelper';
 
 const chai = require('chai')
 const expect = chai.expect
@@ -57,6 +62,35 @@ suite('Playground Controller Test Suite', () => {
         var x = 1;
         x + 2
       `)).to.be.equal('3');
+    });
+
+    test('evaluate interaction with a database', (done) => {
+      const mockActiveConnection = { find: {} };
+      const mockDocument = {
+        _id: new ObjectId('5e32b4d67bf47f4525f2f8ab'),
+        example: 'field'
+      };
+
+      seedDataAndCreateDataService('forest', [mockDocument]).then(
+        async (dataService) => {
+          testConnectionController.setActiveConnection(dataService);
+
+          const actualResult = await testPlaygroundController.evaluate(`
+            use('vscodeTestDatabaseAA');
+            db.forest.find({})
+          `);
+          const expectedResult = '[\n' +
+            '  {\n' +
+            '    _id: 5e32b4d67bf47f4525f2f8ab,\n' +
+            '    example: \'field\'\n' +
+            '  }\n' +
+            ']';
+
+          expect(actualResult).to.be.equal(expectedResult);
+
+          await cleanupTestDB();
+        }
+      ).then(done, done);
     });
   });
 });

--- a/src/test/suite/editors/playgroundController.test.ts
+++ b/src/test/suite/editors/playgroundController.test.ts
@@ -108,7 +108,10 @@ suite('Playground Controller Test Suite', () => {
 
           await testPlaygroundController.evaluate(codeToEvaluate);
 
-          expect(testPlaygroundController.evaluate(codeToEvaluate)).to.be.not.rejected;
+          const result = await testPlaygroundController.evaluate(codeToEvaluate);
+
+          expect(result).to.be.equal('2');
+
           await cleanupTestDB();
         }
       );

--- a/src/test/suite/editors/playgroundController.test.ts
+++ b/src/test/suite/editors/playgroundController.test.ts
@@ -65,7 +65,6 @@ suite('Playground Controller Test Suite', () => {
     });
 
     test('evaluate interaction with a database', (done) => {
-      const mockActiveConnection = { find: {} };
       const mockDocument = {
         _id: new ObjectId('5e32b4d67bf47f4525f2f8ab'),
         example: 'field'
@@ -91,6 +90,28 @@ suite('Playground Controller Test Suite', () => {
           await cleanupTestDB();
         }
       ).then(done, done);
+    });
+
+    test('create a new playground instance for each run', () => {
+      const mockDocument = {
+        _id: new ObjectId('5e32b4d67bf47f4525f2f777'),
+        valueOfTheField: 'is not important'
+      };
+      const codeToEvaluate = `
+        const x = 1;
+        x + 1
+      `;
+
+      seedDataAndCreateDataService('forest', [mockDocument]).then(
+        async (dataService) => {
+          testConnectionController.setActiveConnection(dataService);
+
+          await testPlaygroundController.evaluate(codeToEvaluate);
+
+          expect(testPlaygroundController.evaluate(codeToEvaluate)).to.be.not.rejected;
+          await cleanupTestDB();
+        }
+      );
     });
   });
 });

--- a/src/test/suite/editors/playgroundController.test.ts
+++ b/src/test/suite/editors/playgroundController.test.ts
@@ -49,5 +49,14 @@ suite('Playground Controller Test Suite', () => {
 
       expect(await testPlaygroundController.evaluate('1 + 1')).to.be.equal('2');
     });
+
+    test('evaluate multiple commands at once', async () => {
+      testConnectionController.setActiveConnection(mockActiveConnection);
+
+      expect(await testPlaygroundController.evaluate(`
+        var x = 1;
+        x + 2
+      `)).to.be.equal('3');
+    });
   });
 });

--- a/src/test/suite/mdbExtensionController.test.ts
+++ b/src/test/suite/mdbExtensionController.test.ts
@@ -1113,7 +1113,7 @@ suite('MDBExtensionController Test Suite', () => {
 
     vscode.commands.executeCommand('mdb.createPlayground').then(() => {
       assert(mockOpenTextDocument.firstArg.language === 'mongodb');
-      assert(mockOpenTextDocument.firstArg.content.startsWith('//select the database to use'));
+      assert(mockOpenTextDocument.firstArg.content.startsWith('// Select the database to use'));
       assert(
         mockShowTextDocument.firstArg === 'untitled',
         'Expected it to call vscode to show the playground'
@@ -1121,7 +1121,7 @@ suite('MDBExtensionController Test Suite', () => {
     }).then(done, done);
   });
 
-  test('mdb.createPlayground should create a MongoDB playground with default template', (done) => {
+  test('mdb.createPlayground should create a MongoDB playground without template', (done) => {
     const mockOpenTextDocument = sinon.fake.resolves('untitled');
     sinon.replace(vscode.workspace, 'openTextDocument', mockOpenTextDocument);
 

--- a/src/test/suite/mdbExtensionController.test.ts
+++ b/src/test/suite/mdbExtensionController.test.ts
@@ -1162,18 +1162,18 @@ suite('MDBExtensionController Test Suite', () => {
     }).then(done, done);
   });
 
-  test('mdb.runDBHelpInPlayground command should call runDBHelpInPlayground on the playground controller', (done) => {
-    const mockRunDBHelpInPlayground = sinon.fake.resolves();
+  test('mdb.showActiveConnectionInPlayground command should call showActiveConnectionInPlayground on the playground controller', (done) => {
+    const mockShowActiveConnectionInPlayground = sinon.fake.resolves();
     sinon.replace(
       mdbTestExtension.testExtensionController._playgroundController,
-      'runDBHelpInPlayground',
-      mockRunDBHelpInPlayground
+      'showActiveConnectionInPlayground',
+      mockShowActiveConnectionInPlayground
     );
 
-    vscode.commands.executeCommand('mdb.runDBHelpInPlayground').then(() => {
+    vscode.commands.executeCommand('mdb.showActiveConnectionInPlayground').then(() => {
       assert(
-        mockRunDBHelpInPlayground.called,
-        'Expected "runDBHelpInPlayground" to be called on the playground controller.'
+        mockShowActiveConnectionInPlayground.called,
+        'Expected "showActiveConnectionInPlayground" to be called on the playground controller.'
       );
     }).then(done, done);
   });


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
1) Use a new version of `mongosh` with https://github.com/mongodb-js/mongosh/pull/64 merged that fixes missing db interaction commands in browser runtime (eg. `use('db')`).

2) Create a new runtime instance for each run of the playground. It will allow to repeatedly run the same commands and avoid errors such as `Unable to run playground: Identifier ‘s’ has already been declared`.

Example from @mmarcon:

```
const s = 3, l = 1;
db.users.find().skip(s).limit(l);
```

_"When I run this the first time, this works well. But then if I re-run it, I get “Unable to run playground: Identifier ‘s’ has already been declared” which in the REPL makes sense but in the playground case I’d expect that every run starts with a clean context."_

3) Display active connection instead of active db. When switching connections update active connection name in code lenses.

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
