### PR TITLE
VSCODE-67: add a confirmation when running a playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ Open VS Code, launch the Commmand Palette (⌘+Shift+P on MacOS, Ctrl+Shift+P on
 * `mdb.shell`: The MongoDB shell to use.
 * `mdb.show`: Show or hide the MongoDB view.
 * `mdb.defaultLimit`: The number of documents to fetch when viewing documents from a collection.
+* `mdb.confirmRunAll`: Show a confirmation message before running commands in a playground.
 * `mdb.connectionSaving.hideOptionToChooseWhereToSaveNewConnections`: When a connection is added, a prompt is shown that let's the user decide where the new connection should be saved. When this setting is checked, the prompt is not shown and the default connection saving location setting is used.
-* `mdb.connectionSaving.defaultConnectionSavingLocation`: When the setting that hides the option to choose where to save new connections is checked, this setting sets if and where new connections are saved."
+* `mdb.connectionSaving.defaultConnectionSavingLocation`: When the setting that hides the option to choose where to save new connections is checked, this setting sets if and where new connections are saved.
 
 ![Settings](resources/screenshots/settings.png)
 

--- a/package.json
+++ b/package.json
@@ -410,6 +410,11 @@
           "default": 10,
           "description": "The number of documents to fetch when viewing documents from a collection."
         },
+        "mdb.confirmRunAll": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show a confirmation message before running commands in a playground."
+        },
         "mdb.connectionSaving.hideOptionToChooseWhereToSaveNewConnections": {
           "type": "boolean",
           "default": false,

--- a/src/editors/playgroundController.ts
+++ b/src/editors/playgroundController.ts
@@ -93,6 +93,24 @@ export default class PlaygroundController {
 
   runAllPlaygroundBlocks(): Promise<boolean> {
     return new Promise(async (resolve) => {
+      const activeConnection = this._connectionController.getActiveDataService();
+      const shouldConfirmRunAll = vscode.workspace
+        .getConfiguration('mdb')
+        .get('confirmRunAll');
+
+      if (activeConnection && shouldConfirmRunAll === true) {
+        const name = this._connectionController.getActiveConnectionName();
+        const confirmRunAll = await vscode.window.showInformationMessage(
+          `Are you sure you with to run this playground against ${name}?`,
+          { modal: true },
+          'Yes'
+        );
+
+        if (confirmRunAll !== 'Yes') {
+          return Promise.resolve(false);
+        }
+      }
+
       const activeEditor = vscode.window.activeTextEditor;
       const codeToEvaluate = activeEditor?.document.getText() || '';
       let result;

--- a/src/editors/playgroundController.ts
+++ b/src/editors/playgroundController.ts
@@ -101,7 +101,7 @@ export default class PlaygroundController {
       if (activeConnection && shouldConfirmRunAll === true) {
         const name = this._connectionController.getActiveConnectionName();
         const confirmRunAll = await vscode.window.showInformationMessage(
-          `Are you sure you want to run this playground against ${name}?`,
+          `Are you sure you want to run this playground against ${name}? This confirmation can be disabled in the extension settings.`,
           { modal: true },
           'Yes'
         );

--- a/src/editors/playgroundController.ts
+++ b/src/editors/playgroundController.ts
@@ -101,7 +101,7 @@ export default class PlaygroundController {
       if (activeConnection && shouldConfirmRunAll === true) {
         const name = this._connectionController.getActiveConnectionName();
         const confirmRunAll = await vscode.window.showInformationMessage(
-          `Are you sure you with to run this playground against ${name}?`,
+          `Are you sure you want to run this playground against ${name}?`,
           { modal: true },
           'Yes'
         );

--- a/src/test/suite/editors/playgroundController.test.ts
+++ b/src/test/suite/editors/playgroundController.test.ts
@@ -135,7 +135,7 @@ suite('Playground Controller Test Suite', () => {
           await testPlaygroundController.runAllPlaygroundBlocks();
 
           const expectedMessage =
-            'Are you sure you want to run this playground against fakeName?';
+            'Are you sure you want to run this playground against fakeName? This confirmation can be disabled in the extension settings.';
 
           expect(fakeShowInformationMessage.calledOnce).to.be.true;
           expect(fakeShowInformationMessage.calledWith(expectedMessage)).to.be.true;

--- a/src/test/suite/editors/playgroundController.test.ts
+++ b/src/test/suite/editors/playgroundController.test.ts
@@ -116,5 +116,30 @@ suite('Playground Controller Test Suite', () => {
         }
       );
     });
+
+    test('show a confirmation message before running commands in a playground', (done) => {
+      const mockDocument = {
+        _id: new ObjectId('5e32b4d67bf47f4525f2f8ab'),
+        example: 'field'
+      };
+      const fakeShowInformationMessage = sinon.fake();
+
+      sinon.replace(vscode.window, 'showInformationMessage', fakeShowInformationMessage);
+
+      seedDataAndCreateDataService('forest', [mockDocument]).then(
+        async (dataService) => {
+          testConnectionController.setActiveConnection(dataService);
+          testPlaygroundController.runAllPlaygroundBlocks().then(() => {
+            const expectedMessage =
+              'Are you sure you with to run this playground against ${name}?';
+
+            expect(fakeShowInformationMessage).to.have.been.called;
+            expect(fakeShowInformationMessage.firstArg).to.be.equal(expectedMessage);
+          }).then(done, done);
+
+          await cleanupTestDB();
+        }
+      ).then(done, done);
+    });
   });
 });

--- a/src/test/suite/editors/playgroundController.test.ts
+++ b/src/test/suite/editors/playgroundController.test.ts
@@ -131,7 +131,7 @@ suite('Playground Controller Test Suite', () => {
           testConnectionController.setActiveConnection(dataService);
           testPlaygroundController.runAllPlaygroundBlocks().then(() => {
             const expectedMessage =
-              'Are you sure you with to run this playground against ${name}?';
+              'Are you sure you want to run this playground against ${name}?';
 
             expect(fakeShowInformationMessage).to.have.been.called;
             expect(fakeShowInformationMessage.firstArg).to.be.equal(expectedMessage);

--- a/src/test/suite/editors/playgroundController.test.ts
+++ b/src/test/suite/editors/playgroundController.test.ts
@@ -47,6 +47,9 @@ suite('Playground Controller Test Suite', () => {
       new StatusView(mockExtensionContext),
       mockStorageController
     );
+
+    testConnectionController.getActiveConnectionName = () => 'fakeName';
+
     const testPlaygroundController = new PlaygroundController(mockExtensionContext, testConnectionController);
 
     test('evaluate should sum numbers', async () => {
@@ -131,9 +134,8 @@ suite('Playground Controller Test Suite', () => {
           testConnectionController.setActiveConnection(dataService);
           testPlaygroundController.runAllPlaygroundBlocks().then(() => {
             const expectedMessage =
-              'Are you sure you want to run this playground against ${name}?';
+              'Are you sure you want to run this playground against fakeName?';
 
-            expect(fakeShowInformationMessage).to.have.been.called;
             expect(fakeShowInformationMessage.firstArg).to.be.equal(expectedMessage);
           }).then(done, done);
 

--- a/src/test/suite/editors/playgroundController.test.ts
+++ b/src/test/suite/editors/playgroundController.test.ts
@@ -47,7 +47,6 @@ suite('Playground Controller Test Suite', () => {
       new StatusView(mockExtensionContext),
       mockStorageController
     );
-
     testConnectionController.getActiveConnectionName = () => 'fakeName';
 
     const testPlaygroundController = new PlaygroundController(mockExtensionContext, testConnectionController);
@@ -120,24 +119,53 @@ suite('Playground Controller Test Suite', () => {
       );
     });
 
-    test('show a confirmation message before running commands in a playground', (done) => {
+    test('show a confirmation message before running commands in a playground if mdb.confirmRunAll is true', (done) => {
       const mockDocument = {
         _id: new ObjectId('5e32b4d67bf47f4525f2f8ab'),
         example: 'field'
       };
-      const fakeShowInformationMessage = sinon.fake();
+      const fakeShowInformationMessage = sinon.stub(vscode.window, 'showInformationMessage');
 
-      sinon.replace(vscode.window, 'showInformationMessage', fakeShowInformationMessage);
+      fakeShowInformationMessage.returns('Yes');
 
       seedDataAndCreateDataService('forest', [mockDocument]).then(
         async (dataService) => {
           testConnectionController.setActiveConnection(dataService);
-          testPlaygroundController.runAllPlaygroundBlocks().then(() => {
-            const expectedMessage =
-              'Are you sure you want to run this playground against fakeName?';
 
-            expect(fakeShowInformationMessage.firstArg).to.be.equal(expectedMessage);
-          }).then(done, done);
+          await testPlaygroundController.runAllPlaygroundBlocks();
+
+          const expectedMessage =
+            'Are you sure you want to run this playground against fakeName?';
+
+          expect(fakeShowInformationMessage.calledOnce).to.be.true;
+          expect(fakeShowInformationMessage.calledWith(expectedMessage)).to.be.true;
+          fakeShowInformationMessage.restore();
+
+          await cleanupTestDB();
+        }
+      ).then(done, done);
+    });
+
+    test('show a confirmation message before running commands in a playground if mdb.confirmRunAll is false', (done) => {
+      const mockDocument = {
+        _id: new ObjectId('5e32b4d67bf47f4525f2f8ab'),
+        example: 'field'
+      };
+      const fakeShowInformationMessage = sinon.stub(vscode.window, 'showInformationMessage');
+
+      fakeShowInformationMessage.returns('Yes');
+
+      seedDataAndCreateDataService('forest', [mockDocument]).then(
+        async (dataService) => {
+          testConnectionController.setActiveConnection(dataService);
+
+          await vscode.workspace
+            .getConfiguration('mdb')
+            .update('confirmRunAll', false);
+          await testPlaygroundController.runAllPlaygroundBlocks();
+
+          expect(fakeShowInformationMessage.calledOnce).to.be.false;
+          fakeShowInformationMessage.restore();
 
           await cleanupTestDB();
         }


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
Put running a playground behind a prompt to avoid users accidentally messing up their data or doing unintended queries.

- Before running commands in a playground show the `Are you sure you want to run this playground against [CONNECTION_NAME]?` confirmation message.
- Add a setting that can be turned off in case people would like to live on the wild side.

### Checklist
- [x] New tests and/or benchmarks are included
- [x] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
