### PR TITLE
feat(language): VSCODE-24: Language server setup

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,6 +32,22 @@
         "${workspaceFolder}/out/test/**/*.js"
       ],
       "preLaunchTask": "${defaultBuildTask}"
+    },
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "Attach to Language Server",
+      "protocol": "inspector",
+      "port": 6005,
+      "sourceMaps": true,
+      "outFiles": ["${workspaceFolder}/out/**/*.js"],
+      "preLaunchTask": "${defaultBuildTask}"
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Extension + Server Inspector",
+      "configurations": ["Run Extension", "Attach to Language Server"]
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,9 +24,9 @@
       "request": "launch",
       "runtimeExecutable": "${execPath}",
       "args": [
-        "${workspaceFolder}/out/test",
         "--extensionDevelopmentPath=${workspaceFolder}",
-        "--extensionTestsPath=${workspaceFolder}/out/test/suite/index"
+        "--extensionTestsPath=${workspaceFolder}/out/test/suite/index",
+        "${workspaceRoot}/src/test/fixture"
       ],
       "outFiles": [
         "${workspaceFolder}/out/test/**/*.js"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,11 @@
   // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
   "typescript.tsc.autoDetect": "off",
   "prettier.singleQuote": true,
-  "prettier.arrowParens": "always"
+  "prettier.arrowParens": "always",
+  // Language server logging for
+  // https://github.com/Microsoft/language-server-protocol-inspector
+  "mongodbLanguageServer.trace.server": {
+    "format": "json",
+    "verbosity": "info"
+  }
 }

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
-# MongoDB  for VS Code [Alpha]
+# MongoDB for VS Code ![PREVIEW](https://img.shields.io/badge/-PREVIEW-orange)
 
-[![Build Status](https://dev.azure.com/team-compass/vscode/_apis/build/status/mongodb-js.vscode?branchName=master)](https://dev.azure.com/team-compass/vscode/_build/latest?definitionId=6&branchName=master)
+[![Build Status][azure_img]][azure_url]
 
 **MongoDB for VS Code** lets you easily work with MongoDB directly from your VS Code environment. Using the MongoDB Extension, you can:
 
-* Connect to a MongoDB instance or cluster
-* Navigate your databases and collections
-* Prototype queries and aggregations
-
+- Connect to a MongoDB instance or cluster
+- Navigate your databases and collections
+- Prototype queries and aggregations
 
 MongoDB for VS Code is still a work in progress and is **not yet released**.
 
@@ -31,40 +30,42 @@ code --install-extension /path/to/mongodb-vscode-x.y.z.vsix
 ```
 
 If you get an error because the `code` command is not found, you need to install it in your `$PATH`.
-Open VS Code, launch the Commmand Palette (⌘+Shift+P on MacOS, Ctrl+Shift+P on Windows and Linux), type `code` and select "Install code command in $PATH".
+Open VS Code, launch the Commmand Palette (⌘+Shift+P on MacOS, Ctrl+Shift+P on Windows and Linux), type `code` and select "Install code command in \$PATH".
 
-## Features
+## :construction: Features
 
 ### MongoDB data explorer
-* Connect to your MongoDB instance, cluster or to your [Atlas deployment](https://www.mongodb.com/cloud/atlas/register)
-* Navigate your database and collections
-* See the documents in your collections
-* Get a quick overview of your schema
+
+- Connect to your MongoDB instance, cluster or to your [Atlas deployment](https://www.mongodb.com/cloud/atlas/register)
+- Navigate your database and collections
+- See the documents in your collections
+- Get a quick overview of your schema
 
 ![Explore data with MongoDB for VS Code](resources/screenshots/explore-data.png)
 
 ### MongoDB Playgrounds
-* Prototype your queries, aggregations and MongoDB commands with MongoDB Syntax Highlighting
-* Run your playgrounds and see the results instantly
-* Save your playgrounds in your workspace and use them to document how your application interacts with MongoDB
-* Build aggregations quickly with our helpful and well commented stage snippets
+
+- Prototype your queries, aggregations and MongoDB commands with MongoDB Syntax Highlighting
+- Run your playgrounds and see the results instantly
+- Save your playgrounds in your workspace and use them to document how your application interacts with MongoDB
+- Build aggregations quickly with our helpful and well commented stage snippets
 
 ![Playgrounds](resources/screenshots/playground.png)
 
-
 ### Quick access to the MongoDB Shell
-* Launch the MongoDB Shell from the command palette to quickly connect to the same cluster you have active in VS Code
+
+- Launch the MongoDB Shell from the command palette to quickly connect to the same cluster you have active in VS Code
 
 ![MongoDB Shell](resources/screenshots/shell-launcher.png)
 
 ## Extension Settings
 
-* `mdb.shell`: The MongoDB shell to use.
-* `mdb.show`: Show or hide the MongoDB view.
-* `mdb.defaultLimit`: The number of documents to fetch when viewing documents from a collection.
-* `mdb.confirmRunAll`: Show a confirmation message before running commands in a playground.
-* `mdb.connectionSaving.hideOptionToChooseWhereToSaveNewConnections`: When a connection is added, a prompt is shown that let's the user decide where the new connection should be saved. When this setting is checked, the prompt is not shown and the default connection saving location setting is used.
-* `mdb.connectionSaving.defaultConnectionSavingLocation`: When the setting that hides the option to choose where to save new connections is checked, this setting sets if and where new connections are saved.
+- `mdb.shell`: The MongoDB shell to use.
+- `mdb.show`: Show or hide the MongoDB view.
+- `mdb.defaultLimit`: The number of documents to fetch when viewing documents from a collection.
+- `mdb.confirmRunAll`: Show a confirmation message before running commands in a playground.
+- `mdb.connectionSaving.hideOptionToChooseWhereToSaveNewConnections`: When a connection is added, a prompt is shown that let's the user decide where the new connection should be saved. When this setting is checked, the prompt is not shown and the default connection saving location setting is used.
+- `mdb.connectionSaving.defaultConnectionSavingLocation`: When the setting that hides the option to choose where to save new connections is checked, this setting sets if and where new connections are saved.
 
 ![Settings](resources/screenshots/settings.png)
 
@@ -83,3 +84,10 @@ Is there anything else you’d like to see in Compass? Let us know by submitting
 ## License
 
 [Apache 2.0](./LICENSE.txt)
+[snippet guide]: https://code.visualstudio.com/api/language-extensions/snippet-guide
+[syntax guide]: https://code.visualstudio.com/api/language-extensions/syntax-highlight-guide
+[azure_img]: https://dev.azure.com/team-compass/team-compass/_apis/build/status/mongodb-js.vscode?branchName=master
+[azure_url]: https://dev.azure.com/team-compass/team-compass/_build/latest?definitionId=4&branchName=master
+[jira]: https://jira.mongodb.org/browse/VSCODE
+[vscode api]: https://code.visualstudio.com/api
+[nodejs]: https://nodejs.org

--- a/package-lock.json
+++ b/package-lock.json
@@ -9157,6 +9157,49 @@
         }
       }
     },
+    "vscode-jsonrpc": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz",
+      "integrity": "sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A=="
+    },
+    "vscode-languageclient": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-6.1.1.tgz",
+      "integrity": "sha512-mB6d8Tg+82l8EFUfR+SBu0+lCshyKVgC5E5+MQ0/BJa+9AgeBjtG5npoGaCo4/VvWzK0ZRGm85zU5iRp1RYPIA==",
+      "requires": {
+        "semver": "^6.3.0",
+        "vscode-languageserver-protocol": "^3.15.3"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
+      }
+    },
+    "vscode-languageserver": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-6.1.1.tgz",
+      "integrity": "sha512-DueEpkUAkD5XTR4MLYNr6bQIp/UFR0/IPApgXU3YfCBCB08u2sm9hRCs6DxYZELkk++STPjpcjksR2H8qI3cDQ==",
+      "requires": {
+        "vscode-languageserver-protocol": "^3.15.3"
+      }
+    },
+    "vscode-languageserver-protocol": {
+      "version": "3.15.3",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.3.tgz",
+      "integrity": "sha512-zrMuwHOAQRhjDSnflWdJG+O2ztMWss8GqUUB8dXLR/FPenwkiBNkMIJJYfSN6sgskvsF0rHAoBowNQfbyZnnvw==",
+      "requires": {
+        "vscode-jsonrpc": "^5.0.1",
+        "vscode-languageserver-types": "3.15.1"
+      }
+    },
+    "vscode-languageserver-types": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz",
+      "integrity": "sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ=="
+    },
     "vscode-test": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -453,7 +453,9 @@
     "mongodb-ns": "^2.2.0",
     "mongodb-schema": "^8.2.5",
     "ts-log": "^2.1.4",
-    "uuid": "^7.0.0"
+    "uuid": "^7.0.0",
+    "vscode-languageclient": "^6.1.1",
+    "vscode-languageserver": "^6.1.1"
   },
   "devDependencies": {
     "@types/chai": "^4.2.9",

--- a/src/language/README.md
+++ b/src/language/README.md
@@ -1,7 +1,7 @@
 # MongoDB Language Server
 
-https://code.visualstudio.com/api/language-extensions/programmatic-language-features
-https://code.visualstudio.com/api/language-extensions/language-server-extension-guide
+> NOTE (lucas) This is mostly a regurgitation of the docs so I can think out loud and keep notes. You may find the source material more useful: [programmatic language features](https://code.visualstudio.com/api/language-extensions/programmatic-language-features) and
+> [language server extension guide](https://code.visualstudio.com/api/language-extensions/language-server-extension-guide)
 
 **MongoDB Language Server** runs as a separate node.js process using [vscode-languageserver](https://github.com/microsoft/vscode-languageserver-node/tree/master/server)
 
@@ -11,14 +11,15 @@ https://code.visualstudio.com/api/language-extensions/language-server-extension-
 
 VS Code's integration of the [Language Server Protocol](https://microsoft.github.io/language-server-protocol) provides the potential to implement the following user facing features:
 
-| What                                                                                                                                   | Example Behavior                    |
-| :------------------------------------------------------------------------------------------------------------------------------------- | :---------------------------------- |
-| **[completions](https://code.visualstudio.com/api/language-extensions/programmatic-language-features#show-code-completion-proposals)** | ex. mongodb-ace-mode autocompletion |
-
-**[diagnostics](https://code.visualstudio.com/api/language-extensions/programmatic-language-features#provide-diagnostics)** ex. eslint errors/warnings on .mongodb files
-
-- `formatting` ex. prettier on .mongodb files
-- `hover` ex. show mini-schema view when hovering over a collection name
+| What                                                                                                                                            | Example Behavior                                                                                      |
+| :---------------------------------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------- |
+| **[completions](https://code.visualstudio.com/api/language-extensions/programmatic-language-features#show-code-completion-proposals)**          | ex. mongodb-ace-mode autocompletion                                                                   |
+| **[diagnostics](https://code.visualstudio.com/api/language-extensions/programmatic-language-features#provide-diagnostics)**                     | ex. eslint errors/warnings on .mongodb files                                                          | \  |
+| **[formatting](https://code.visualstudio.com/api/language-extensions/programmatic-language-features#format-source-code-in-an-editor)**          | ex. prettier on .mongodb files                                                                        |
+| **[hovers](https://code.visualstudio.com/api/language-extensions/programmatic-language-features#show-hovers)**                                  | ex. show mini-schema view when hovering over a collection name, docs description for an agg operator. |
+| **[signatures](https://code.visualstudio.com/api/language-extensions/programmatic-language-features#help-with-function-and-method-signatures)** | ex. what are the types and shape of args an agg operator or SHELL API method takes                    |
+| **[definitions](https://code.visualstudio.com/api/language-extensions/programmatic-language-features#show-definitions-of-a-symbol)**            | ex. view mongosh source for a SHELL API method                                                        |
+| **[codeActions](https://code.visualstudio.com/api/language-extensions/programmatic-language-features#possible-actions-on-errors-or-warnings)**  | ex. field name mispelled                                                                              |
 
 We can also extend the mongodb language server and client with custom methods to leverage it as a background worker. Because the language server is a separate JSON RPC enabled process, we can add RPC definitions for:
 

--- a/src/language/README.md
+++ b/src/language/README.md
@@ -1,24 +1,68 @@
-## static
-
-- grammars for syntax highlighting
-
-https://code.visualstudio.com/api/language-extensions/syntax-highlight-guide
-https://code.visualstudio.com/api/language-extensions/language-configuration-guide
-
-> The contributes.languages Contribution Point allows you to define a language configuration that controls the following Declarative Language Features:
->
-> - Comment toggling
-> - Brackets definition
-> - Autoclosing
-> - Autosurrounding
-> - Folding
-> - Word pattern
-> - Indentation Rules
-
-## dynamic
-
-- language server (client/server)
-- here or in services?
+# MongoDB Language Server
 
 https://code.visualstudio.com/api/language-extensions/programmatic-language-features
 https://code.visualstudio.com/api/language-extensions/language-server-extension-guide
+
+**MongoDB Language Server** runs as a separate node.js process using [vscode-languageserver](https://github.com/microsoft/vscode-languageserver-node/tree/master/server)
+
+**MongoDB Language Client** runs next to UI code and uses [vscode-languageclient](https://github.com/microsoft/vscode-languageserver-node/tree/master/client) for JSON RPC over IPC.
+
+![](./langserver-diagram.svg)
+
+VS Code's integration of the [Language Server Protocol](https://microsoft.github.io/language-server-protocol) provides the potential to implement the following user facing features:
+
+| What                                                                                                                                   | Example Behavior                    |
+| :------------------------------------------------------------------------------------------------------------------------------------- | :---------------------------------- |
+| **[completions](https://code.visualstudio.com/api/language-extensions/programmatic-language-features#show-code-completion-proposals)** | ex. mongodb-ace-mode autocompletion |
+
+**[diagnostics](https://code.visualstudio.com/api/language-extensions/programmatic-language-features#provide-diagnostics)** ex. eslint errors/warnings on .mongodb files
+
+- `formatting` ex. prettier on .mongodb files
+- `hover` ex. show mini-schema view when hovering over a collection name
+
+We can also extend the mongodb language server and client with custom methods to leverage it as a background worker. Because the language server is a separate JSON RPC enabled process, we can add RPC definitions for:
+
+- Execute playground .mongodb scripts with mongosh repl evaluator thingie
+- Schema analysis and caching
+
+### Debugging
+
+#### Output Channel
+
+`MongoDB Language Server`
+
+From server side: `connection.console.log(<string>)`
+
+![MongoDB Language Server output channel](https://user-images.githubusercontent.com/23074/76441349-a489e980-6395-11ea-8247-50cfe9b3ff61.png)
+
+#### Log Streaming + LSP Inspector
+
+https://github.com/microsoft/vscode-extension-samples/tree/master/lsp-log-streaming-sample
+https://microsoft.github.io/language-server-protocol/inspector/
+
+In `.vscode/settings.json`
+
+```json
+"mongodbLanguageServer.trace.server": {
+  "format": "json",
+  "verbosity": "verbose"
+},
+```
+
+#### LSP Notifications
+
+From the server:
+
+```javascript
+connection.sendNotification('mongodbNotification', `Hi, Friend.`);
+```
+
+From the client:
+
+```javascript
+client.onNotification('mongodbNotification', (messsage) => {
+  vscode.window.showInformationMessage(messsage);
+});
+```
+
+![Screenshot 2020-03-11 12 04 42](https://user-images.githubusercontent.com/23074/76441224-74424b00-6395-11ea-8f28-f9e0387098e0.png)

--- a/src/language/index.ts
+++ b/src/language/index.ts
@@ -1,0 +1,3 @@
+import LanguageServerController from './languageServerController';
+
+export { LanguageServerController };

--- a/src/language/langserver-diagram.svg
+++ b/src/language/langserver-diagram.svg
@@ -1,0 +1,32 @@
+
+<svg width="872px" height="234px" viewBox="0 0 872 234" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <rect id="Rectangle" stroke="#979797" fill="#FFFFFF" x="0.5" y="0.5" width="871" height="233"></rect>
+        <rect id="Rectangle" stroke="#979797" fill="#D8D8D8" x="13.5" y="54.5" width="302" height="157"></rect>
+        <rect id="Rectangle" fill="#13AA52" x="25" y="106" width="280" height="90"></rect>
+        <rect id="Rectangle" stroke="#979797" fill="#D8D8D8" x="555.5" y="54.5" width="302" height="157"></rect>
+        <rect id="Rectangle" fill="#13AA52" x="566" y="106" width="280" height="90"></rect>
+        <text id="Language-Server-Prot" font-family="AkzidenzGroteskStd-Md, Akzidenz-Grotesk Std" font-size="14" font-weight="400" fill="#42494F">
+            <tspan x="359" y="130">Language Server Protocol</tspan>
+        </text>
+        <text id="JSON-RPC-via-IPC" font-family="AkzidenzGroteskStd-Md, Akzidenz-Grotesk Std" font-size="12" font-weight="400" fill="#42494F">
+            <tspan x="392" y="173">JSON RPC via IPC</tspan>
+        </text>
+        <text id="VS-Code" font-family="AkzidenzGroteskStd-Md, Akzidenz-Grotesk Std" font-size="18" font-weight="400" fill="#42494F">
+            <tspan x="406" y="26">VS Code</tspan>
+        </text>
+        <text id="Extension-Host" font-family="AkzidenzGroteskStd-Md, Akzidenz-Grotesk Std" font-size="18" font-weight="400" fill="#42494F">
+            <tspan x="94" y="85">Extension Host</tspan>
+        </text>
+        <text id="node.js-process" font-family="AkzidenzGroteskStd-Md, Akzidenz-Grotesk Std" font-size="18" font-weight="400" fill="#42494F">
+            <tspan x="641" y="85">node.js process</tspan>
+        </text>
+        <text id="MongoDB-Language-Cli" font-family="AkzidenzGroteskStd-Md, Akzidenz-Grotesk Std" font-size="18" font-weight="400" fill="#FFFFFF">
+            <tspan x="57" y="162">MongoDB Language Client</tspan>
+        </text>
+        <path id="Line" d="M323.75,149.5 L547.25,149.5 L547.25,141.5 L566.25,151 L547.25,160.5 L547.25,152.5 L323.75,152.5 L323.75,160.5 L304.75,151 L323.75,141.5 L323.75,149.5 Z" fill="#42494F" fill-rule="nonzero"></path>
+        <text id="MongoDB-Language-Ser" font-family="AkzidenzGroteskStd-Md, Akzidenz-Grotesk Std" font-size="18" font-weight="400" fill="#FFFFFF">
+            <tspan x="596" y="157">MongoDB Language Server</tspan>
+        </text>
+    </g>
+</svg>

--- a/src/language/languageServerController.ts
+++ b/src/language/languageServerController.ts
@@ -1,0 +1,97 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { workspace, ExtensionContext } from 'vscode';
+
+import {
+  LanguageClient,
+  LanguageClientOptions,
+  ServerOptions,
+  TransportKind
+} from 'vscode-languageclient';
+
+import ConnectionController from '../connectionController';
+import { createLogger } from '../logging';
+
+const log = createLogger('LanguageServerController');
+
+/**
+ * This controller manages the language server and client.
+ */
+export default class LanguageServerController {
+  _connectionController?: ConnectionController;
+  client?: LanguageClient;
+  constructor(
+    context: vscode.ExtensionContext,
+    connectionController: ConnectionController
+  ) {
+    this._connectionController = connectionController;
+    this.activate(context);
+  }
+
+  async activate(context: ExtensionContext): Promise<LanguageClient> {
+    // The server is implemented in node
+    const serverModule = context.asAbsolutePath(
+      path.join('out', 'language', 'server.js')
+    );
+    // The debug options for the server
+    // --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging
+    const debugOptions = { execArgv: ['--nolazy', '--inspect=6009'] };
+
+    // If the extension is launched in debug mode then the debug server options are used
+    // Otherwise the run options are used
+    const serverOptions: ServerOptions = {
+      run: { module: serverModule, transport: TransportKind.ipc },
+      debug: {
+        module: serverModule,
+        transport: TransportKind.ipc,
+        options: debugOptions
+      }
+    };
+
+    // Options to control the language client
+    const clientOptions: LanguageClientOptions = {
+      // Register the server for plain text documents
+      documentSelector: [
+        { scheme: 'untitled', language: 'mongodb' },
+        { scheme: 'file', language: 'mongodb' }
+      ],
+      synchronize: {
+        // Notify the server about file changes to '.clientrc files contained in the workspace
+        fileEvents: workspace.createFileSystemWatcher('**/*')
+      }
+    };
+
+    log.info('Activating MongoDB language server', {
+      serverOptions,
+      clientOptions
+    });
+
+    // Create the language client and start the client.
+    this.client = new LanguageClient(
+      'mongodbLanguageServer',
+      'MongoDB Language Server',
+      serverOptions,
+      clientOptions
+    );
+
+    // Start the client. This will also launch the server
+    this.client.start();
+
+    await this.client.onReady();
+    /**
+     * TODO: Notification is for setup docs only.
+     */
+    this.client.onNotification('mongodbNotification', (messsage) => {
+      vscode.window.showInformationMessage(messsage);
+    });
+
+    return new Promise((resolve) => resolve(this.client));
+  }
+
+  deactivate(): Thenable<void> | undefined {
+    if (!this.client) {
+      return undefined;
+    }
+    return this.client.stop();
+  }
+}

--- a/src/language/server.ts
+++ b/src/language/server.ts
@@ -1,0 +1,344 @@
+import {
+  createConnection,
+  TextDocuments,
+  TextDocumentsConfiguration,
+  TextDocument,
+  Diagnostic,
+  DiagnosticSeverity,
+  ProposedFeatures,
+  InitializeParams,
+  DidChangeConfigurationNotification,
+  CompletionItem,
+  CompletionItemKind,
+  TextDocumentPositionParams,
+  RequestType
+} from 'vscode-languageserver';
+
+// Create a connection for the server. The connection uses Node's IPC as a transport.
+// Also include all preview / proposed LSP features.
+const connection = createConnection(ProposedFeatures.all);
+
+// Create a simple text document manager. The text document manager
+// supports full document sync only
+const documentsConfig = {
+  create(uri: string, languageId: string, version: number, content: string) {
+    // connection.console.log(
+    //   `documentsConfig.create: ${JSON.stringify({
+    //     uri,
+    //     languageId,
+    //     version,
+    //     content
+    //   })}`
+    // );
+  },
+  update(document: any, changes: any[], version: number) {
+    // connection.console.log(
+    //   `documentsConfig.update: ${JSON.stringify({
+    //     document,
+    //     changes,
+    //     version
+    //   })}`
+    // );
+  }
+} as TextDocumentsConfiguration<any>;
+
+const documents: TextDocuments<any> = new TextDocuments(documentsConfig);
+
+let hasConfigurationCapability = false;
+let hasWorkspaceFolderCapability = false;
+let hasDiagnosticRelatedInformationCapability = false;
+
+connection.onInitialize((params: InitializeParams) => {
+  const capabilities = params.capabilities;
+
+  // Does the client support the `workspace/configuration` request?
+  // If not, we will fall back using global settings
+  hasConfigurationCapability = !!(
+    capabilities.workspace && !!capabilities.workspace.configuration
+  );
+  hasWorkspaceFolderCapability = !!(
+    capabilities.workspace && !!capabilities.workspace.workspaceFolders
+  );
+  hasDiagnosticRelatedInformationCapability = !!(
+    capabilities.textDocument &&
+    capabilities.textDocument.publishDiagnostics &&
+    capabilities.textDocument.publishDiagnostics.relatedInformation
+  );
+
+  return {
+    capabilities: {
+      textDocumentSync: (documents as any).syncKind,
+      // Tell the client that the server supports code completion
+      completionProvider: {
+        resolveProvider: true
+      }
+      // documentFormattingProvider: true,
+      // documentRangeFormattingProvider: true,
+      // codeLensProvider: {
+      //   resolveProvider: true
+      // }
+    }
+  };
+});
+
+connection.onInitialized(() => {
+  if (hasConfigurationCapability) {
+    // Register for all configuration changes.
+    connection.client.register(
+      DidChangeConfigurationNotification.type,
+      undefined
+    );
+  }
+  // if (hasWorkspaceFolderCapability) {
+  //   connection.workspace.onDidChangeWorkspaceFolders((_event) => {
+  //     connection.console.log('Workspace folder change event received.');
+  //   });
+  // }
+});
+
+// The example settings
+interface ExampleSettings {
+  maxNumberOfProblems: number;
+}
+
+// The global settings, used when the `workspace/configuration` request is not supported by the client.
+// Please note that this is not the case when using this server with the client provided in this example
+// but could happen with other clients.
+const defaultSettings: ExampleSettings = { maxNumberOfProblems: 1000 };
+let globalSettings: ExampleSettings = defaultSettings;
+
+// Cache the settings of all open documents
+const documentSettings: Map<string, Thenable<ExampleSettings>> = new Map();
+
+connection.onDidChangeConfiguration((change) => {
+  if (hasConfigurationCapability) {
+    // Reset all cached document settings
+    documentSettings.clear();
+  } else {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    globalSettings = <ExampleSettings>(
+      (change.settings.languageServerExample || defaultSettings)
+    );
+  }
+
+  // Revalidate all open text documents
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
+  documents.all().forEach(validateTextDocument);
+});
+
+function getDocumentSettings(resource: string): Thenable<ExampleSettings> {
+  if (!hasConfigurationCapability) {
+    return Promise.resolve(globalSettings);
+  }
+  let result = documentSettings.get(resource);
+  if (!result) {
+    result = connection.workspace.getConfiguration({
+      scopeUri: resource,
+      section: 'mongodbLanguageServer'
+    });
+    documentSettings.set(resource, result);
+  }
+  return result;
+}
+
+// Only keep settings for open documents
+documents.onDidClose((e) => {
+  // connection.console.log(`documents.onDidClose: ${JSON.stringify(e)}`);
+  documentSettings.delete(e.document.uri);
+});
+
+async function validateTextDocument(textDocument: TextDocument): Promise<void> {
+  // In this simple example we get the settings for every validate run.
+  const settings = await getDocumentSettings(textDocument.uri);
+
+  // The validator creates diagnostics for all uppercase words length 2 and more
+  const text = textDocument.getText();
+  const pattern = /\b[A-Z]{2,}\b/g;
+  let m: RegExpExecArray | null;
+
+  let problems = 0;
+  const diagnostics: Diagnostic[] = [];
+  // eslint-disable-next-line no-cond-assign
+  while ((m = pattern.exec(text)) && problems < settings.maxNumberOfProblems) {
+    problems++;
+    const diagnostic: Diagnostic = {
+      severity: DiagnosticSeverity.Warning,
+      range: {
+        start: textDocument.positionAt(m.index),
+        end: textDocument.positionAt(m.index + m[0].length)
+      },
+      message: `${m[0]} is all uppercase.`,
+      source: 'ex'
+    };
+    if (hasDiagnosticRelatedInformationCapability) {
+      diagnostic.relatedInformation = [
+        {
+          location: {
+            uri: textDocument.uri,
+            range: Object.assign({}, diagnostic.range)
+          },
+          message: 'Spelling matters'
+        },
+        {
+          location: {
+            uri: textDocument.uri,
+            range: Object.assign({}, diagnostic.range)
+          },
+          message: 'Particularly for names'
+        }
+      ];
+    }
+    diagnostics.push(diagnostic);
+  }
+
+  // Send the computed diagnostics to VSCode.
+  // connection.console.log(
+  //   `sendDiagnostics: ${JSON.stringify({ uri: textDocument.uri, diagnostics })}`
+  // );
+  connection.sendDiagnostics({ uri: textDocument.uri, diagnostics });
+
+  // const notification = new NotificationType<string>('mongodbNotification');
+  connection.sendNotification(
+    'mongodbNotification',
+    'Enjoy these diagnostics!'
+  );
+}
+
+// The content of a text document has changed. This event is emitted
+// when the text document first opened or when its content has changed.
+documents.onDidChangeContent((change) => {
+  // connection.console.log(
+  //   `documents.onDidChangeContent: ${JSON.stringify(change)}`
+  // );
+
+  if (change.document) {
+    validateTextDocument(change.document);
+  }
+});
+
+connection.onRequest(new RequestType('textDocument/codeLens'), (event) => {
+  // connection.console.log(
+  //   `documents.onDidChangeContent: ${JSON.stringify(event)}`
+  // );
+  // const text = documents.get(event.textDocument.uri).getText();
+  // const parsed = parseDocument(text);
+  // return parsed;
+});
+
+connection.onDidChangeWatchedFiles((_change) => {
+  // Monitored files have change in VSCode
+  // connection.console.log(
+  //   `We received an file change event: ${JSON.stringify(_change)}`
+  // );
+});
+
+// This handler provides the initial list of the completion items.
+connection.onCompletion(
+  (_textDocumentPosition: TextDocumentPositionParams): CompletionItem[] => {
+    // The pass parameter contains the position of the text document in
+    // which code complete got requested. For the example we ignore this
+    // info and always provide the same completion items.
+    // connection.console.log(
+    //   `onCompletion: ${JSON.stringify({ _textDocumentPosition })}`
+    // );
+    return [
+      {
+        label: 'TypeScript',
+        kind: CompletionItemKind.Text,
+        data: 1
+      },
+      {
+        label: 'JavaScript',
+        kind: CompletionItemKind.Text,
+        data: 2
+      }
+    ];
+  }
+);
+
+// This handler resolves additional information for the item selected in
+// the completion list.
+connection.onCompletionResolve(
+  (item: CompletionItem): CompletionItem => {
+    // connection.console.log(`onCompletionResolve: ${JSON.stringify(item)}`);
+    if (item.data === 1) {
+      item.detail = 'TypeScript details';
+      item.documentation = 'TypeScript documentation';
+    } else if (item.data === 2) {
+      item.detail = 'JavaScript details';
+      item.documentation = 'JavaScript documentation';
+    }
+    return item;
+  }
+);
+
+/**
+ * Execute the entire playground script.
+ */
+connection.onRequest('executeAll', (event) => {
+  // connection.console.log(`executeAll: ${JSON.stringify(event)}`);
+  return '';
+});
+
+/**
+ * Execute a single block of code in the playground.
+ */
+connection.onRequest('executeRange', (event) => {
+  // connection.console.log(`executeRange: ${JSON.stringify(event)}`);
+  return '';
+});
+
+connection.onRequest('textDocument/rangeFormatting', (event) => {
+  // connection.console.log(
+  //   `textDocument/rangeFormatting: ${JSON.stringify({ event })}`
+  // );
+  const text = documents.get(event.textDocument.uri).getText(event.range);
+
+  return text;
+});
+
+connection.onRequest('textDocument/formatting', (event) => {
+  const document = documents.get(event.textDocument.uri);
+  const text = document.getText();
+  const range = {
+    start: { line: 0, character: 0 },
+    end: { line: document.lineCount, character: 0 }
+  };
+  // connection.console.log(
+  //   `textDocument/formatting: ${JSON.stringify({
+  //     text,
+  //     options: event.options,
+  //     range
+  //   })}`
+  // );
+  return text;
+});
+
+connection.onDidOpenTextDocument((params) => {
+  // A text document got opened in VSCode.
+  // params.textDocument.uri uniquely identifies the document. For documents store on disk this is a file URI.
+  // params.textDocument.text the initial full content of the document.
+  // connection.console.log(`${params.textDocument.uri} opened.`);
+});
+connection.onDidChangeTextDocument((params) => {
+  // The content of a text document did change in VSCode.
+  // params.textDocument.uri uniquely identifies the document.
+  // params.contentChanges describe the content changes to the document.
+  // connection.console.log(
+  //   `${params.textDocument.uri} changed: ${JSON.stringify(
+  //     params.contentChanges
+  //   )}`
+  // );
+});
+connection.onDidCloseTextDocument((params) => {
+  // A text document got closed in VSCode.
+  // params.textDocument.uri uniquely identifies the document.
+  // connection.console.log(`${params.textDocument.uri} closed.`);
+});
+
+// Make the text document manager listen on the connection
+// for open, change and close text document events
+documents.listen(connection);
+
+// Listen on the connection
+connection.listen();

--- a/src/test/fixture/.vscode/settings.json
+++ b/src/test/fixture/.vscode/settings.json
@@ -1,0 +1,16 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+  "editor.formatOnSave": true,
+  "editor.tabSize": 2,
+  "editor.insertSpaces": true,
+  "files.trimTrailingWhitespace": true,
+  "files.insertFinalNewline": true,
+  "prettier.singleQuote": true,
+  "prettier.arrowParens": "always",
+  // Language server logging for
+  // https://github.com/Microsoft/language-server-protocol-inspector
+  "mongodbLanguageServer.trace.server": {
+    "format": "json",
+    "verbosity": "verbose"
+  }
+}

--- a/src/test/fixture/README.md
+++ b/src/test/fixture/README.md
@@ -1,0 +1,3 @@
+# test/fixture: E2E workspace
+
+> The workspace added to the extension host for e2e tests.

--- a/src/test/fixture/diagnostics.mongodb
+++ b/src/test/fixture/diagnostics.mongodb
@@ -1,0 +1,1 @@
+ANY browsers, ANY OS.

--- a/src/test/fixture/test.mongodb
+++ b/src/test/fixture/test.mongodb
@@ -1,0 +1,2 @@
+use temp;
+db.plantTempReadings.find();

--- a/src/test/suite/language/completion.test.ts
+++ b/src/test/suite/language/completion.test.ts
@@ -1,0 +1,102 @@
+// /* eslint-disable @typescript-eslint/no-use-before-define */
+// import * as vscode from 'vscode';
+// import * as assert from 'assert';
+// import { getDocUri, activate } from './helper';
+
+// describe.skip('Should do completion', () => {
+//   let docUri;
+//   before(() => {
+//     docUri = getDocUri('test.mongodb');
+//   });
+
+//   it('Completes JS/TS in mongodb file', async () => {
+//     await testCompletion(docUri, new vscode.Position(0, 0), {
+//       items: [
+//         { label: 'JavaScript', kind: vscode.CompletionItemKind.Text },
+//         { label: 'TypeScript', kind: vscode.CompletionItemKind.Text }
+//       ]
+//     });
+//   });
+// });
+
+// async function testCompletion(
+//   docUri: vscode.Uri,
+//   position: vscode.Position,
+//   expectedCompletionList: vscode.CompletionList
+// ) {
+//   await activate(docUri);
+
+//   // Executing the command `vscode.executeCompletionItemProvider` to simulate triggering completion
+//   const actualCompletionList = (await vscode.commands.executeCommand(
+//     'vscode.executeCompletionItemProvider',
+//     docUri,
+//     position
+//   )) as vscode.CompletionList;
+
+//   assert.equal(
+//     actualCompletionList.items.length,
+//     expectedCompletionList.items.length
+//   );
+//   expectedCompletionList.items.forEach((expectedItem, i) => {
+//     const actualItem = actualCompletionList.items[i];
+//     assert.equal(actualItem.label, expectedItem.label);
+//     assert.equal(actualItem.kind, expectedItem.kind);
+//   });
+// }
+// /* eslint-disable @typescript-eslint/no-use-before-define */
+// import * as vscode from 'vscode';
+// import * as assert from 'assert';
+// import { getDocUri, activate } from './helper';
+
+// describe.skip('Should get diagnostics', () => {
+//   let docUri;
+//   before(() => {
+//     docUri = getDocUri('diagnostics.mongodb');
+//   });
+//   it.skip('Diagnoses uppercase texts', async () => {
+//     await testDiagnostics(docUri, [
+//       {
+//         message: 'ANY is all uppercase.',
+//         range: toRange(0, 0, 0, 3),
+//         severity: vscode.DiagnosticSeverity.Warning,
+//         source: 'ex'
+//       },
+//       {
+//         message: 'ANY is all uppercase.',
+//         range: toRange(0, 14, 0, 17),
+//         severity: vscode.DiagnosticSeverity.Warning,
+//         source: 'ex'
+//       },
+//       {
+//         message: 'OS is all uppercase.',
+//         range: toRange(0, 18, 0, 20),
+//         severity: vscode.DiagnosticSeverity.Warning,
+//         source: 'ex'
+//       }
+//     ]);
+//   });
+// });
+
+// function toRange(sLine: number, sChar: number, eLine: number, eChar: number) {
+//   const start = new vscode.Position(sLine, sChar);
+//   const end = new vscode.Position(eLine, eChar);
+//   return new vscode.Range(start, end);
+// }
+
+// async function testDiagnostics(
+//   docUri: vscode.Uri,
+//   expectedDiagnostics: vscode.Diagnostic[]
+// ) {
+//   await activate(docUri);
+
+//   const actualDiagnostics = vscode.languages.getDiagnostics(docUri);
+
+//   assert.equal(actualDiagnostics.length, expectedDiagnostics.length);
+
+//   expectedDiagnostics.forEach((expectedDiagnostic, i) => {
+//     const actualDiagnostic = actualDiagnostics[i];
+//     assert.equal(actualDiagnostic.message, expectedDiagnostic.message);
+//     assert.deepEqual(actualDiagnostic.range, expectedDiagnostic.range);
+//     assert.equal(actualDiagnostic.severity, expectedDiagnostic.severity);
+//   });
+// }

--- a/src/test/suite/language/diagnostics.test.ts
+++ b/src/test/suite/language/diagnostics.test.ts
@@ -1,0 +1,55 @@
+// /* eslint-disable @typescript-eslint/no-use-before-define */
+// import * as vscode from 'vscode';
+// import * as assert from 'assert';
+// import { getDocUri, activate } from './helper';
+
+// describe('Should get diagnostics', () => {
+//   const docUri = getDocUri('diagnostics.txt');
+
+//   it.skip('Diagnoses uppercase texts', async () => {
+//     await testDiagnostics(docUri, [
+//       {
+//         message: 'ANY is all uppercase.',
+//         range: toRange(0, 0, 0, 3),
+//         severity: vscode.DiagnosticSeverity.Warning,
+//         source: 'ex'
+//       },
+//       {
+//         message: 'ANY is all uppercase.',
+//         range: toRange(0, 14, 0, 17),
+//         severity: vscode.DiagnosticSeverity.Warning,
+//         source: 'ex'
+//       },
+//       {
+//         message: 'OS is all uppercase.',
+//         range: toRange(0, 18, 0, 20),
+//         severity: vscode.DiagnosticSeverity.Warning,
+//         source: 'ex'
+//       }
+//     ]);
+//   });
+// });
+
+// function toRange(sLine: number, sChar: number, eLine: number, eChar: number) {
+//   const start = new vscode.Position(sLine, sChar);
+//   const end = new vscode.Position(eLine, eChar);
+//   return new vscode.Range(start, end);
+// }
+
+// async function testDiagnostics(
+//   docUri: vscode.Uri,
+//   expectedDiagnostics: vscode.Diagnostic[]
+// ) {
+//   await activate(docUri);
+
+//   const actualDiagnostics = vscode.languages.getDiagnostics(docUri);
+
+//   assert.equal(actualDiagnostics.length, expectedDiagnostics.length);
+
+//   expectedDiagnostics.forEach((expectedDiagnostic, i) => {
+//     const actualDiagnostic = actualDiagnostics[i];
+//     assert.equal(actualDiagnostic.message, expectedDiagnostic.message);
+//     assert.deepEqual(actualDiagnostic.range, expectedDiagnostic.range);
+//     assert.equal(actualDiagnostic.severity, expectedDiagnostic.severity);
+//   });
+// }

--- a/src/test/suite/language/helper.ts
+++ b/src/test/suite/language/helper.ts
@@ -1,0 +1,48 @@
+// /* eslint-disable @typescript-eslint/explicit-function-return-type */
+// /* eslint-disable @typescript-eslint/no-use-before-define */
+// import * as vscode from 'vscode';
+// import * as path from 'path';
+
+// export let doc: vscode.TextDocument;
+// export let editor: vscode.TextEditor;
+// export let documentEol: string;
+// export let platformEol: string;
+
+// /**
+//  * Activates the mongodb.mongodb-vscode extension
+//  */
+// export async function activate(docUri: vscode.Uri) {
+//   // The extensionId is `publisher.name` from package.json
+//   const ext = vscode.extensions.getExtension('mongodb.mongodb-vscode');
+//   if (!ext) {
+//     throw new Error('Failed to get extension mongodb.mongodb-vscode');
+//   }
+//   await ext.activate();
+
+//   try {
+//     doc = await vscode.workspace.openTextDocument(docUri);
+//     editor = await vscode.window.showTextDocument(doc);
+//     await sleep(2000); // Wait for server activation
+//   } catch (e) {
+//     console.error(e);
+//   }
+// }
+
+// async function sleep(ms: number) {
+//   return new Promise((resolve) => setTimeout(resolve, ms));
+// }
+
+// export const getDocPath = (p: string) => {
+//   return path.resolve(__dirname, '../../fixture', p);
+// };
+// export const getDocUri = (p: string) => {
+//   return vscode.Uri.file(getDocPath(p));
+// };
+
+// export async function setTestContent(content: string): Promise<boolean> {
+//   const all = new vscode.Range(
+//     doc.positionAt(0),
+//     doc.positionAt(doc.getText().length)
+//   );
+//   return editor.edit((eb) => eb.replace(all, content));
+// }


### PR DESCRIPTION
This PR provides the initial setup for MongoDB Language Server; primarily, it is documentation, dependencies and test fixture setup we'll add user-facing features on top of in the future. I also added a static mongodb language configuration in ./language for the editor.

A test fixture workspace has been added under `src/test/fixture`.