### PR TITLE
Retrieve the connection string from the right place

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
       },
       {
         "command": "mdb.openMongoDBShell",
-        "title": "MongoDB: Launch Mongo Shell"
+        "title": "MongoDB: Launch MongoDB Shell"
       },
       {
         "command": "mdb.createPlayground",

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -511,11 +511,11 @@ export default class ConnectionController {
   }
 
   public getActiveConnectionDriverUrl(): string | null {
-    if (!this._connectingConnectionId) {
+    if (!this._currentConnectionId) {
       return null;
     }
 
-    return this._savedConnections[this._connectingConnectionId].driverUrl;
+    return this._savedConnections[this._currentConnectionId].driverUrl;
   }
 
   public addEventListener(

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -54,7 +54,10 @@ export default class MDBExtensionController implements vscode.Disposable {
     this._explorerController = new ExplorerController(
       this._connectionController
     );
-    this._playgroundController = new PlaygroundController(context, this._connectionController);
+    this._playgroundController = new PlaygroundController(
+      context,
+      this._connectionController
+    );
   }
 
   activate(): void {
@@ -87,8 +90,10 @@ export default class MDBExtensionController implements vscode.Disposable {
     this.registerCommand('mdb.runAllPlaygroundBlocks', () =>
       this._playgroundController.runAllPlaygroundBlocks()
     );
-    this.registerCommand('mdb.showActiveConnectionInPlayground', (message: string) =>
-      this._playgroundController.showActiveConnectionInPlayground(message)
+    this.registerCommand(
+      'mdb.showActiveConnectionInPlayground',
+      (message: string) =>
+        this._playgroundController.showActiveConnectionInPlayground(message)
     );
 
     this.registerEditorCommands();
@@ -367,7 +372,9 @@ export default class MDBExtensionController implements vscode.Disposable {
         : '';
     }
     if (!mdbConnectionString) {
-      vscode.window.showErrorMessage('You need to be connected before launching the MongoDB Shell');
+      vscode.window.showErrorMessage(
+        'You need to be connected before launching the MongoDB Shell.'
+      );
       return Promise.resolve(false);
     }
     const mongoDBShell = vscode.window.createTerminal({

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -366,6 +366,10 @@ export default class MDBExtensionController implements vscode.Disposable {
         ? activeConnectionDriverUrl
         : '';
     }
+    if (!mdbConnectionString) {
+      vscode.window.showErrorMessage('You need to be connected before launching the MongoDB Shell');
+      return Promise.resolve(false);
+    }
     const mongoDBShell = vscode.window.createTerminal({
       name: 'MongoDB Shell',
       env: { MDB_CONNECTION_STRING: mdbConnectionString }

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1,10 +1,12 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import { afterEach } from 'mocha';
+import * as sinon from 'sinon';
 
 import MDBExtensionController from '../../mdbExtensionController';
 
 import { TestExtensionContext } from './stubs';
+import { TEST_DATABASE_URI } from './dbTestHelper';
 
 suite('Extension Test Suite', () => {
   vscode.window.showInformationMessage('Starting tests...');
@@ -14,6 +16,8 @@ suite('Extension Test Suite', () => {
   afterEach(() => {
     disposables.forEach((d) => d.dispose());
     disposables.length = 0;
+
+    sinon.restore();
   });
 
   test('commands are registered in vscode', (done) => {
@@ -64,12 +68,79 @@ suite('Extension Test Suite', () => {
       .then(() => done(), done);
   });
 
-  test('openMongoDBShell should open a terminal', (done) => {
-    disposables.push(vscode.window.onDidOpenTerminal(() => done()));
+  test('openMongoDBShell should display an error message when not connected', (done) => {
     const mockExtensionContext = new TestExtensionContext();
+
+    const fakeVscodeErrorMessage = sinon.fake();
+    sinon.replace(vscode.window, 'showErrorMessage', fakeVscodeErrorMessage);
 
     const mockMDBExtension = new MDBExtensionController(mockExtensionContext);
 
-    mockMDBExtension.openMongoDBShell();
+    mockMDBExtension
+      .openMongoDBShell()
+      .then((didOpenShell) => {
+        assert(didOpenShell === false);
+        assert(
+          fakeVscodeErrorMessage.firstArg ===
+            'You need to be connected before launching the MongoDB Shell.'
+        );
+      })
+      .then(done, done);
+  });
+
+  test('openMongoDBShell should open a terminal with the active connection driver url', (done) => {
+    const mockExtensionContext = new TestExtensionContext();
+
+    const mockMDBExtension = new MDBExtensionController(mockExtensionContext);
+    const testConnectionController = mockMDBExtension._connectionController;
+
+    const fakeVscodeInfoMessage = sinon.fake();
+    sinon.replace(
+      vscode.window,
+      'showInformationMessage',
+      fakeVscodeInfoMessage
+    );
+
+    testConnectionController
+      .addNewConnectionAndConnect(TEST_DATABASE_URI)
+      .then((succesfullyConnected) => {
+        assert(
+          succesfullyConnected === true,
+          'Expected a successful connection response.'
+        );
+
+        const spyActiveConnectionDriverUrl = sinon.spy(
+          testConnectionController,
+          'getActiveConnectionDriverUrl'
+        );
+        const createTerminalSpy = sinon.spy(vscode.window, 'createTerminal');
+
+        disposables.push(
+          vscode.window.onDidOpenTerminal(() => {
+            testConnectionController.disconnect();
+
+            try {
+              assert(spyActiveConnectionDriverUrl.called);
+              assert(createTerminalSpy.called);
+              const expectedUri =
+                'mongodb://localhost:27018/?readPreference=primary&ssl=false';
+              assert(
+                createTerminalSpy.getCall(0).args[0].env
+                  .MDB_CONNECTION_STRING === expectedUri,
+                `Expected open terminal to set env var 'MDB_CONNECTION_STRING' to ${expectedUri} found ${
+                  createTerminalSpy.getCall(0).args[0].env.MDB_CONNECTION_STRING
+                }`
+              );
+            } catch (e) {
+              done(e);
+              return;
+            }
+
+            done();
+          })
+        );
+
+        mockMDBExtension.openMongoDBShell();
+      });
   });
 });


### PR DESCRIPTION
The previous implementation was always returning null.

## Description

I realized the shell was always connected to localhost and I noticed the code was looking for the connecting connection instead of the active one.

Additionally, added error message when attempting to launch a shell without an active connection.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
