### PR TITLE
VSCODE-79: move playground to the language server

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -38,7 +38,7 @@
       "request": "attach",
       "name": "Attach to Language Server",
       "protocol": "inspector",
-      "port": 6005,
+      "port": 6009,
       "sourceMaps": true,
       "outFiles": [
         "${workspaceFolder}/out/**/*.js"

--- a/package.json
+++ b/package.json
@@ -475,7 +475,7 @@
     "redux": "^4.0.5",
     "ts-log": "^2.1.4",
     "uuid": "^7.0.0",
-    "vscode-languageclient": "^6.1.1",
+    "vscode-languageclient": "^6.1.3",
     "vscode-languageserver": "^6.1.1"
   },
   "devDependencies": {

--- a/scripts/generate-keyfile.ts
+++ b/scripts/generate-keyfile.ts
@@ -25,5 +25,5 @@ config({ path: resolve(__dirname, '../.env') });
   }
 })().catch((error) => {
   ui.fail('Failed to generate constants keyfile');
-  console.log(error);
+  console.log(error.message);
 })

--- a/src/language/languageServerController.ts
+++ b/src/language/languageServerController.ts
@@ -62,7 +62,7 @@ export default class LanguageServerController {
       }
     };
 
-    log.info('Activating MongoDB language server', {
+    log.info('Creating MongoDB Language Server', {
       serverOptions,
       clientOptions
     });
@@ -74,10 +74,11 @@ export default class LanguageServerController {
       serverOptions,
       clientOptions
     );
+  }
 
+  activate() {
     // Start the client. This will also launch the server
     this.client.start();
-
     this.client.onReady().then(() => {
       /**
        * TODO: Notification is for setup docs only.

--- a/src/language/languageServerController.ts
+++ b/src/language/languageServerController.ts
@@ -74,9 +74,7 @@ export default class LanguageServerController {
       serverOptions,
       clientOptions
     );
-  }
 
-  activate() {
     // Start the client. This will also launch the server
     this.client.start();
     this.client.onReady().then(() => {

--- a/src/language/languageServerController.ts
+++ b/src/language/languageServerController.ts
@@ -28,11 +28,7 @@ export default class LanguageServerController {
     this._connectionController = connectionController;
 
     // The server is implemented in node
-    const serverModule = context.asAbsolutePath(
-      context.extensionPath === 'TEST_FOLDER'
-        ? path.join('..', '..', 'out', 'language', 'server.js')
-        : path.join('out', 'language', 'server.js')
-    );
+    const serverModule = path.join(context.extensionPath, 'out', 'language', 'server.js');
 
     // The debug options for the server
     // --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging

--- a/src/language/languageServerController.ts
+++ b/src/language/languageServerController.ts
@@ -74,7 +74,9 @@ export default class LanguageServerController {
       serverOptions,
       clientOptions
     );
+  }
 
+  activate() {
     // Start the client. This will also launch the server
     this.client.start();
     this.client.onReady().then(() => {

--- a/src/language/languageServerController.ts
+++ b/src/language/languageServerController.ts
@@ -101,6 +101,12 @@ export default class LanguageServerController {
       return undefined;
     }
 
-    return this.client.sendRequest('executeAll', { codeToEvaluate, connectionString, connectionOptions });
+    return this.client.onReady().then(() => {
+      if (!this.client) {
+        return undefined;
+      }
+
+      return this.client.sendRequest('executeAll', { codeToEvaluate, connectionString, connectionOptions });
+    });
   }
 }

--- a/src/language/languageServerController.ts
+++ b/src/language/languageServerController.ts
@@ -19,26 +19,25 @@ const log = createLogger('LanguageServerController');
  */
 export default class LanguageServerController {
   _connectionController?: ConnectionController;
-  client?: LanguageClient;
+  client: LanguageClient;
 
   constructor(
     context: vscode.ExtensionContext,
     connectionController?: ConnectionController
   ) {
     this._connectionController = connectionController;
-    this.activate(context);
-  }
 
-  async activate(context: ExtensionContext): Promise<LanguageClient> {
     // The server is implemented in node
     const serverModule = context.asAbsolutePath(
       context.extensionPath === 'TEST_FOLDER'
         ? path.join('..', '..', 'out', 'language', 'server.js')
         : path.join('out', 'language', 'server.js')
     );
+
     // The debug options for the server
     // --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging
     const debugOptions = { execArgv: ['--nolazy', '--inspect=6009'] };
+
     // If the extension is launched in debug mode then the debug server options are used
     // Otherwise the run options are used
     const serverOptions: ServerOptions = {
@@ -49,6 +48,7 @@ export default class LanguageServerController {
         options: debugOptions
       }
     };
+
     // Options to control the language client
     const clientOptions: LanguageClientOptions = {
       // Register the server for plain text documents
@@ -78,35 +78,22 @@ export default class LanguageServerController {
     // Start the client. This will also launch the server
     this.client.start();
 
-    await this.client.onReady();
-
-    /**
-     * TODO: Notification is for setup docs only.
-     */
-    this.client.onNotification('mongodbNotification', (messsage) => {
-      vscode.window.showInformationMessage(messsage);
+    this.client.onReady().then(() => {
+      /**
+       * TODO: Notification is for setup docs only.
+       */
+      this.client.onNotification('mongodbNotification', (messsage) => {
+        vscode.window.showInformationMessage(messsage);
+      });
     });
-
-    return new Promise((resolve) => resolve(this.client));
   }
 
   deactivate(): Thenable<void> | undefined {
-    if (!this.client) {
-      return undefined;
-    }
     return this.client.stop();
   }
 
   executeAll(codeToEvaluate: string, connectionString: string, connectionOptions: any = {}): Thenable<any> | undefined {
-    if (!this.client) {
-      return undefined;
-    }
-
     return this.client.onReady().then(() => {
-      if (!this.client) {
-        return undefined;
-      }
-
       return this.client.sendRequest('executeAll', { codeToEvaluate, connectionString, connectionOptions });
     });
   }

--- a/src/language/languageServerController.ts
+++ b/src/language/languageServerController.ts
@@ -20,9 +20,10 @@ const log = createLogger('LanguageServerController');
 export default class LanguageServerController {
   _connectionController?: ConnectionController;
   client?: LanguageClient;
+
   constructor(
     context: vscode.ExtensionContext,
-    connectionController: ConnectionController
+    connectionController?: ConnectionController
   ) {
     this._connectionController = connectionController;
     this.activate(context);
@@ -31,7 +32,7 @@ export default class LanguageServerController {
   async activate(context: ExtensionContext): Promise<LanguageClient> {
     // The server is implemented in node
     const serverModule = context.asAbsolutePath(
-      path.join('out', 'language', 'server.js')
+      path.join(process.cwd(), 'out', 'language', 'server.js')
     );
     // The debug options for the server
     // --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging
@@ -93,5 +94,13 @@ export default class LanguageServerController {
       return undefined;
     }
     return this.client.stop();
+  }
+
+  executeAll(codeToEvaluate: string, connectionString: string, connectionOptions: any = {}): Thenable<any> | undefined {
+    if (!this.client) {
+      return undefined;
+    }
+
+    return this.client.sendRequest('executeAll', { codeToEvaluate, connectionString, connectionOptions });
   }
 }

--- a/src/language/languageServerController.ts
+++ b/src/language/languageServerController.ts
@@ -37,7 +37,6 @@ export default class LanguageServerController {
     // The debug options for the server
     // --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging
     const debugOptions = { execArgv: ['--nolazy', '--inspect=6009'] };
-
     // If the extension is launched in debug mode then the debug server options are used
     // Otherwise the run options are used
     const serverOptions: ServerOptions = {
@@ -48,7 +47,6 @@ export default class LanguageServerController {
         options: debugOptions
       }
     };
-
     // Options to control the language client
     const clientOptions: LanguageClientOptions = {
       // Register the server for plain text documents
@@ -79,6 +77,7 @@ export default class LanguageServerController {
     this.client.start();
 
     await this.client.onReady();
+
     /**
      * TODO: Notification is for setup docs only.
      */

--- a/src/language/languageServerController.ts
+++ b/src/language/languageServerController.ts
@@ -32,7 +32,9 @@ export default class LanguageServerController {
   async activate(context: ExtensionContext): Promise<LanguageClient> {
     // The server is implemented in node
     const serverModule = context.asAbsolutePath(
-      path.join(process.cwd(), 'out', 'language', 'server.js')
+      context.extensionPath === 'TEST_FOLDER'
+        ? path.join('..', '..', 'out', 'language', 'server.js')
+        : path.join('out', 'language', 'server.js')
     );
     // The debug options for the server
     // --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging

--- a/src/language/server.ts
+++ b/src/language/server.ts
@@ -278,16 +278,12 @@ connection.onCompletionResolve(
  * Execute the entire playground script.
  */
 connection.onRequest('executeAll', async (params) => {
-  try {
-    const connectionOptions = params.connectionOptions || {};
-    const runtime = new ElectronRuntime(
-      await CliServiceProvider.connect(params.connectionString, connectionOptions)
-    );
+  const connectionOptions = params.connectionOptions || {};
+  const runtime = new ElectronRuntime(
+    await CliServiceProvider.connect(params.connectionString, connectionOptions)
+  );
 
-    return await runtime.evaluate(params.codeToEvaluate);
-  } catch (error) {
-    throw new Error('Unable to connect to MongoDB instance. Make sure it is started correctly.');
-  }
+  return await runtime.evaluate(params.codeToEvaluate);
 });
 
 /**

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -74,6 +74,7 @@ export default class MDBExtensionController implements vscode.Disposable {
     this._connectionController.loadSavedConnections();
     this._explorerController.createTreeView();
     this._telemetryController.activate();
+    this._languageServerController.activate();
 
     log.info('Registering commands...');
 

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -8,6 +8,7 @@ import * as vscode from 'vscode';
 import ConnectionController from './connectionController';
 import { EditorsController, PlaygroundController } from './editors';
 import { ExplorerController, CollectionTreeItem } from './explorer';
+import { LanguageServerController } from './language';
 import { TelemetryController } from './telemetry';
 import { StatusView } from './views';
 import { createLogger } from './logging';
@@ -30,6 +31,7 @@ export default class MDBExtensionController implements vscode.Disposable {
   _statusView: StatusView;
   _storageController: StorageController;
   _telemetryController: TelemetryController;
+  _languageServerController: LanguageServerController;
 
   constructor(
     context: vscode.ExtensionContext,
@@ -52,6 +54,7 @@ export default class MDBExtensionController implements vscode.Disposable {
       );
     }
 
+    this._languageServerController = new LanguageServerController(context);
     this._editorsController = new EditorsController(
       context,
       this._connectionController
@@ -62,6 +65,7 @@ export default class MDBExtensionController implements vscode.Disposable {
     this._playgroundController = new PlaygroundController(
       context,
       this._connectionController,
+      this._languageServerController,
       this._telemetryController
     );
   }

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -411,5 +411,6 @@ export default class MDBExtensionController implements vscode.Disposable {
     this._explorerController.deactivate();
     this._playgroundController.deactivate();
     this._telemetryController.deactivate();
+    this._languageServerController.deactivate();
   }
 }

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -74,7 +74,6 @@ export default class MDBExtensionController implements vscode.Disposable {
     this._connectionController.loadSavedConnections();
     this._explorerController.createTreeView();
     this._telemetryController.activate();
-    this._languageServerController.activate();
 
     log.info('Registering commands...');
 

--- a/src/test/suite/editors/playgroundController.test.ts
+++ b/src/test/suite/editors/playgroundController.test.ts
@@ -19,9 +19,6 @@ const expect = chai.expect;
 
 chai.use(require('chai-as-promised'));
 
-let doc: vscode.TextDocument;
-let editor: vscode.TextEditor;
-
 const getDocUri = (docName: string) => {
   const docPath = path.resolve(__dirname, '../../../../src/test/fixture', docName);
 
@@ -33,8 +30,9 @@ const getDocUri = (docName: string) => {
  */
 export async function openPlayground(docUri: vscode.Uri) {
   try {
-    doc = await vscode.workspace.openTextDocument(docUri);
-    editor = await vscode.window.showTextDocument(doc);
+    const doc = await vscode.workspace.openTextDocument(docUri);
+
+    await vscode.window.showTextDocument(doc);
   } catch (e) {
     console.error(e);
   }
@@ -57,6 +55,8 @@ suite('Playground Controller Test Suite', () => {
       const testLanguageServerController = new LanguageServerController(mockExtensionContext, testConnectionController);
       const testPlaygroundController = new PlaygroundController(mockExtensionContext, testConnectionController, testLanguageServerController);
 
+      testLanguageServerController.activate();
+
       expect(testPlaygroundController.evaluate('1 + 1')).to.be.rejectedWith(Error, 'Please connect to a database before running a playground.');
     });
   });
@@ -68,6 +68,7 @@ suite('Playground Controller Test Suite', () => {
     );
     const testLanguageServerController = new LanguageServerController(mockExtensionContext, testConnectionController);
 
+    testLanguageServerController.activate();
     testConnectionController.getActiveConnectionDriverUrl = () => 'mongodb://localhost:27018';
 
     const testPlaygroundController = new PlaygroundController(mockExtensionContext, testConnectionController, testLanguageServerController);
@@ -133,6 +134,8 @@ suite('Playground Controller Test Suite', () => {
       mockStorageController
     );
     const testLanguageServerController = new LanguageServerController(mockExtensionContext, testConnectionController);
+
+    testLanguageServerController.activate();
     testConnectionController.getActiveConnectionName = () => 'fakeName';
     testConnectionController.getActiveConnectionDriverUrl = () => 'mongodb://localhost:27018';
 

--- a/src/test/suite/editors/playgroundController.test.ts
+++ b/src/test/suite/editors/playgroundController.test.ts
@@ -55,8 +55,6 @@ suite('Playground Controller Test Suite', () => {
       const testLanguageServerController = new LanguageServerController(mockExtensionContext, testConnectionController);
       const testPlaygroundController = new PlaygroundController(mockExtensionContext, testConnectionController, testLanguageServerController);
 
-      testLanguageServerController.activate();
-
       expect(testPlaygroundController.evaluate('1 + 1')).to.be.rejectedWith(Error, 'Please connect to a database before running a playground.');
     });
   });
@@ -68,7 +66,6 @@ suite('Playground Controller Test Suite', () => {
     );
     const testLanguageServerController = new LanguageServerController(mockExtensionContext, testConnectionController);
 
-    testLanguageServerController.activate();
     testConnectionController.getActiveConnectionDriverUrl = () => 'mongodb://localhost:27018';
 
     const testPlaygroundController = new PlaygroundController(mockExtensionContext, testConnectionController, testLanguageServerController);
@@ -135,7 +132,6 @@ suite('Playground Controller Test Suite', () => {
     );
     const testLanguageServerController = new LanguageServerController(mockExtensionContext, testConnectionController);
 
-    testLanguageServerController.activate();
     testConnectionController.getActiveConnectionName = () => 'fakeName';
     testConnectionController.getActiveConnectionDriverUrl = () => 'mongodb://localhost:27018';
 

--- a/src/test/suite/editors/playgroundController.test.ts
+++ b/src/test/suite/editors/playgroundController.test.ts
@@ -61,68 +61,6 @@ suite('Playground Controller Test Suite', () => {
     });
   });
 
-  suite('test confirmation message', () => {
-    const testConnectionController = new ConnectionController(
-      new StatusView(mockExtensionContext),
-      mockStorageController
-    );
-    const testLanguageServerController = new LanguageServerController(mockExtensionContext, testConnectionController);
-
-    testConnectionController.getActiveConnectionDriverUrl = () => 'mongodb://localhost:27018';
-
-    const testPlaygroundController = new PlaygroundController(mockExtensionContext, testConnectionController, testLanguageServerController);
-    let fakeShowInformationMessage;
-
-    beforeEach(() => {
-      fakeShowInformationMessage = sandbox.stub(vscode.window, 'showInformationMessage').resolves('Yes');
-    });
-
-    afterEach(async () => {
-      sandbox.restore();
-      await cleanupTestDB()
-    });
-
-    test('show a confirmation message before running commands in a playground if mdb.confirmRunAll is true', (done) => {
-      const mockDocument = {
-        _id: new ObjectId('5e32b4d67bf47f4525f2f833'),
-        example: 'field'
-      };
-
-      seedDataAndCreateDataService('forest', [mockDocument]).then(
-        async (dataService) => {
-          testConnectionController.setActiveConnection(dataService);
-
-          await testPlaygroundController.runAllPlaygroundBlocks();
-
-          const expectedMessage =
-            'Are you sure you want to run this playground against fakeName? This confirmation can be disabled in the extension settings.';
-
-          expect(fakeShowInformationMessage.calledOnce).to.be.true;
-        }
-      ).then(done, done);
-    });
-
-    test('show a confirmation message before running commands in a playground if mdb.confirmRunAll is false', (done) => {
-      const mockDocument = {
-        _id: new ObjectId('5e32b4d67bf47f4525f2f844'),
-        example: 'field'
-      };
-
-      seedDataAndCreateDataService('forest', [mockDocument]).then(
-        async (dataService) => {
-          testConnectionController.setActiveConnection(dataService);
-
-          await vscode.workspace
-            .getConfiguration('mdb')
-            .update('confirmRunAll', false);
-          await testPlaygroundController.runAllPlaygroundBlocks();
-
-          expect(fakeShowInformationMessage.calledOnce).to.be.false;
-        }
-      ).then(done, done);
-    });
-  });
-
   suite('when user is connected', () => {
     afterEach(async () => {
       await cleanupTestDB()

--- a/src/test/suite/editors/playgroundController.test.ts
+++ b/src/test/suite/editors/playgroundController.test.ts
@@ -46,7 +46,7 @@ suite('Playground Controller Test Suite', () => {
 
   const sandbox = sinon.createSandbox();
 
-  mockExtensionContext.extensionPath = 'TEST_FOLDER';
+  mockExtensionContext.extensionPath = '../../';
 
   suite('when user is not connected', () => {
     test('evaluate should throw the missing active connection error', async () => {

--- a/src/test/suite/editors/playgroundController.test.ts
+++ b/src/test/suite/editors/playgroundController.test.ts
@@ -46,6 +46,8 @@ suite('Playground Controller Test Suite', () => {
 
   const sandbox = sinon.createSandbox();
 
+  mockExtensionContext.extensionPath = 'TEST_FOLDER';
+
   suite('when user is not connected', () => {
     test('evaluate should throw the missing active connection error', async () => {
       const testConnectionController = new ConnectionController(

--- a/src/test/suite/editors/playgroundController.test.ts
+++ b/src/test/suite/editors/playgroundController.test.ts
@@ -28,7 +28,7 @@ const getDocUri = (docName: string) => {
 /**
  * Opens the MongoDB playground
  */
-export async function openPlayground(docUri: vscode.Uri) {
+async function openPlayground(docUri: vscode.Uri) {
   try {
     const doc = await vscode.workspace.openTextDocument(docUri);
 

--- a/src/test/suite/editors/playgroundController.test.ts
+++ b/src/test/suite/editors/playgroundController.test.ts
@@ -247,7 +247,7 @@ suite('Playground Controller Test Suite', () => {
 
     test('show a confirmation message before running commands in a playground if mdb.confirmRunAll is true', (done) => {
       const mockDocument = {
-        _id: new ObjectId('5e32b4d67bf47f4525f2f8ab'),
+        _id: new ObjectId('5e32b4d67bf47f4525f2f811'),
         example: 'field'
       };
       const fakeShowInformationMessage = sandbox.stub(vscode.window, 'showInformationMessage');
@@ -274,7 +274,7 @@ suite('Playground Controller Test Suite', () => {
 
     test('show a confirmation message before running commands in a playground if mdb.confirmRunAll is false', (done) => {
       const mockDocument = {
-        _id: new ObjectId('5e32b4d67bf47f4525f2f8ab'),
+        _id: new ObjectId('5e32b4d67bf47f4525f2f822'),
         example: 'field'
       };
       const fakeShowInformationMessage = sandbox.stub(vscode.window, 'showInformationMessage');

--- a/src/test/suite/editors/playgroundController.test.ts
+++ b/src/test/suite/editors/playgroundController.test.ts
@@ -55,6 +55,8 @@ suite('Playground Controller Test Suite', () => {
       const testLanguageServerController = new LanguageServerController(mockExtensionContext, testConnectionController);
       const testPlaygroundController = new PlaygroundController(mockExtensionContext, testConnectionController, testLanguageServerController);
 
+      testLanguageServerController.activate();
+
       expect(testPlaygroundController.evaluate('1 + 1')).to.be.rejectedWith(Error, 'Please connect to a database before running a playground.');
     });
   });
@@ -66,6 +68,7 @@ suite('Playground Controller Test Suite', () => {
     );
     const testLanguageServerController = new LanguageServerController(mockExtensionContext, testConnectionController);
 
+    testLanguageServerController.activate();
     testConnectionController.getActiveConnectionDriverUrl = () => 'mongodb://localhost:27018';
 
     const testPlaygroundController = new PlaygroundController(mockExtensionContext, testConnectionController, testLanguageServerController);
@@ -132,6 +135,7 @@ suite('Playground Controller Test Suite', () => {
     );
     const testLanguageServerController = new LanguageServerController(mockExtensionContext, testConnectionController);
 
+    testLanguageServerController.activate();
     testConnectionController.getActiveConnectionName = () => 'fakeName';
     testConnectionController.getActiveConnectionDriverUrl = () => 'mongodb://localhost:27018';
 

--- a/src/test/suite/stubs.ts
+++ b/src/test/suite/stubs.ts
@@ -36,7 +36,7 @@ class TestExtensionContext implements vscode.ExtensionContext {
         return new Promise<void>(() => { this._globalState[key] = value; });
       }
     };
-    this.extensionPath = 'TEST_FOLDER';
+    this.extensionPath = '';
     this.storagePath = '';
   }
 }

--- a/src/test/suite/stubs.ts
+++ b/src/test/suite/stubs.ts
@@ -36,7 +36,7 @@ class TestExtensionContext implements vscode.ExtensionContext {
         return new Promise<void>(() => { this._globalState[key] = value; });
       }
     };
-    this.extensionPath = '';
+    this.extensionPath = 'TEST_FOLDER';
     this.storagePath = '';
   }
 }

--- a/src/test/suite/views/connectFormView.test.ts
+++ b/src/test/suite/views/connectFormView.test.ts
@@ -50,29 +50,29 @@ suite('Connect Form View Test Suite', () => {
     assert(stubOnDidRecieveMessage.called);
   });
 
-  test('web view content is rendered with the js form', async () => {
-    async function readFile(filePath): Promise<string> {
-      return new Promise((resolve, reject) => {
-        fs.readFile(filePath, 'utf8', function(err, data) {
-          if (err) {
-            reject(err);
-          }
-          resolve(data);
-        });
-      });
-    }
+  // test('web view content is rendered with the js form', async () => {
+  //   async function readFile(filePath): Promise<string> {
+  //     return new Promise((resolve, reject) => {
+  //       fs.readFile(filePath, 'utf8', function(err, data) {
+  //         if (err) {
+  //           reject(err);
+  //         }
+  //         resolve(data);
+  //       });
+  //     });
+  //   }
 
-    const extensionPath = mdbTestExtension.testExtensionContext.extensionPath;
-    const appUri = getReactAppUri(extensionPath);
-    const htmlString = getConnectWebviewContent(appUri);
+  //   const extensionPath = mdbTestExtension.testExtensionContext.extensionPath;
+  //   const appUri = getReactAppUri(extensionPath);
+  //   const htmlString = getConnectWebviewContent(appUri);
 
-    assert(
-      htmlString.includes('vscode-resource:/out/connect-form/connectForm.js')
-    );
-    const connectFormFileName = (): string => 'out/connect-form/connectForm.js';
-    const jsFileString = await readFile(
-      path.resolve(__dirname, '..', '..', '..', '..', connectFormFileName())
-    );
-    assert(`${jsFileString}`.includes('ConnectionForm'));
-  });
+  //   assert(
+  //     htmlString.includes('vscode-resource:/out/connect-form/connectForm.js')
+  //   );
+  //   const connectFormFileName = (): string => 'out/connect-form/connectForm.js';
+  //   const jsFileString = await readFile(
+  //     path.resolve(__dirname, '..', '..', '..', '..', connectFormFileName())
+  //   );
+  //   assert(`${jsFileString}`.includes('ConnectionForm'));
+  // });
 });

--- a/src/test/suite/views/connectFormView.test.ts
+++ b/src/test/suite/views/connectFormView.test.ts
@@ -50,29 +50,29 @@ suite('Connect Form View Test Suite', () => {
     assert(stubOnDidRecieveMessage.called);
   });
 
-  // test('web view content is rendered with the js form', async () => {
-  //   async function readFile(filePath): Promise<string> {
-  //     return new Promise((resolve, reject) => {
-  //       fs.readFile(filePath, 'utf8', function(err, data) {
-  //         if (err) {
-  //           reject(err);
-  //         }
-  //         resolve(data);
-  //       });
-  //     });
-  //   }
+  test('web view content is rendered with the js form', async () => {
+    async function readFile(filePath): Promise<string> {
+      return new Promise((resolve, reject) => {
+        fs.readFile(filePath, 'utf8', function (err, data) {
+          if (err) {
+            reject(err);
+          }
+          resolve(data);
+        });
+      });
+    }
 
-  //   const extensionPath = mdbTestExtension.testExtensionContext.extensionPath;
-  //   const appUri = getReactAppUri(extensionPath);
-  //   const htmlString = getConnectWebviewContent(appUri);
+    const extensionPath = mdbTestExtension.testExtensionContext.extensionPath;
+    const appUri = getReactAppUri(extensionPath);
+    const htmlString = getConnectWebviewContent(appUri);
 
-  //   assert(
-  //     htmlString.includes('vscode-resource:/out/connect-form/connectForm.js')
-  //   );
-  //   const connectFormFileName = (): string => 'out/connect-form/connectForm.js';
-  //   const jsFileString = await readFile(
-  //     path.resolve(__dirname, '..', '..', '..', '..', connectFormFileName())
-  //   );
-  //   assert(`${jsFileString}`.includes('ConnectionForm'));
-  // });
+    assert(
+      htmlString.includes('vscode-resource:/out/connect-form/connectForm.js')
+    );
+    const connectFormFileName = (): string => 'out/connect-form/connectForm.js';
+    const jsFileString = await readFile(
+      path.resolve(__dirname, '..', '..', '..', '..', connectFormFileName())
+    );
+    assert(`${jsFileString}`.includes('ConnectionForm'));
+  });
 });


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
- In this PR I added instantiation of Language Server to the mdbExtensionController and moved playground execution to this Language Server.

- The playground makes a call to the Language Server Client and sends two parameters: code that needs to be evaluated and driverUrl.

- The Language Server Client sends a request with these values to the Language Server Server.

- Looks like we can't use DataService in the Language Server Server. Probably because it extends from EventEmitter. But we can use CliServiceProvider from '@mongosh/service-provider-server' instead. It accepts 2 params driverUrl and driverOptions. It provides similar methods as DataService does: https://github.com/mongodb-js/mongosh/blob/master/packages/service-provider-server/src/cli-service-provider.ts. Please let me know if you have any objections? The investigation ticket was created: https://jira.mongodb.org/browse/VSCODE-81

- I have noticed that the "Extension + Server Inspector" and "Attach to Language Server" runners from Launch file do not work. The first thing it should be 6009 instead of 6005, but even if I change it, Vscode complains anyway that a connection is refused.

- Moved code from the `activate` method of the Language Server to the `constructor` in order to set `this.client` value in the constructor and get rid of later checks on undefined in each method with sendRequest.

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
