### PR TITLE
Fix: missing appname when connecting with connectionId

### DIFF
--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -182,9 +182,6 @@ export default class ConnectionController {
             return reject(new Error(`Unable to connect: ${error}`));
           }
 
-          // Override the default connection `appname`.
-          newConnectionModel.appname = `${name} ${version}`;
-
           this.connect(newConnection.id, newConnectionModel).then(
             (connectSuccess) => {
               if (!connectSuccess) {
@@ -233,6 +230,9 @@ export default class ConnectionController {
     this._statusView.showMessage('Connecting to MongoDB...');
 
     return new Promise<boolean>((resolve, reject) => {
+      // Override the default connection `appname`.
+      connectionModel.appname = `${name} ${version}`;
+
       const newDataService: DataServiceType = new DataService(connectionModel);
       newDataService.connect((err: Error | undefined) => {
         this._statusView.hideMessage();
@@ -272,9 +272,6 @@ export default class ConnectionController {
               );
               return resolve(false);
             }
-
-            // Override the default connection `appname`.
-            connectionModel.appname = `${name} ${version}`;
 
             return this.connect(connectionId, connectionModel).then(
               resolve,

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -273,6 +273,9 @@ export default class ConnectionController {
               return resolve(false);
             }
 
+            // Override the default connection `appname`.
+            connectionModel.appname = `${name} ${version}`;
+
             return this.connect(connectionId, connectionModel).then(
               resolve,
               (err: Error) => {
@@ -430,13 +433,13 @@ export default class ConnectionController {
     const connectionNameToRemove:
       | string
       | undefined = await vscode.window.showQuickPick(
-      connectionIds.map(
-        (id, index) => `${index + 1}: ${this._savedConnections[id].name}`
-      ),
-      {
-        placeHolder: 'Choose a connection to remove...'
-      }
-    );
+        connectionIds.map(
+          (id, index) => `${index + 1}: ${this._savedConnections[id].name}`
+        ),
+        {
+          placeHolder: 'Choose a connection to remove...'
+        }
+      );
 
     if (!connectionNameToRemove) {
       return Promise.resolve(false);

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -67,6 +67,7 @@ suite('Connection Controller Test Suite', () => {
         );
         const dataService = testConnectionController.getActiveDataService();
         assert(dataService !== null);
+        assert(testConnectionController._activeConnectionModel?.appname.startsWith('mongodb-vscode'));
         assert(testConnectionController.isCurrentlyConnected());
       })
       .then(done, done);
@@ -477,7 +478,7 @@ suite('Connection Controller Test Suite', () => {
     assert(
       Object.keys(connections).length === 4,
       `Expected 4 connection configurations found ${
-        Object.keys(connections).length
+      Object.keys(connections).length
       }`
     );
     assert(
@@ -486,7 +487,7 @@ suite('Connection Controller Test Suite', () => {
     );
     assert(
       Object.keys(connections).includes('testWorkspaceConnectionModel2') ===
-        true,
+      true,
       "Expected connection configurations to include 'testWorkspaceConnectionModel2'"
     );
     assert(
@@ -495,7 +496,7 @@ suite('Connection Controller Test Suite', () => {
     );
     assert(
       connections.testGlobalConnectionModel2.driverUrl ===
-        'testGlobalConnectionModel2DriverUrl',
+      'testGlobalConnectionModel2DriverUrl',
       "Expected loaded connection to include driver url 'testGlobalConnectionModel2DriverUrl'"
     );
   });
@@ -525,7 +526,7 @@ suite('Connection Controller Test Suite', () => {
     assert(
       Object.keys(globalStoreConnections).length === 1,
       `Expected global store connections to have 1 connection found ${
-        Object.keys(globalStoreConnections).length
+      Object.keys(globalStoreConnections).length
       }`
     );
     const id = Object.keys(globalStoreConnections)[0];
@@ -573,7 +574,7 @@ suite('Connection Controller Test Suite', () => {
     assert(
       Object.keys(workspaceStoreConnections).length === 1,
       `Expected workspace store connections to have 1 connection found ${
-        Object.keys(workspaceStoreConnections).length
+      Object.keys(workspaceStoreConnections).length
       }`
     );
     const id = Object.keys(workspaceStoreConnections)[0];
@@ -619,7 +620,7 @@ suite('Connection Controller Test Suite', () => {
             assert(
               Object.keys(workspaceStoreConnections).length === 1,
               `Expected workspace store connections to have 1 connection found ${
-                Object.keys(workspaceStoreConnections).length
+              Object.keys(workspaceStoreConnections).length
               }`
             );
 
@@ -635,7 +636,7 @@ suite('Connection Controller Test Suite', () => {
               assert(
                 testConnectionController.getSavedConnections().length === 1,
                 `Expected 1 connection config, found ${
-                  testConnectionController.getSavedConnections().length
+                testConnectionController.getSavedConnections().length
                 }.`
               );
               const id = testConnectionController.getSavedConnections()[0].id;
@@ -655,6 +656,7 @@ suite('Connection Controller Test Suite', () => {
                     name === 'localhost:27018',
                     `Expected the active connection name to be 'localhost:27018', found ${name}.`
                   );
+                  assert(testConnectionController._activeConnectionModel?.appname.startsWith('mongodb-vscode'));
                 })
                 .then(done, done);
             });
@@ -778,7 +780,7 @@ suite('Connection Controller Test Suite', () => {
               assert(
                 Object.keys(workspaceStoreConnections).length === 1,
                 `Expected workspace store connections to have 1 connection found ${
-                  Object.keys(workspaceStoreConnections).length
+                Object.keys(workspaceStoreConnections).length
                 }`
               );
 
@@ -793,7 +795,7 @@ suite('Connection Controller Test Suite', () => {
               assert(
                 Object.keys(postWorkspaceStoreConnections).length === 0,
                 `Expected workspace store connections to have 0 connections found ${
-                  Object.keys(postWorkspaceStoreConnections).length
+                Object.keys(postWorkspaceStoreConnections).length
                 }`
               );
             })
@@ -827,7 +829,7 @@ suite('Connection Controller Test Suite', () => {
     assert(
       Object.keys(globalStoreConnections).length === 1,
       `Expected workspace store connections to have 1 connection found ${
-        Object.keys(globalStoreConnections).length
+      Object.keys(globalStoreConnections).length
       }`
     );
 
@@ -841,7 +843,7 @@ suite('Connection Controller Test Suite', () => {
     assert(
       Object.keys(postGlobalStoreConnections).length === 0,
       `Expected global store connections to have 0 connections found ${
-        Object.keys(postGlobalStoreConnections).length
+      Object.keys(postGlobalStoreConnections).length
       }`
     );
   });
@@ -877,7 +879,7 @@ suite('Connection Controller Test Suite', () => {
               assert(
                 Object.keys(workspaceStoreConnections).length === 1,
                 `Expected workspace store connections to have 1 connection found ${
-                  Object.keys(workspaceStoreConnections).length
+                Object.keys(workspaceStoreConnections).length
                 }`
               );
               const connectionId =
@@ -912,7 +914,7 @@ suite('Connection Controller Test Suite', () => {
                         testConnectionController.getSavedConnections()
                           .length === 1,
                         `Expected 1 connection config, found ${
-                          testConnectionController.getSavedConnections().length
+                        testConnectionController.getSavedConnections().length
                         }.`
                       );
                       const id = testConnectionController.getSavedConnections()[0]


### PR DESCRIPTION
`appname` was being set only when connecting to a new connection but not when connecting to one that was already added. This fixes it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
