### PR TITLE
VSCODE-85: Add default button to tree view

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "viewsWelcome": [
       {
         "view": "mongoDB",
-        "contents": "No connections found.\n[Add Connection](command:mdb.connectWithURI)"
+        "contents": "No connections found.\n[Add Connection](command:mdb.connect)"
       }
     ],
     "languages": [
@@ -255,6 +255,10 @@
     ],
     "menus": {
       "view/title": [
+        {
+          "command": "mdb.createPlayground",
+          "when": "view == mongoDB"
+        },
         {
           "command": "mdb.addConnection",
           "when": "view == mongoDB"

--- a/package.json
+++ b/package.json
@@ -91,6 +91,12 @@
         }
       ]
     },
+    "viewsWelcome": [
+      {
+        "view": "mongoDB",
+        "contents": "No connections found.\n[Add Connection](command:mdb.connectWithURI)"
+      }
+    ],
     "languages": [
       {
         "id": "mongodb",

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -18,7 +18,7 @@ const MAX_CONNECTION_NAME_LENGTH = 512;
 
 export enum DataServiceEventTypes {
   CONNECTIONS_DID_CHANGE = 'CONNECTIONS_DID_CHANGE',
-  ACTIVE_CONNECTION_CHANGED = 'ACTIVE_CONNECTION_CHANGED'
+  ACTIVE_CONNECTION_CHANGED = 'ACTIVE_CONNECTION_CHANGED',
 }
 
 export default class ConnectionController {
@@ -64,7 +64,7 @@ export default class ConnectionController {
         driverUrl: savedConnection.driverUrl,
         name: savedConnection.name,
         connectionModel: savedConnection.connectionModel,
-        storageLocation: savedConnection.storageLocation
+        storageLocation: savedConnection.storageLocation,
       };
     } catch (error) {
       // Here we're leniant when loading connections in case their
@@ -123,7 +123,7 @@ export default class ConnectionController {
           }
 
           return null;
-        }
+        },
       });
     } catch (e) {
       return Promise.resolve(false);
@@ -189,7 +189,7 @@ export default class ConnectionController {
     connectionModel: ConnectionModelType
   ): Promise<boolean> => {
     const { driverUrl, instanceId } = connectionModel.getAttributes({
-      derived: true
+      derived: true,
     });
 
     const newConnection: SavedConnection = {
@@ -199,7 +199,7 @@ export default class ConnectionController {
       driverUrl,
       // To begin we just store it on the session, the storage controller
       // handles changing this based on user preference.
-      storageLocation: StorageScope.NONE
+      storageLocation: StorageScope.NONE,
     };
     this._savedConnections[newConnection.id] = newConnection;
 
@@ -223,7 +223,7 @@ export default class ConnectionController {
     log.info(
       'Connect called to connect to instance:',
       connectionModel.getAttributes({
-        derived: true
+        derived: true,
       }).instanceId
     );
 
@@ -453,13 +453,13 @@ export default class ConnectionController {
     const connectionNameToRemove:
       | string
       | undefined = await vscode.window.showQuickPick(
-        connectionIds.map(
-          (id, index) => `${index + 1}: ${this._savedConnections[id].name}`
-        ),
-        {
-          placeHolder: 'Choose a connection to remove...'
-        }
-      );
+      connectionIds.map(
+        (id, index) => `${index + 1}: ${this._savedConnections[id].name}`
+      ),
+      {
+        placeHolder: 'Choose a connection to remove...',
+      }
+    );
 
     if (!connectionNameToRemove) {
       return Promise.resolve(false);
@@ -489,7 +489,7 @@ export default class ConnectionController {
           }
 
           return null;
-        }
+        },
       });
     } catch (e) {
       return Promise.reject(

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -64,7 +64,7 @@ export default class ConnectionController {
         driverUrl: savedConnection.driverUrl,
         name: savedConnection.name,
         connectionModel: savedConnection.connectionModel,
-        storageLocation: savedConnection.storageLocation,
+        storageLocation: savedConnection.storageLocation
       };
     } catch (error) {
       // Here we're leniant when loading connections in case their
@@ -123,7 +123,7 @@ export default class ConnectionController {
           }
 
           return null;
-        },
+        }
       });
     } catch (e) {
       return Promise.resolve(false);
@@ -189,7 +189,7 @@ export default class ConnectionController {
     connectionModel: ConnectionModelType
   ): Promise<boolean> => {
     const { driverUrl, instanceId } = connectionModel.getAttributes({
-      derived: true,
+      derived: true
     });
 
     const newConnection: SavedConnection = {
@@ -199,7 +199,7 @@ export default class ConnectionController {
       driverUrl,
       // To begin we just store it on the session, the storage controller
       // handles changing this based on user preference.
-      storageLocation: StorageScope.NONE,
+      storageLocation: StorageScope.NONE
     };
     this._savedConnections[newConnection.id] = newConnection;
 
@@ -223,7 +223,7 @@ export default class ConnectionController {
     log.info(
       'Connect called to connect to instance:',
       connectionModel.getAttributes({
-        derived: true,
+        derived: true
       }).instanceId
     );
 
@@ -453,13 +453,13 @@ export default class ConnectionController {
     const connectionNameToRemove:
       | string
       | undefined = await vscode.window.showQuickPick(
-      connectionIds.map(
-        (id, index) => `${index + 1}: ${this._savedConnections[id].name}`
-      ),
-      {
-        placeHolder: 'Choose a connection to remove...',
-      }
-    );
+        connectionIds.map(
+          (id, index) => `${index + 1}: ${this._savedConnections[id].name}`
+        ),
+        {
+          placeHolder: 'Choose a connection to remove...'
+        }
+      );
 
     if (!connectionNameToRemove) {
       return Promise.resolve(false);
@@ -489,7 +489,7 @@ export default class ConnectionController {
           }
 
           return null;
-        },
+        }
       });
     } catch (e) {
       return Promise.reject(

--- a/src/explorer/explorerTreeController.ts
+++ b/src/explorer/explorerTreeController.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 
 import ConnectionController, {
-  DataServiceEventTypes
+  DataServiceEventTypes,
 } from '../connectionController';
 import { DOCUMENT_ITEM } from './documentTreeItem';
 import ConnectionTreeItem from './connectionTreeItem';
@@ -14,7 +14,8 @@ import { DOCUMENT_LIST_ITEM, CollectionTypes } from './documentListTreeItem';
 
 const log = createLogger('explorer controller');
 
-export default class ExplorerTreeController implements vscode.TreeDataProvider<vscode.TreeItem> {
+export default class ExplorerTreeController
+  implements vscode.TreeDataProvider<vscode.TreeItem> {
   private _connectionController: ConnectionController;
   private _mdbConnectionsTreeItem: MDBConnectionsTreeItem;
 

--- a/src/explorer/explorerTreeController.ts
+++ b/src/explorer/explorerTreeController.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 
 import ConnectionController, {
-  DataServiceEventTypes,
+  DataServiceEventTypes
 } from '../connectionController';
 import { DOCUMENT_ITEM } from './documentTreeItem';
 import ConnectionTreeItem from './connectionTreeItem';
@@ -15,7 +15,7 @@ import { DOCUMENT_LIST_ITEM, CollectionTypes } from './documentListTreeItem';
 const log = createLogger('explorer controller');
 
 export default class ExplorerTreeController
-  implements vscode.TreeDataProvider<vscode.TreeItem> {
+implements vscode.TreeDataProvider<vscode.TreeItem> {
   private _connectionController: ConnectionController;
   private _mdbConnectionsTreeItem: MDBConnectionsTreeItem;
 

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -398,7 +398,7 @@ export default class MDBExtensionController implements vscode.Disposable {
     }
     const mongoDBShell = vscode.window.createTerminal({
       name: 'MongoDB Shell',
-      env: { MDB_CONNECTION_STRING: mdbConnectionString },
+      env: { MDB_CONNECTION_STRING: mdbConnectionString }
     });
     const shellCommand = vscode.workspace.getConfiguration('mdb').get('shell');
     mongoDBShell.sendText(

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -74,8 +74,8 @@ export default class MDBExtensionController implements vscode.Disposable {
   }
 
   activate(): void {
+    this._explorerController.activateTreeView();
     this._connectionController.loadSavedConnections();
-    this._explorerController.createTreeView();
     this._telemetryController.activate();
     this._languageServerController.activate();
 
@@ -398,7 +398,7 @@ export default class MDBExtensionController implements vscode.Disposable {
     }
     const mongoDBShell = vscode.window.createTerminal({
       name: 'MongoDB Shell',
-      env: { MDB_CONNECTION_STRING: mdbConnectionString }
+      env: { MDB_CONNECTION_STRING: mdbConnectionString },
     });
     const shellCommand = vscode.workspace.getConfiguration('mdb').get('shell');
     mongoDBShell.sendText(

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -5,12 +5,12 @@ import * as sinon from 'sinon';
 import Connection = require('mongodb-connection-model/lib/model');
 
 import ConnectionController, {
-  DataServiceEventTypes,
+  DataServiceEventTypes
 } from '../../connectionController';
 import { StorageController, StorageVariables } from '../../storage';
 import {
   StorageScope,
-  DefaultSavingLocations,
+  DefaultSavingLocations
 } from '../../storage/storageController';
 import { StatusView } from '../../views';
 import MDBExtensionController from '../../mdbExtensionController';
@@ -63,7 +63,7 @@ suite('Connection Controller Test Suite', () => {
         assert(connectionModel !== null);
         assert(
           connectionModel?.getAttributes({
-            derived: true,
+            derived: true
           }).instanceId === 'localhost:27018'
         );
         const dataService = testConnectionController.getActiveDataService();
@@ -447,14 +447,14 @@ suite('Connection Controller Test Suite', () => {
           id: 'testGlobalConnectionModel',
           name: 'name1',
           connectionModel: new Connection({ port: 29999 }),
-          driverUrl: 'testGlobalConnectionModelDriverUrl',
+          driverUrl: 'testGlobalConnectionModelDriverUrl'
         },
         testGlobalConnectionModel2: {
           id: 'testGlobalConnectionModel2',
           name: 'name2',
           connectionModel: new Connection({ port: 30000 }),
-          driverUrl: 'testGlobalConnectionModel2DriverUrl',
-        },
+          driverUrl: 'testGlobalConnectionModel2DriverUrl'
+        }
       }
     );
     testExtensionContext.workspaceState.update(
@@ -465,14 +465,14 @@ suite('Connection Controller Test Suite', () => {
           name: 'name3',
           connectionModel: new Connection({ port: 29999 }),
 
-          driverUrl: 'testWorkspaceConnectionModel1DriverUrl',
+          driverUrl: 'testWorkspaceConnectionModel1DriverUrl'
         },
         testWorkspaceConnectionModel2: {
           id: 'testWorkspaceConnectionModel2',
           name: 'name4',
           connectionModel: new Connection({ port: 22345 }),
-          driverUrl: 'testWorkspaceConnectionModel2DriverUrl',
-        },
+          driverUrl: 'testWorkspaceConnectionModel2DriverUrl'
+        }
       }
     );
     const testStorageController = new StorageController(testExtensionContext);
@@ -629,8 +629,8 @@ suite('Connection Controller Test Suite', () => {
           driverUrl: TEST_DATABASE_URI,
           name: 'tester',
           connectionModel,
-          storageLocation: StorageScope.NONE,
-        },
+          storageLocation: StorageScope.NONE
+        }
       };
 
       testConnectionController

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
-import { afterEach } from 'mocha';
+import { afterEach, beforeEach } from 'mocha';
 import * as sinon from 'sinon';
 import Connection = require('mongodb-connection-model/lib/model');
 
@@ -26,6 +26,11 @@ suite('Connection Controller Test Suite', () => {
   const mockExtensionContext = new TestExtensionContext();
   const mockStorageController = new StorageController(mockExtensionContext);
 
+  beforeEach(() => {
+    // Here we stub the showInformationMessage process because it is too much
+    // for the render process and leads to crashes while testing.
+    sinon.replace(vscode.window, 'showInformationMessage', sinon.stub());
+  });
   afterEach(() => {
     // Reset our mock extension's state.
     mockExtensionContext._workspaceState = {};

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -5,12 +5,12 @@ import * as sinon from 'sinon';
 import Connection = require('mongodb-connection-model/lib/model');
 
 import ConnectionController, {
-  DataServiceEventTypes
+  DataServiceEventTypes,
 } from '../../connectionController';
 import { StorageController, StorageVariables } from '../../storage';
 import {
   StorageScope,
-  DefaultSavingLocations
+  DefaultSavingLocations,
 } from '../../storage/storageController';
 import { StatusView } from '../../views';
 import MDBExtensionController from '../../mdbExtensionController';
@@ -63,12 +63,16 @@ suite('Connection Controller Test Suite', () => {
         assert(connectionModel !== null);
         assert(
           connectionModel?.getAttributes({
-            derived: true
+            derived: true,
           }).instanceId === 'localhost:27018'
         );
         const dataService = testConnectionController.getActiveDataService();
         assert(dataService !== null);
-        assert(testConnectionController._activeConnectionModel?.appname.startsWith('mongodb-vscode'));
+        assert(
+          testConnectionController._activeConnectionModel?.appname.startsWith(
+            'mongodb-vscode'
+          )
+        );
         assert(testConnectionController.isCurrentlyConnected());
       })
       .then(done, done);
@@ -443,14 +447,14 @@ suite('Connection Controller Test Suite', () => {
           id: 'testGlobalConnectionModel',
           name: 'name1',
           connectionModel: new Connection({ port: 29999 }),
-          driverUrl: 'testGlobalConnectionModelDriverUrl'
+          driverUrl: 'testGlobalConnectionModelDriverUrl',
         },
         testGlobalConnectionModel2: {
           id: 'testGlobalConnectionModel2',
           name: 'name2',
           connectionModel: new Connection({ port: 30000 }),
-          driverUrl: 'testGlobalConnectionModel2DriverUrl'
-        }
+          driverUrl: 'testGlobalConnectionModel2DriverUrl',
+        },
       }
     );
     testExtensionContext.workspaceState.update(
@@ -461,14 +465,14 @@ suite('Connection Controller Test Suite', () => {
           name: 'name3',
           connectionModel: new Connection({ port: 29999 }),
 
-          driverUrl: 'testWorkspaceConnectionModel1DriverUrl'
+          driverUrl: 'testWorkspaceConnectionModel1DriverUrl',
         },
         testWorkspaceConnectionModel2: {
           id: 'testWorkspaceConnectionModel2',
           name: 'name4',
           connectionModel: new Connection({ port: 22345 }),
-          driverUrl: 'testWorkspaceConnectionModel2DriverUrl'
-        }
+          driverUrl: 'testWorkspaceConnectionModel2DriverUrl',
+        },
       }
     );
     const testStorageController = new StorageController(testExtensionContext);
@@ -484,7 +488,7 @@ suite('Connection Controller Test Suite', () => {
     assert(
       Object.keys(connections).length === 4,
       `Expected 4 connection configurations found ${
-      Object.keys(connections).length
+        Object.keys(connections).length
       }`
     );
     assert(
@@ -493,7 +497,7 @@ suite('Connection Controller Test Suite', () => {
     );
     assert(
       Object.keys(connections).includes('testWorkspaceConnectionModel2') ===
-      true,
+        true,
       "Expected connection configurations to include 'testWorkspaceConnectionModel2'"
     );
     assert(
@@ -502,7 +506,7 @@ suite('Connection Controller Test Suite', () => {
     );
     assert(
       connections.testGlobalConnectionModel2.driverUrl ===
-      'testGlobalConnectionModel2DriverUrl',
+        'testGlobalConnectionModel2DriverUrl',
       "Expected loaded connection to include driver url 'testGlobalConnectionModel2DriverUrl'"
     );
     assert(
@@ -540,7 +544,7 @@ suite('Connection Controller Test Suite', () => {
     assert(
       Object.keys(globalStoreConnections).length === 1,
       `Expected global store connections to have 1 connection found ${
-      Object.keys(globalStoreConnections).length
+        Object.keys(globalStoreConnections).length
       }`
     );
     const id = Object.keys(globalStoreConnections)[0];
@@ -588,7 +592,7 @@ suite('Connection Controller Test Suite', () => {
     assert(
       Object.keys(workspaceStoreConnections).length === 1,
       `Expected workspace store connections to have 1 connection found ${
-      Object.keys(workspaceStoreConnections).length
+        Object.keys(workspaceStoreConnections).length
       }`
     );
     const id = Object.keys(workspaceStoreConnections)[0];
@@ -625,8 +629,8 @@ suite('Connection Controller Test Suite', () => {
           driverUrl: TEST_DATABASE_URI,
           name: 'tester',
           connectionModel,
-          storageLocation: StorageScope.NONE
-        }
+          storageLocation: StorageScope.NONE,
+        },
       };
 
       testConnectionController
@@ -669,7 +673,7 @@ suite('Connection Controller Test Suite', () => {
             assert(
               Object.keys(workspaceStoreConnections).length === 1,
               `Expected workspace store connections to have 1 connection found ${
-              Object.keys(workspaceStoreConnections).length
+                Object.keys(workspaceStoreConnections).length
               }`
             );
 
@@ -687,7 +691,7 @@ suite('Connection Controller Test Suite', () => {
                 assert(
                   testConnectionController.getSavedConnections().length === 1,
                   `Expected 1 connection config, found ${
-                  testConnectionController.getSavedConnections().length
+                    testConnectionController.getSavedConnections().length
                   }.`
                 );
                 const id = testConnectionController.getSavedConnections()[0].id;
@@ -839,7 +843,7 @@ suite('Connection Controller Test Suite', () => {
               assert(
                 Object.keys(workspaceStoreConnections).length === 1,
                 `Expected workspace store connections to have 1 connection found ${
-                Object.keys(workspaceStoreConnections).length
+                  Object.keys(workspaceStoreConnections).length
                 }`
               );
 
@@ -855,7 +859,7 @@ suite('Connection Controller Test Suite', () => {
               assert(
                 Object.keys(postWorkspaceStoreConnections).length === 0,
                 `Expected workspace store connections to have 0 connections found ${
-                Object.keys(postWorkspaceStoreConnections).length
+                  Object.keys(postWorkspaceStoreConnections).length
                 }`
               );
             })
@@ -889,7 +893,7 @@ suite('Connection Controller Test Suite', () => {
     assert(
       Object.keys(globalStoreConnections).length === 1,
       `Expected workspace store connections to have 1 connection found ${
-      Object.keys(globalStoreConnections).length
+        Object.keys(globalStoreConnections).length
       }`
     );
 
@@ -903,7 +907,7 @@ suite('Connection Controller Test Suite', () => {
     assert(
       Object.keys(postGlobalStoreConnections).length === 0,
       `Expected global store connections to have 0 connections found ${
-      Object.keys(postGlobalStoreConnections).length
+        Object.keys(postGlobalStoreConnections).length
       }`
     );
   });
@@ -939,7 +943,7 @@ suite('Connection Controller Test Suite', () => {
               assert(
                 Object.keys(workspaceStoreConnections).length === 1,
                 `Expected workspace store connections to have 1 connection found ${
-                Object.keys(workspaceStoreConnections).length
+                  Object.keys(workspaceStoreConnections).length
                 }`
               );
               const connectionId =
@@ -974,7 +978,7 @@ suite('Connection Controller Test Suite', () => {
                         testConnectionController.getSavedConnections()
                           .length === 1,
                         `Expected 1 connection config, found ${
-                        testConnectionController.getSavedConnections().length
+                          testConnectionController.getSavedConnections().length
                         }.`
                       );
                       const id = testConnectionController.getSavedConnections()[0]

--- a/src/test/suite/explorer/explorerController.test.ts
+++ b/src/test/suite/explorer/explorerController.test.ts
@@ -2,10 +2,11 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 import { beforeEach, afterEach } from 'mocha';
 import Connection = require('mongodb-connection-model/lib/model');
+import * as sinon from 'sinon';
 
 import {
   DefaultSavingLocations,
-  StorageScope
+  StorageScope,
 } from '../../../storage/storageController';
 
 import { TEST_DATABASE_URI } from '../dbTestHelper';
@@ -34,6 +35,7 @@ suite('Explorer Controller Test Suite', () => {
       );
     // Reset our connections.
     mdbTestExtension.testExtensionController._connectionController.clearAllConnections();
+    sinon.restore();
   });
 
   test('should have a connections root', (done) => {
@@ -74,8 +76,8 @@ suite('Explorer Controller Test Suite', () => {
         connectionModel: new Connection(),
         name: 'testConnectionName',
         driverUrl: 'url',
-        storageLocation: StorageScope.NONE
-      }
+        storageLocation: StorageScope.NONE,
+      },
     };
     testConnectionController.setConnnectingConnectionId(mockConnectionId);
     testConnectionController.setConnnecting(true);
@@ -324,5 +326,37 @@ suite('Explorer Controller Test Suite', () => {
           });
         });
       });
+  });
+
+  test('tree view should be not created by default (shows welcome view)', () => {
+    const testExplorerController =
+      mdbTestExtension.testExtensionController._explorerController;
+
+    assert(testExplorerController.getTreeView() === undefined);
+  });
+
+  test('tree view should call create tree view after a "CONNECTIONS_DID_CHANGE" event', (done) => {
+    const testExplorerController =
+      mdbTestExtension.testExtensionController._explorerController;
+
+    testExplorerController.activateTreeView();
+
+    const treeControllerStub = sinon.stub().returns();
+    sinon.replace(
+      testExplorerController.getTreeController(),
+      'activateTreeViewEventHandlers',
+      treeControllerStub
+    );
+
+    const vscodeCreateTreeViewStub = sinon.stub().returns('');
+    sinon.replace(vscode.window, 'createTreeView', vscodeCreateTreeViewStub);
+
+    mdbTestExtension.testExtensionController._connectionController
+      .addNewConnectionStringAndConnect(TEST_DATABASE_URI)
+      .then(() => {
+        mdbTestExtension.testExtensionController._connectionController.disconnect();
+        assert(vscodeCreateTreeViewStub.called);
+      })
+      .then(done);
   });
 });

--- a/src/test/suite/explorer/explorerController.test.ts
+++ b/src/test/suite/explorer/explorerController.test.ts
@@ -6,7 +6,7 @@ import * as sinon from 'sinon';
 
 import {
   DefaultSavingLocations,
-  StorageScope,
+  StorageScope
 } from '../../../storage/storageController';
 
 import { TEST_DATABASE_URI } from '../dbTestHelper';
@@ -76,8 +76,8 @@ suite('Explorer Controller Test Suite', () => {
         connectionModel: new Connection(),
         name: 'testConnectionName',
         driverUrl: 'url',
-        storageLocation: StorageScope.NONE,
-      },
+        storageLocation: StorageScope.NONE
+      }
     };
     testConnectionController.setConnnectingConnectionId(mockConnectionId);
     testConnectionController.setConnnecting(true);

--- a/src/test/suite/mdbExtensionController.test.ts
+++ b/src/test/suite/mdbExtensionController.test.ts
@@ -12,7 +12,7 @@ import {
   ConnectionTreeItem,
   DatabaseTreeItem,
   DocumentTreeItem,
-  SchemaTreeItem,
+  SchemaTreeItem
 } from '../../explorer';
 import { mdbTestExtension } from './stubbableMdbExtension';
 import ConnectionController from '../../connectionController';
@@ -36,7 +36,7 @@ suite('MDBExtensionController Test Suite', () => {
     const textCollectionTree = new CollectionTreeItem(
       {
         name: 'testColName',
-        type: CollectionTypes.collection,
+        type: CollectionTypes.collection
       },
       'testDbName',
       {},
@@ -77,7 +77,7 @@ suite('MDBExtensionController Test Suite', () => {
     const textCollectionTree = new CollectionTreeItem(
       {
         name: 'testColName',
-        type: CollectionTypes.collection,
+        type: CollectionTypes.collection
       },
       'testDbName',
       {},
@@ -275,7 +275,7 @@ suite('MDBExtensionController Test Suite', () => {
     const mockTreeItem = new CollectionTreeItem(
       {
         name: 'waterBuffalo',
-        type: CollectionTypes.collection,
+        type: CollectionTypes.collection
       },
       'airZebra',
       {},
@@ -331,7 +331,7 @@ suite('MDBExtensionController Test Suite', () => {
     const mockTreeItem = new CollectionTreeItem(
       {
         name: 'iSawACatThatLookedLikeALionToday',
-        type: CollectionTypes.collection,
+        type: CollectionTypes.collection
       },
       'airZebra',
       {},
@@ -449,7 +449,7 @@ suite('MDBExtensionController Test Suite', () => {
       createCollection: (namespace, options, callback) => {
         returnedNamespaceArg = namespace;
         callback(null);
-      },
+      }
     });
     sinon.replace(
       mdbTestExtension.testExtensionController._connectionController,
@@ -580,7 +580,7 @@ suite('MDBExtensionController Test Suite', () => {
     const testStatusViewObject = {
       show: stubShowMessage,
       hide: stubHideMessage,
-      text: '',
+      text: ''
     };
     const mockSatusBarItem = sinon.fake.returns(testStatusViewObject);
     sinon.replace(vscode.window, 'createStatusBarItem', mockSatusBarItem);
@@ -608,7 +608,7 @@ suite('MDBExtensionController Test Suite', () => {
         );
 
         callback(null);
-      },
+      }
     });
     sinon.replace(
       mdbTestExtension.testExtensionController._connectionController,
@@ -638,7 +638,7 @@ suite('MDBExtensionController Test Suite', () => {
         createCollection: (namespace, options, callback): void => {
           returnedNamespaceArg = namespace;
           callback(null);
-        },
+        }
       },
       false,
       {}
@@ -705,7 +705,7 @@ suite('MDBExtensionController Test Suite', () => {
     const testStatusViewObject = {
       show: stubShowMessage,
       hide: stubHideMessage,
-      text: '',
+      text: ''
     };
     const mockSatusBarItem = sinon.fake.returns(testStatusViewObject);
     sinon.replace(vscode.window, 'createStatusBarItem', mockSatusBarItem);
@@ -723,7 +723,7 @@ suite('MDBExtensionController Test Suite', () => {
           );
 
           callback(null);
-        },
+        }
       },
       false,
       {}
@@ -752,7 +752,7 @@ suite('MDBExtensionController Test Suite', () => {
         dropCollection: (namespace, callback): void => {
           calledNamespace = namespace;
           callback(null, true);
-        },
+        }
       },
       false
     );
@@ -868,7 +868,7 @@ suite('MDBExtensionController Test Suite', () => {
         dropDatabase: (dbName, callback): void => {
           calledDatabaseName = dbName;
           callback(null, true);
-        },
+        }
       },
       false,
       {}
@@ -982,7 +982,7 @@ suite('MDBExtensionController Test Suite', () => {
       connectionModel: new Connection(),
       name: 'NAAAME',
       driverUrl: '',
-      storageLocation: StorageScope.NONE,
+      storageLocation: StorageScope.NONE
     };
 
     const mockTreeItem = new ConnectionTreeItem(
@@ -1024,7 +1024,7 @@ suite('MDBExtensionController Test Suite', () => {
       name: 'NAAAME',
       connectionModel: new Connection(),
       driverUrl: '',
-      storageLocation: StorageScope.NONE,
+      storageLocation: StorageScope.NONE
     };
 
     const mockTreeItem = new ConnectionTreeItem(
@@ -1066,7 +1066,7 @@ suite('MDBExtensionController Test Suite', () => {
 
     const documentItem = new DocumentTreeItem(
       {
-        _id: 'pancakes',
+        _id: 'pancakes'
       },
       'waffle.house',
       0
@@ -1110,7 +1110,7 @@ suite('MDBExtensionController Test Suite', () => {
       get: (prop) => {
         assert(prop === 'useDefaultTemplateForPlayground');
         return true;
-      },
+      }
     });
     sinon.replace(
       vscode.workspace,
@@ -1146,7 +1146,7 @@ suite('MDBExtensionController Test Suite', () => {
       get: (prop) => {
         assert(prop === 'useDefaultTemplateForPlayground');
         return false;
-      },
+      }
     });
     sinon.replace(
       vscode.workspace,

--- a/src/test/suite/mdbExtensionController.test.ts
+++ b/src/test/suite/mdbExtensionController.test.ts
@@ -12,7 +12,7 @@ import {
   ConnectionTreeItem,
   DatabaseTreeItem,
   DocumentTreeItem,
-  SchemaTreeItem
+  SchemaTreeItem,
 } from '../../explorer';
 import { mdbTestExtension } from './stubbableMdbExtension';
 import ConnectionController from '../../connectionController';
@@ -36,7 +36,7 @@ suite('MDBExtensionController Test Suite', () => {
     const textCollectionTree = new CollectionTreeItem(
       {
         name: 'testColName',
-        type: CollectionTypes.collection
+        type: CollectionTypes.collection,
       },
       'testDbName',
       {},
@@ -77,7 +77,7 @@ suite('MDBExtensionController Test Suite', () => {
     const textCollectionTree = new CollectionTreeItem(
       {
         name: 'testColName',
-        type: CollectionTypes.collection
+        type: CollectionTypes.collection,
       },
       'testDbName',
       {},
@@ -275,7 +275,7 @@ suite('MDBExtensionController Test Suite', () => {
     const mockTreeItem = new CollectionTreeItem(
       {
         name: 'waterBuffalo',
-        type: CollectionTypes.collection
+        type: CollectionTypes.collection,
       },
       'airZebra',
       {},
@@ -331,7 +331,7 @@ suite('MDBExtensionController Test Suite', () => {
     const mockTreeItem = new CollectionTreeItem(
       {
         name: 'iSawACatThatLookedLikeALionToday',
-        type: CollectionTypes.collection
+        type: CollectionTypes.collection,
       },
       'airZebra',
       {},
@@ -449,7 +449,7 @@ suite('MDBExtensionController Test Suite', () => {
       createCollection: (namespace, options, callback) => {
         returnedNamespaceArg = namespace;
         callback(null);
-      }
+      },
     });
     sinon.replace(
       mdbTestExtension.testExtensionController._connectionController,
@@ -580,7 +580,7 @@ suite('MDBExtensionController Test Suite', () => {
     const testStatusViewObject = {
       show: stubShowMessage,
       hide: stubHideMessage,
-      text: ''
+      text: '',
     };
     const mockSatusBarItem = sinon.fake.returns(testStatusViewObject);
     sinon.replace(vscode.window, 'createStatusBarItem', mockSatusBarItem);
@@ -608,7 +608,7 @@ suite('MDBExtensionController Test Suite', () => {
         );
 
         callback(null);
-      }
+      },
     });
     sinon.replace(
       mdbTestExtension.testExtensionController._connectionController,
@@ -638,7 +638,7 @@ suite('MDBExtensionController Test Suite', () => {
         createCollection: (namespace, options, callback): void => {
           returnedNamespaceArg = namespace;
           callback(null);
-        }
+        },
       },
       false,
       {}
@@ -705,7 +705,7 @@ suite('MDBExtensionController Test Suite', () => {
     const testStatusViewObject = {
       show: stubShowMessage,
       hide: stubHideMessage,
-      text: ''
+      text: '',
     };
     const mockSatusBarItem = sinon.fake.returns(testStatusViewObject);
     sinon.replace(vscode.window, 'createStatusBarItem', mockSatusBarItem);
@@ -723,7 +723,7 @@ suite('MDBExtensionController Test Suite', () => {
           );
 
           callback(null);
-        }
+        },
       },
       false,
       {}
@@ -752,7 +752,7 @@ suite('MDBExtensionController Test Suite', () => {
         dropCollection: (namespace, callback): void => {
           calledNamespace = namespace;
           callback(null, true);
-        }
+        },
       },
       false
     );
@@ -868,7 +868,7 @@ suite('MDBExtensionController Test Suite', () => {
         dropDatabase: (dbName, callback): void => {
           calledDatabaseName = dbName;
           callback(null, true);
-        }
+        },
       },
       false,
       {}
@@ -982,7 +982,7 @@ suite('MDBExtensionController Test Suite', () => {
       connectionModel: new Connection(),
       name: 'NAAAME',
       driverUrl: '',
-      storageLocation: StorageScope.NONE
+      storageLocation: StorageScope.NONE,
     };
 
     const mockTreeItem = new ConnectionTreeItem(
@@ -1024,7 +1024,7 @@ suite('MDBExtensionController Test Suite', () => {
       name: 'NAAAME',
       connectionModel: new Connection(),
       driverUrl: '',
-      storageLocation: StorageScope.NONE
+      storageLocation: StorageScope.NONE,
     };
 
     const mockTreeItem = new ConnectionTreeItem(
@@ -1066,7 +1066,7 @@ suite('MDBExtensionController Test Suite', () => {
 
     const documentItem = new DocumentTreeItem(
       {
-        _id: 'pancakes'
+        _id: 'pancakes',
       },
       'waffle.house',
       0
@@ -1110,7 +1110,7 @@ suite('MDBExtensionController Test Suite', () => {
       get: (prop) => {
         assert(prop === 'useDefaultTemplateForPlayground');
         return true;
-      }
+      },
     });
     sinon.replace(
       vscode.workspace,
@@ -1146,7 +1146,7 @@ suite('MDBExtensionController Test Suite', () => {
       get: (prop) => {
         assert(prop === 'useDefaultTemplateForPlayground');
         return false;
-      }
+      },
     });
     sinon.replace(
       vscode.workspace,

--- a/src/test/suite/mdbExtensionController.test.ts
+++ b/src/test/suite/mdbExtensionController.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
-import { afterEach } from 'mocha';
+import { afterEach, beforeEach } from 'mocha';
 import Connection = require('mongodb-connection-model/lib/model');
 const sinon = require('sinon');
 
@@ -22,6 +22,11 @@ import { StorageScope } from '../../storage/storageController';
 const testDatabaseURI = 'mongodb://localhost:27018';
 
 suite('MDBExtensionController Test Suite', () => {
+  beforeEach(() => {
+    // Here we stub the showInformationMessage process because it is too much
+    // for the render process and leads to crashes while testing.
+    sinon.replace(vscode.window, 'showInformationMessage', sinon.stub());
+  });
   afterEach(() => {
     sinon.restore();
   });


### PR DESCRIPTION
https://jira.mongodb.org/browse/VSCODE-85

This PR adds a button to the tree view for when the user has not yet added a connection.  This should improve the experience for users who have just installed the extension.

Note: If the user adds a connection and removes it, the button does not show up. If they refresh their vscode though, and there are no connections, it will show up. When they're first loading the extension and their connections have not yet loaded, the message also shows up - which might be enough of a reason not to use this button format. From what I've read it looks like there's no way for us to specify that our extension is being activated... https://github.com/microsoft/vscode/issues/59645 This will be less of an issue once we're webpacking and load times are hopefully significantly reduced.

**Screenshots**
___
<img width="339" alt="Screen Shot 2020-04-16 at 7 11 41 PM" src="https://user-images.githubusercontent.com/1791149/79485857-2a90f400-8016-11ea-9daa-76c74cad98a5.png">

![Apr-16-2020 18-06-38](https://user-images.githubusercontent.com/1791149/79485863-2d8be480-8016-11ea-9169-6f0399a729f6.gif)
