### PR TITLE
(fix): Use correct worker file name and clean and webpack before watching

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "compile:keyfile": "ts-node ./scripts/generate-keyfile.ts",
     "compile:resources": "npm run update-grammar && npm run update-snippets",
     "compile:extension": "tsc -p ./",
-    "watch": "npm-run-all -p watch:*",
+    "watch": "npm run clean && npm run webpack-dev && npm-run-all -p watch:*",
     "watch:extension": "npm run compile:extension -- -watch",
     "watch:extension-bundles": "webpack --mode development --info-verbosity verbose --watch",
     "pretest": "npm run compile && npm run webpack-dev && cross-env MONGODB_VERSION=4.2.3 mongodb-runner start --port=27018",

--- a/src/editors/playgroundController.ts
+++ b/src/editors/playgroundController.ts
@@ -81,7 +81,8 @@ export default class PlaygroundController {
 
       return this._languageServerController.connectToServiceProvider({
         connectionString: this._connectionString,
-        connectionOptions: this._connectionOptions
+        connectionOptions: this._connectionOptions,
+        extensionPath: this._context.extensionPath
       });
     }
 

--- a/src/language/languageServerController.ts
+++ b/src/language/languageServerController.ts
@@ -157,6 +157,7 @@ export default class LanguageServerController {
   connectToServiceProvider(params: {
     connectionString?: string;
     connectionOptions?: any;
+    extensionPath: string;
   }): Promise<any> {
     return this.client.onReady().then(async () => {
       return this.client.sendRequest(

--- a/src/test/helper/playgroundHelper.ts
+++ b/src/test/helper/playgroundHelper.ts
@@ -51,6 +51,7 @@ export class MockLanguageServerController implements LanguageServerController {
   connectToServiceProvider(params: {
     connectionString?: string;
     connectionOptions?: any;
+    extensionPath: string;
   }): Promise<any> {
     return Promise.resolve(true);
   }

--- a/src/test/suite/language/mongoDBService.test.ts
+++ b/src/test/suite/language/mongoDBService.test.ts
@@ -21,7 +21,8 @@ suite('MongoDBService Test Suite', () => {
     sendNotification: () => {}
   };
   const params = {
-    connectionString: 'mongodb://localhost:27018'
+    connectionString: 'mongodb://localhost:27018',
+    extensionPath: mdbTestExtension.testExtensionContext.extensionPath
   };
 
   suite('Connect', () => {


### PR DESCRIPTION
When adding webpack to the project, we started using bundles for the language server and language server worker. This PR updates an older file naming to use the bundled language server worker.
We also now run clean and webpack before watching for updates in files to be sure our extension can be developed properly.
I'm working on a test for this now to make sure it can't happen in future, I'll pass the extension path in a less hacky way then as well. That PR will be coming soon, this fix is just to unblock.