### PR TITLE
Add language server file dependency tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "watch": "npm run clean && npm run webpack-dev && npm-run-all -p watch:*",
     "watch:extension": "npm run compile:extension -- -watch",
     "watch:extension-bundles": "webpack --mode development --info-verbosity verbose --watch",
-    "pretest": "npm run compile && npm run webpack-dev && cross-env MONGODB_VERSION=4.2.3 mongodb-runner start --port=27018",
+    "pretest": "npm run clean && npm run compile && npm run webpack-dev && cross-env MONGODB_VERSION=4.2.3 mongodb-runner start --port=27018",
     "test": "cross-env NODE_OPTIONS=--no-force-async-hooks-checks xvfb-maybe node ./out/test/runTest.js",
     "posttest": "mongodb-runner stop --port=27018",
     "vscode:prepublish": "npm run clean && npm run compile && webpack --mode production",

--- a/package.json
+++ b/package.json
@@ -151,6 +151,10 @@
         "title": "MongoDB: Create MongoDB Playground"
       },
       {
+        "command": "mdb.createNewPlaygroundFromViewAction",
+        "title": "Create MongoDB Playground"
+      },
+      {
         "command": "mdb.showActiveConnectionInPlayground",
         "title": "MongoDB: Show Active Connection In Playground"
       },
@@ -258,7 +262,7 @@
     "menus": {
       "view/title": [
         {
-          "command": "mdb.createPlayground",
+          "command": "mdb.createNewPlaygroundFromViewAction",
           "when": "view == mongoDB"
         },
         {
@@ -398,6 +402,76 @@
           "command": "mdb.runAllPlaygroundBlocks",
           "group": "navigation",
           "when": "editorLangId == mongodb"
+        }
+      ],
+      "commandPalette": [
+        {
+          "command": "mdb.createNewPlaygroundFromViewAction",
+          "when": "false"
+        },
+        {
+          "command": "mdb.copyConnectionString",
+          "when": "false"
+        },
+        {
+          "command": "mdb.renameConnection",
+          "when": "false"
+        },
+        {
+          "command": "mdb.treeItemRemoveConnection",
+          "when": "false"
+        },
+        {
+          "command": "mdb.addDatabase",
+          "when": "false"
+        },
+        {
+          "command": "mdb.connectToConnectionTreeItem",
+          "when": "false"
+        },
+        {
+          "command": "mdb.disconnectFromConnectionTreeItem",
+          "when": "false"
+        },
+        {
+          "command": "mdb.refreshConnection",
+          "when": "false"
+        },
+        {
+          "command": "mdb.copyDatabaseName",
+          "when": "false"
+        },
+        {
+          "command": "mdb.dropDatabase",
+          "when": "false"
+        },
+        {
+          "command": "mdb.refreshDatabase",
+          "when": "false"
+        },
+        {
+          "command": "mdb.addCollection",
+          "when": "false"
+        },
+        {
+          "command": "mdb.viewCollectionDocuments",
+          "when": "false"
+        },
+        {
+          "command": "mdb.copyCollectionName",
+          "when": "false"
+        },
+        {
+          "command": "mdb.dropCollection",
+          "when": "false"
+        },
+        {
+          "command": "mdb.refreshCollection",
+          "when": "false"
+        },
+        {
+          "command": "mdb.refreshSchema",
+          "when": "false"
         }
       ]
     },

--- a/src/commands/README.md
+++ b/src/commands/README.md
@@ -7,6 +7,7 @@ handlers defined in `mdb.ts`.
 Think RPC handlers.
 
 ## Connection commands
+
 - `mdb.connect`
 - `mdb.connectWithURI`
 - `mdb.disconnect`
@@ -15,8 +16,9 @@ Think RPC handlers.
 - `mdb.refresh`
 
 - `mdb.openMongoDBShell`
--
+
 ## General database commands
+
 - `mdb.createDatabase`
 - `mdb.createCollection`
 
@@ -27,27 +29,32 @@ Think RPC handlers.
 - `mdb.viewCollectionDocuments`
 
 ## Query commands (json input fields)
+
 - `mdb.aggregate`
 - `mdb.explainAggregate`
 - `mdb.find`
 - `mdb.findOne`
-- `mdb.findBy`  *-> pick(value) -> pick(key) -> show*
-- `mdb.explain` *Uses the active cursor (only possible after a query)*
-- `mdb.getMore` *Uses the active cursor (only possible after a query)*
+- `mdb.findBy` _-> pick(value) -> pick(key) -> show_
+- `mdb.explain` _Uses the active cursor (only possible after a query)_
+- `mdb.getMore` _Uses the active cursor (only possible after a query)_
 
 ## Playground commands
+
 - `mdb.playground`
 - `mdb.createPlayground`
 - `mdb.removePlayground`
 - `mdb.runPlaygroundBlock`
 - `mdb.runAllPlaygroundBlocks`
+- `mdb.createNewPlaygroundFromViewAction`
 
 ## Index commands
+
 - `mdb.createIndex`
 - `mdb.getIndex`
 - `mdb.removeIndex`
 
 ## Import/Export commands
+
 - `mdb.importDocument`
 
 - `mdb.import`
@@ -56,4 +63,5 @@ Think RPC handlers.
 - `mdb.cancelExport`
 
 ## CodeLens commands
+
 - `mdb.codeLens.showMoreDocumentsClicked`

--- a/src/language/languageServerController.ts
+++ b/src/language/languageServerController.ts
@@ -146,8 +146,7 @@ export default class LanguageServerController {
       return this.client.sendRequest(
         ServerCommands.EXECUTE_ALL_FROM_PLAYGROUND,
         {
-          codeToEvaluate,
-          extensionPath: this._context.extensionPath
+          codeToEvaluate
         } as PlaygroundRunParameters,
         this._source.token
       );

--- a/src/language/languageServerController.ts
+++ b/src/language/languageServerController.ts
@@ -11,8 +11,7 @@ import {
 import * as WebSocket from 'ws';
 
 import { createLogger } from '../logging';
-import { ServerCommands } from './serverCommands';
-import { PlaygroundRunParameters } from './playgroundRunParametersType';
+import { ServerCommands, PlaygroundRunParameters } from './serverCommands';
 
 const log = createLogger('LanguageServerController');
 let socket: WebSocket | null;

--- a/src/language/mongoDBService.ts
+++ b/src/language/mongoDBService.ts
@@ -12,7 +12,7 @@ const path = require('path');
 const esprima = require('esprima');
 const estraverse = require('estraverse');
 
-const languageServerWorkerFileName = 'languageServerWorker.js';
+export const languageServerWorkerFileName = 'languageServerWorker.js';
 
 export default class MongoDBService {
   _serviceProvider?: CliServiceProvider;

--- a/src/language/mongoDBService.ts
+++ b/src/language/mongoDBService.ts
@@ -4,9 +4,8 @@ import { ElectronRuntime } from '@mongosh/browser-runtime-electron';
 import { CliServiceProvider } from '@mongosh/service-provider-server';
 import { signatures } from '@mongosh/shell-api';
 import * as util from 'util';
-import { ServerCommands } from './serverCommands';
 
-import { PlaygroundRunParameters } from './playgroundRunParametersType';
+import { ServerCommands, PlaygroundRunParameters } from './serverCommands';
 
 const path = require('path');
 const esprima = require('esprima');

--- a/src/language/playgroundRunParametersType.ts
+++ b/src/language/playgroundRunParametersType.ts
@@ -1,5 +1,4 @@
 
 export type PlaygroundRunParameters = {
   codeToEvaluate: string;
-  extensionPath: string;
 };

--- a/src/language/playgroundRunParametersType.ts
+++ b/src/language/playgroundRunParametersType.ts
@@ -1,4 +1,0 @@
-
-export type PlaygroundRunParameters = {
-  codeToEvaluate: string;
-};

--- a/src/language/server.ts
+++ b/src/language/server.ts
@@ -9,7 +9,7 @@ import {
   CompletionItem,
   TextDocumentPositionParams,
   RequestType,
-  TextDocumentSyncKind,
+  TextDocumentSyncKind
 } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 
@@ -54,14 +54,14 @@ connection.onInitialize((params: InitializeParams) => {
       // Tell the client that the server supports code completion
       completionProvider: {
         resolveProvider: true,
-        triggerCharacters: ['.'],
-      },
+        triggerCharacters: ['.']
+      }
       // documentFormattingProvider: true,
       // documentRangeFormattingProvider: true,
       // codeLensProvider: {
       //   resolveProvider: true
       // }
-    },
+    }
   };
 });
 
@@ -121,7 +121,7 @@ const getDocumentSettings = (resource: string): Thenable<ExampleSettings> => {
   if (!result) {
     result = connection.workspace.getConfiguration({
       scopeUri: resource,
-      section: 'mongodbLanguageServer',
+      section: 'mongodbLanguageServer'
     });
     documentSettings.set(resource, result);
   }
@@ -157,10 +157,10 @@ const validateTextDocument = async (
       severity: DiagnosticSeverity.Warning,
       range: {
         start: textDocument.positionAt(m.index),
-        end: textDocument.positionAt(m.index + m[0].length),
+        end: textDocument.positionAt(m.index + m[0].length)
       },
       message: `${m[0]} is all uppercase.`,
-      source: 'ex',
+      source: 'ex'
     };
 
     if (hasDiagnosticRelatedInformationCapability) {
@@ -168,17 +168,17 @@ const validateTextDocument = async (
         {
           location: {
             uri: textDocument.uri,
-            range: Object.assign({}, diagnostic.range),
+            range: Object.assign({}, diagnostic.range)
           },
-          message: 'Spelling matters',
+          message: 'Spelling matters'
         },
         {
           location: {
             uri: textDocument.uri,
-            range: Object.assign({}, diagnostic.range),
+            range: Object.assign({}, diagnostic.range)
           },
-          message: 'Particularly for names',
-        },
+          message: 'Particularly for names'
+        }
       ];
     }
 

--- a/src/language/server.ts
+++ b/src/language/server.ts
@@ -9,13 +9,12 @@ import {
   CompletionItem,
   TextDocumentPositionParams,
   RequestType,
-  TextDocumentSyncKind
+  TextDocumentSyncKind,
 } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 
 import MongoDBService from './mongoDBService';
-import { ServerCommands } from './serverCommands';
-import { PlaygroundRunParameters } from './playgroundRunParametersType';
+import { ServerCommands, PlaygroundRunParameters } from './serverCommands';
 
 // Create a connection for the server. The connection uses Node's IPC as a transport.
 // Also include all preview / proposed LSP features.
@@ -55,14 +54,14 @@ connection.onInitialize((params: InitializeParams) => {
       // Tell the client that the server supports code completion
       completionProvider: {
         resolveProvider: true,
-        triggerCharacters: ['.']
-      }
+        triggerCharacters: ['.'],
+      },
       // documentFormattingProvider: true,
       // documentRangeFormattingProvider: true,
       // codeLensProvider: {
       //   resolveProvider: true
       // }
-    }
+    },
   };
 });
 
@@ -122,7 +121,7 @@ const getDocumentSettings = (resource: string): Thenable<ExampleSettings> => {
   if (!result) {
     result = connection.workspace.getConfiguration({
       scopeUri: resource,
-      section: 'mongodbLanguageServer'
+      section: 'mongodbLanguageServer',
     });
     documentSettings.set(resource, result);
   }
@@ -158,10 +157,10 @@ const validateTextDocument = async (
       severity: DiagnosticSeverity.Warning,
       range: {
         start: textDocument.positionAt(m.index),
-        end: textDocument.positionAt(m.index + m[0].length)
+        end: textDocument.positionAt(m.index + m[0].length),
       },
       message: `${m[0]} is all uppercase.`,
-      source: 'ex'
+      source: 'ex',
     };
 
     if (hasDiagnosticRelatedInformationCapability) {
@@ -169,17 +168,17 @@ const validateTextDocument = async (
         {
           location: {
             uri: textDocument.uri,
-            range: Object.assign({}, diagnostic.range)
+            range: Object.assign({}, diagnostic.range),
           },
-          message: 'Spelling matters'
+          message: 'Spelling matters',
         },
         {
           location: {
             uri: textDocument.uri,
-            range: Object.assign({}, diagnostic.range)
+            range: Object.assign({}, diagnostic.range),
           },
-          message: 'Particularly for names'
-        }
+          message: 'Particularly for names',
+        },
       ];
     }
 

--- a/src/language/serverCommands.ts
+++ b/src/language/serverCommands.ts
@@ -7,3 +7,7 @@ export enum ServerCommands {
   GET_LIST_DATABASES = 'GET_LIST_DATABASES',
   GET_LIST_COLLECTIONS = 'GET_LIST_COLLECTIONS'
 }
+
+export type PlaygroundRunParameters = {
+  codeToEvaluate: string;
+};

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -103,6 +103,9 @@ export default class MDBExtensionController implements vscode.Disposable {
     this.registerCommand('mdb.createPlayground', () =>
       this._playgroundController.createPlayground()
     );
+    this.registerCommand('mdb.createNewPlaygroundFromViewAction', () =>
+      this._playgroundController.createPlayground()
+    );
     this.registerCommand('mdb.runAllPlaygroundBlocks', () =>
       this._playgroundController.runAllPlaygroundBlocks()
     );

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -32,6 +32,7 @@ suite('Extension Test Suite', () => {
           'mdb.removeConnection',
           'mdb.openMongoDBShell',
           'mdb.createPlayground',
+          'mdb.createNewPlaygroundFromViewAction',
 
           // Tree view commands.
           'mdb.addConnection',

--- a/src/test/suite/language/languageServerController.test.ts
+++ b/src/test/suite/language/languageServerController.test.ts
@@ -1,17 +1,20 @@
-import * as vscode from 'vscode';
-import { PlaygroundController } from '../../../editors';
-import { LanguageServerController } from '../../../language';
-import ConnectionController from '../../../connectionController';
-import { StatusView } from '../../../views';
-import { StorageController } from '../../../storage';
-import { TestExtensionContext } from '../stubs';
 import { before, after } from 'mocha';
-
+const path = require('path');
+const fs = require('fs');
 const sinon = require('sinon');
 const chai = require('chai');
 const expect = chai.expect;
 
 chai.use(require('chai-as-promised'));
+
+import { PlaygroundController } from '../../../editors';
+import { LanguageServerController } from '../../../language';
+import ConnectionController from '../../../connectionController';
+import { StatusView } from '../../../views';
+import { StorageController } from '../../../storage';
+
+import { TestExtensionContext } from '../stubs';
+import { mdbTestExtension } from '../stubbableMdbExtension';
 
 const CONNECTION = {
   driverUrl: 'mongodb://localhost:27018',
@@ -83,5 +86,18 @@ suite('Language Server Controller Test Suite', () => {
     const result = await testLanguageServerController.executeAll('4 + 4');
 
     expect(result).to.be.equal('8');
+  });
+
+  test('the language server dependency bundle exists', () => {
+    const extensionPath = mdbTestExtension.testExtensionContext.extensionPath;
+
+    const languageServerModuleBundlePath = path.join(
+      extensionPath,
+      'dist',
+      'languageServer.js'
+    );
+
+    // eslint-disable-next-line no-sync
+    expect(fs.existsSync(languageServerModuleBundlePath)).to.equal(true);
   });
 });

--- a/src/test/suite/language/mongoDBService.test.ts
+++ b/src/test/suite/language/mongoDBService.test.ts
@@ -5,8 +5,10 @@ import {
 import { before } from 'mocha';
 
 const chai = require('chai');
+const path = require('path');
+const fs = require('fs');
 
-import MongoDBService from '../../../language/mongoDBService';
+import MongoDBService, { languageServerWorkerFileName } from '../../../language/mongoDBService';
 
 import { mdbTestExtension } from '../stubbableMdbExtension';
 
@@ -16,14 +18,25 @@ const INCREASED_TEST_TIMEOUT = 5000;
 
 suite('MongoDBService Test Suite', () => {
   const connection = {
-    console: { log: () => {} },
-    sendRequest: () => {},
-    sendNotification: () => {}
+    console: { log: (): void => {} },
+    sendRequest: (): void => {},
+    sendNotification: (): void => {}
   };
   const params = {
     connectionString: 'mongodb://localhost:27018',
     extensionPath: mdbTestExtension.testExtensionContext.extensionPath
   };
+
+  test('the language server worker dependency bundle exists', () => {
+    const languageServerModuleBundlePath = path.join(
+      mdbTestExtension.testExtensionContext.extensionPath,
+      'dist',
+      languageServerWorkerFileName
+    );
+
+    // eslint-disable-next-line no-sync
+    expect(fs.existsSync(languageServerModuleBundlePath)).to.equal(true);
+  });
 
   suite('Connect', () => {
     test('connect and disconnect from cli service provider', async () => {
@@ -545,8 +558,7 @@ suite('MongoDBService Test Suite', () => {
       const source = new CancellationTokenSource();
       const result = await testMongoDBService.executeAll(
         {
-          codeToEvaluate: '1 + 1',
-          extensionPath: mdbTestExtension.testExtensionContext.extensionPath
+          codeToEvaluate: '1 + 1'
         },
         source.token
       );
@@ -560,8 +572,7 @@ suite('MongoDBService Test Suite', () => {
       const source = new CancellationTokenSource();
       const result = await testMongoDBService.executeAll(
         {
-          codeToEvaluate: 'const x = 1; x + 2',
-          extensionPath: mdbTestExtension.testExtensionContext.extensionPath
+          codeToEvaluate: 'const x = 1; x + 2'
         },
         source.token
       );
@@ -575,8 +586,7 @@ suite('MongoDBService Test Suite', () => {
       const source = new CancellationTokenSource();
       const firstEvalResult = await testMongoDBService.executeAll(
         {
-          codeToEvaluate: 'const x = 1 + 1; x',
-          extensionPath: mdbTestExtension.testExtensionContext.extensionPath
+          codeToEvaluate: 'const x = 1 + 1; x'
         },
         source.token
       );
@@ -585,8 +595,7 @@ suite('MongoDBService Test Suite', () => {
 
       const secondEvalResult = await testMongoDBService.executeAll(
         {
-          codeToEvaluate: 'const x = 2 + 1; x',
-          extensionPath: mdbTestExtension.testExtensionContext.extensionPath
+          codeToEvaluate: 'const x = 2 + 1; x'
         },
         source.token
       );

--- a/src/test/suite/mdbExtensionController.test.ts
+++ b/src/test/suite/mdbExtensionController.test.ts
@@ -1140,6 +1140,25 @@ suite('MDBExtensionController Test Suite', () => {
       .then(done, done);
   });
 
+  test('mdb.createNewPlaygroundFromViewAction should create a MongoDB playground', (done) => {
+    const mockOpenTextDocument = sinon.fake.resolves('untitled');
+    sinon.replace(vscode.workspace, 'openTextDocument', mockOpenTextDocument);
+
+    const mockShowTextDocument = sinon.fake.resolves();
+    sinon.replace(vscode.window, 'showTextDocument', mockShowTextDocument);
+
+    vscode.commands
+      .executeCommand('mdb.createPlayground')
+      .then(() => {
+        assert(mockOpenTextDocument.firstArg.language === 'mongodb');
+        assert(
+          mockShowTextDocument.firstArg === 'untitled',
+          'Expected it to call vscode to show the playground'
+        );
+      })
+      .then(done, done);
+  });
+
   test('mdb.createPlayground command should create a MongoDB playground without template', (done) => {
     const mockOpenTextDocument = sinon.fake.resolves('untitled');
     sinon.replace(vscode.workspace, 'openTextDocument', mockOpenTextDocument);


### PR DESCRIPTION
This PR adds two tests to ensure the language server bundles exist.

This PR also cleans up our commands a bit, we were showing some of the commands from the tree view in the command palette, so now it won't show those. When we add future commands lets keep in mind to hide them from the command palette if we don't want them used there.
I'd like to clean up the commands a bit more and have them live in an a `commands.ts` file where they exist as variable we can reference. That can wait though.

Small text change on the create playground action in the tree view: 
<img width="443" alt="Screen Shot 2020-04-28 at 12 17 18 PM" src="https://user-images.githubusercontent.com/1791149/80476779-25ec0a00-894b-11ea-9ec9-68fd1d7e4d6c.png">
(It was MongoDB: Create New Playground)