### PR TITLE
VSCODE-87: Add message when successful uri connection

### DIFF
--- a/src/test/suite/views/webviewController.test.ts
+++ b/src/test/suite/views/webviewController.test.ts
@@ -171,7 +171,7 @@ suite('Connect Form View Test Suite', () => {
       html: '',
       postMessage: (message: any): void => {
         assert(message.connectionSuccess);
-        assert(message.connectionMessage === 'Connected.');
+        assert(message.connectionMessage === 'Successfully connected.');
 
         testConnectionController.disconnect();
         done();
@@ -396,7 +396,7 @@ suite('Connect Form View Test Suite', () => {
       }
     };
 
-    const fakeVSCodeExecuteCommand = sinon.fake();
+    const fakeVSCodeExecuteCommand = sinon.fake.resolves(false);
     sinon.replace(vscode.commands, 'executeCommand', fakeVSCodeExecuteCommand);
 
     const fakeVSCodeCreateWebviewPanel = sinon.fake.returns({

--- a/src/views/webview-app/components/app.tsx
+++ b/src/views/webview-app/components/app.tsx
@@ -94,7 +94,7 @@ const mapDispatchToProps: props = {
   onUriConnectedEvent: (
     successfullyConnected: boolean,
     connectionMessage: string
-  ): URIConnectionEventOccuredAction => ({
+  ): UriConnectionEventOccuredAction => ({
     type: ActionTypes.URI_CONNECTION_EVENT_OCCURED,
     successfullyConnected,
     connectionMessage

--- a/src/views/webview-app/components/app.tsx
+++ b/src/views/webview-app/components/app.tsx
@@ -8,7 +8,8 @@ import {
   ActionTypes,
   ConnectionEventOccuredAction,
   FilePickerActions,
-  FilePickerActionTypes
+  FilePickerActionTypes,
+  UriConnectionEventOccuredAction
 } from '../store/actions';
 import {
   MESSAGE_TYPES,
@@ -27,6 +28,10 @@ type props = {
     action: FilePickerActionTypes,
     files: string[] | undefined
   ) => void;
+  onUriConnectedEvent: (
+    successfullyConnected: boolean,
+    connectionMessage: string
+  ) => void;
 };
 
 class App extends React.Component<props> {
@@ -37,10 +42,18 @@ class App extends React.Component<props> {
 
       switch (message.command) {
         case MESSAGE_TYPES.CONNECT_RESULT:
-          this.props.onConnectedEvent(
-            message.connectionSuccess,
-            message.connectionMessage
-          );
+          if (message.isUriConnection) {
+            this.props.onUriConnectedEvent(
+              message.connectionSuccess,
+              message.connectionMessage
+            );
+          } else {
+            this.props.onConnectedEvent(
+              message.connectionSuccess,
+              message.connectionMessage
+            );
+          }
+
           return;
         case MESSAGE_TYPES.FILE_PICKER_RESULTS:
           this.props.onFilePickerEvent(message.action, message.files);
@@ -77,6 +90,14 @@ const mapDispatchToProps: props = {
   ): FilePickerActions => ({
     type: action,
     files
+  }),
+  onUriConnectedEvent: (
+    successfullyConnected: boolean,
+    connectionMessage: string
+  ): URIConnectionEventOccuredAction => ({
+    type: ActionTypes.URI_CONNECTION_EVENT_OCCURED,
+    successfullyConnected,
+    connectionMessage
   })
 };
 

--- a/src/views/webview-app/components/connect-form/connection-form.tsx
+++ b/src/views/webview-app/components/connect-form/connection-form.tsx
@@ -27,10 +27,12 @@ type stateProps = {
   errorMessage: string;
   isConnected: boolean;
   isConnecting: boolean;
+  isUriConnected: boolean;
   isHostChanged: boolean;
   isPortChanged: boolean;
   isValid: boolean;
   syntaxErrorMessage: string;
+  uriConnectionMessage: string;
 };
 
 type dispatchProps = {
@@ -128,6 +130,28 @@ class ConnectionForm extends React.Component<props> {
     );
   }
 
+  /**
+   * Renders a component with messages.
+   *
+   * @returns {React.Component}
+   */
+  renderURIConnectionMessage(): React.ReactNode {
+    const {
+      isUriConnected,
+      uriConnectionMessage
+    } = this.props;
+
+    if (isUriConnected) {
+      return (
+        <div className={styles['connection-message-container']}>
+          <div className={styles['connection-message-container-success']}>
+            <div className={styles['connection-message']}>{`${uriConnectionMessage} You may now close this window.`}</div>
+          </div>
+        </div>
+      );
+    }
+  }
+
   render(): React.ReactNode {
     const {
       currentConnection,
@@ -151,6 +175,7 @@ class ConnectionForm extends React.Component<props> {
             connect with a connection string
           </a>
         </div>
+        {this.renderURIConnectionMessage()}
         <div className={classnames(styles.fields)}>
           {this.renderHostnameArea()}
           {this.renderConnectionOptionsArea()}
@@ -174,10 +199,12 @@ const mapStateToProps = (state: AppState): stateProps => {
     errorMessage: state.errorMessage,
     isConnected: state.isConnected,
     isConnecting: state.isConnecting,
+    isUriConnected: state.isUriConnected,
     isHostChanged: state.isHostChanged,
     isPortChanged: state.isPortChanged,
     isValid: state.isValid,
-    syntaxErrorMessage: state.syntaxErrorMessage
+    syntaxErrorMessage: state.syntaxErrorMessage,
+    uriConnectionMessage: state.uriConnectionMessage
   };
 };
 

--- a/src/views/webview-app/extension-app-message-constants.ts
+++ b/src/views/webview-app/extension-app-message-constants.ts
@@ -23,6 +23,7 @@ export interface ConnectResultsMessage extends BasicWebviewMessage {
   command: MESSAGE_TYPES.CONNECT_RESULT;
   connectionSuccess: boolean;
   connectionMessage: string;
+  isUriConnection: boolean;
 }
 
 export interface OpenConnectionStringInputMessage extends BasicWebviewMessage {

--- a/src/views/webview-app/store/actions.ts
+++ b/src/views/webview-app/store/actions.ts
@@ -12,6 +12,7 @@ export enum ActionTypes {
   HOSTNAME_CHANGED = 'HOSTNAME_CHANGED',
   IS_SRV_RECORD_TOGGLED = 'IS_SRV_RECORD_TOGGLED',
   KERBEROS_PARAMETERS_CHANGED = 'KERBEROS_PARAMETERS_CHANGED',
+  LINK_CLICKED = 'LINK_CLICKED',
   LDAP_PASSWORD_CHANGED = 'LDAP_PASSWORD_CHANGED',
   LDAP_USERNAME_CHANGED = 'LDAP_USERNAME_CHANGED',
   ON_CHANGE_SSH_TUNNEL_IDENTITY_FILE = 'ON_CHANGE_SSH_TUNNEL_IDENTITY_FILE',
@@ -35,9 +36,9 @@ export enum ActionTypes {
   SSL_KEY_CHANGED = 'SSL_KEY_CHANGED',
   SSL_METHOD_CHANGED = 'SSL_METHOD_CHANGED',
   SSL_PASS_CHANGED = 'SSL_PASS_CHANGED',
+  URI_CONNECTION_EVENT_OCCURED = 'URI_CONNECTION_EVENT_OCCURED',
   USERNAME_CHANGED = 'USERNAME_CHANGED',
-  X509_USERNAME_CHANGED = 'X509_USERNAME_CHANGED',
-  LINK_CLICKED = 'LINK_CLICKED'
+  X509_USERNAME_CHANGED = 'X509_USERNAME_CHANGED'
 }
 
 export type FilePickerActionTypes =
@@ -217,6 +218,12 @@ export interface SSLPassChangedAction extends BaseAction {
   sslPass: string;
 }
 
+export interface UriConnectionEventOccuredAction extends BaseAction {
+  type: ActionTypes.URI_CONNECTION_EVENT_OCCURED;
+  successfullyConnected: boolean;
+  connectionMessage: string;
+}
+
 export interface UsernameChangedAction extends BaseAction {
   type: ActionTypes.USERNAME_CHANGED;
   mongodbUsername: string;
@@ -266,5 +273,6 @@ export type Actions =
   | SSLKeyChangedAction
   | SSLMethodChangedAction
   | SSLPassChangedAction
+  | UriConnectionEventOccuredAction
   | UsernameChangedAction
   | X509UsernameChangedAction;

--- a/src/views/webview-app/store/store.ts
+++ b/src/views/webview-app/store/store.ts
@@ -6,6 +6,7 @@ import ConnectionModel, {
 import SSL_METHODS from '../connection-model/constants/ssl-methods';
 import { MESSAGE_TYPES } from '../extension-app-message-constants';
 
+// eslint-disable-next-line no-var
 declare var acquireVsCodeApi: any;
 const vscode = acquireVsCodeApi();
 
@@ -14,11 +15,13 @@ export interface AppState {
   isValid: boolean;
   isConnecting: boolean;
   isConnected: boolean;
+  isUriConnected: boolean;
   errorMessage: string;
   syntaxErrorMessage: string;
   isHostChanged: boolean;
   isPortChanged: boolean;
   savedMessage: string;
+  uriConnectionMessage: string;
 }
 
 export const initialState = {
@@ -26,11 +29,13 @@ export const initialState = {
   isValid: true,
   isConnecting: false,
   isConnected: false,
+  isUriConnected: false,
   errorMessage: '',
   syntaxErrorMessage: '',
   isHostChanged: false,
   isPortChanged: false,
-  savedMessage: ''
+  savedMessage: '',
+  uriConnectionMessage: ''
 };
 
 const showFilePicker = (
@@ -123,6 +128,7 @@ export const rootReducer = (
         ...state,
         isValid: true,
         isConnected: false,
+        isUriConnected: false,
         errorMessage: '',
         syntaxErrorMessage: ''
       };
@@ -240,7 +246,8 @@ export const rootReducer = (
       });
 
       return {
-        ...state
+        ...state,
+        isUriConnected: false
       };
 
     case ActionTypes.PASSWORD_CHANGED:
@@ -399,6 +406,13 @@ export const rootReducer = (
           ...state.currentConnection,
           sslPass: action.sslPass
         }
+      };
+
+    case ActionTypes.URI_CONNECTION_EVENT_OCCURED:
+      return {
+        ...state,
+        isUriConnected: action.successfullyConnected,
+        uriConnectionMessage: action.connectionMessage
       };
 
     case ActionTypes.USERNAME_CHANGED:

--- a/src/views/webviewController.ts
+++ b/src/views/webviewController.ts
@@ -78,7 +78,7 @@ export default class WebviewController {
                 command: MESSAGE_TYPES.CONNECT_RESULT,
                 connectionSuccess,
                 connectionMessage: connectionSuccess
-                  ? 'Connected.'
+                  ? 'Successfully connected.'
                   : 'Unable to connect.'
               });
             },
@@ -109,7 +109,16 @@ export default class WebviewController {
           });
         return;
       case MESSAGE_TYPES.OPEN_CONNECTION_STRING_INPUT:
-        vscode.commands.executeCommand('mdb.connectWithURI');
+        vscode.commands.executeCommand('mdb.connectWithURI').then(connectionSuccess => {
+          if (connectionSuccess) {
+            panel.webview.postMessage({
+              command: MESSAGE_TYPES.CONNECT_RESULT,
+              connectionSuccess: true,
+              connectionMessage: 'Successfully connected.',
+              isUriConnection: true
+            });
+          }
+        });
 
         return;
       case MESSAGE_TYPES.LINK_CLICKED:


### PR DESCRIPTION
https://jira.mongodb.org/browse/VSCODE-87

This PR adds a message on successful uri connection to the connection form just for some visual feedback. It does not show anything if the connection event was unsuccessful (vscode shows an information message for that in the bottom left). The message is hidden when connect with uri is clicked again, or an action is done on the form. We can give more feedback later on, I thought this will be a nice quick solution for now. Claudia has some thoughts/designs for this connect form so there's a good change this will change around.

![May-02-2020 16-20-13](https://user-images.githubusercontent.com/1791149/80866818-23621b00-8c91-11ea-8304-411e90ef69cf.gif)
