### PR TITLE
Vscode 102 coll names completion improvement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2246,6 +2246,83 @@
         "resolve": "^1.12.0"
       }
     },
+    "babel-helper-evaluate-path": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.5.0.tgz",
+      "integrity": "sha512-mUh0UhS607bGh5wUMAQfOpt2JX2ThXMtppHRdRU1kL7ZLRWIXxoV2UIV1r2cAeeNeU1M5SB5/RSUgUxrK8yOkA=="
+    },
+    "babel-helper-flip-expressions": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.4.3.tgz",
+      "integrity": "sha1-NpZzahKKwYvCUlS19AoizrPB0/0="
+    },
+    "babel-helper-is-nodes-equiv": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
+      "integrity": "sha1-NOmzALFHnd2Y7HfqC76TQt/jloQ="
+    },
+    "babel-helper-is-void-0": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/babel-helper-is-void-0/-/babel-helper-is-void-0-0.4.3.tgz",
+      "integrity": "sha1-fZwBtFYee5Xb2g9u7kj1tg5nMT4="
+    },
+    "babel-helper-mark-eval-scopes": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.4.3.tgz",
+      "integrity": "sha1-0kSjvvmESHJgP/tG4izorN9VFWI="
+    },
+    "babel-helper-remove-or-void": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.4.3.tgz",
+      "integrity": "sha1-pPA7QAd6D/6I5F0HAQ3uJB/1rmA="
+    },
+    "babel-helper-to-multiple-sequence-expressions": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.5.0.tgz",
+      "integrity": "sha512-m2CvfDW4+1qfDdsrtf4dwOslQC3yhbgyBFptncp4wvtdrDHqueW7slsYv4gArie056phvQFhT2nRcGS4bnm6mA=="
+    },
+    "babel-minify": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/babel-minify/-/babel-minify-0.5.1.tgz",
+      "integrity": "sha512-ftEYu5OCDXEqaX/eINIaekPgkCaVPJNwFHzXKKARnRLggK8g4a9dEOflLKDgRNYOwhcLVoicUchZG6FYyOpqSA==",
+      "requires": {
+        "@babel/core": "^7.1.0",
+        "babel-preset-minify": "^0.5.1",
+        "fs-readdir-recursive": "^1.1.0",
+        "lodash": "^4.17.11",
+        "mkdirp": "^0.5.1",
+        "util.promisify": "^1.0.0",
+        "yargs-parser": "^10.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+        },
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "yargs-parser": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+          "requires": {
+            "camelcase": "^4.1.0"
+          }
+        }
+      }
+    },
     "babel-plugin-emotion": {
       "version": "10.0.33",
       "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.33.tgz",
@@ -2299,10 +2376,184 @@
         }
       }
     },
+    "babel-plugin-minify-builtins": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-builtins/-/babel-plugin-minify-builtins-0.5.0.tgz",
+      "integrity": "sha512-wpqbN7Ov5hsNwGdzuzvFcjgRlzbIeVv1gMIlICbPj0xkexnfoIDe7q+AZHMkQmAE/F9R5jkrB6TLfTegImlXag=="
+    },
+    "babel-plugin-minify-constant-folding": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.5.0.tgz",
+      "integrity": "sha512-Vj97CTn/lE9hR1D+jKUeHfNy+m1baNiJ1wJvoGyOBUx7F7kJqDZxr9nCHjO/Ad+irbR3HzR6jABpSSA29QsrXQ==",
+      "requires": {
+        "babel-helper-evaluate-path": "^0.5.0"
+      }
+    },
+    "babel-plugin-minify-dead-code-elimination": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.5.1.tgz",
+      "integrity": "sha512-x8OJOZIrRmQBcSqxBcLbMIK8uPmTvNWPXH2bh5MDCW1latEqYiRMuUkPImKcfpo59pTUB2FT7HfcgtG8ZlR5Qg==",
+      "requires": {
+        "babel-helper-evaluate-path": "^0.5.0",
+        "babel-helper-mark-eval-scopes": "^0.4.3",
+        "babel-helper-remove-or-void": "^0.4.3",
+        "lodash": "^4.17.11"
+      }
+    },
+    "babel-plugin-minify-flip-comparisons": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.4.3.tgz",
+      "integrity": "sha1-AMqHDLjxO0XAOLPB68DyJyk8llo=",
+      "requires": {
+        "babel-helper-is-void-0": "^0.4.3"
+      }
+    },
+    "babel-plugin-minify-guarded-expressions": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.4.4.tgz",
+      "integrity": "sha512-RMv0tM72YuPPfLT9QLr3ix9nwUIq+sHT6z8Iu3sLbqldzC1Dls8DPCywzUIzkTx9Zh1hWX4q/m9BPoPed9GOfA==",
+      "requires": {
+        "babel-helper-evaluate-path": "^0.5.0",
+        "babel-helper-flip-expressions": "^0.4.3"
+      }
+    },
+    "babel-plugin-minify-infinity": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.4.3.tgz",
+      "integrity": "sha1-37h2obCKBldjhO8/kuZTumB7Oco="
+    },
+    "babel-plugin-minify-mangle-names": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.5.0.tgz",
+      "integrity": "sha512-3jdNv6hCAw6fsX1p2wBGPfWuK69sfOjfd3zjUXkbq8McbohWy23tpXfy5RnToYWggvqzuMOwlId1PhyHOfgnGw==",
+      "requires": {
+        "babel-helper-mark-eval-scopes": "^0.4.3"
+      }
+    },
+    "babel-plugin-minify-numeric-literals": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.4.3.tgz",
+      "integrity": "sha1-jk/VYcefeAEob/YOjF/Z3u6TwLw="
+    },
+    "babel-plugin-minify-replace": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.5.0.tgz",
+      "integrity": "sha512-aXZiaqWDNUbyNNNpWs/8NyST+oU7QTpK7J9zFEFSA0eOmtUNMU3fczlTTTlnCxHmq/jYNFEmkkSG3DDBtW3Y4Q=="
+    },
+    "babel-plugin-minify-simplify": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.5.1.tgz",
+      "integrity": "sha512-OSYDSnoCxP2cYDMk9gxNAed6uJDiDz65zgL6h8d3tm8qXIagWGMLWhqysT6DY3Vs7Fgq7YUDcjOomhVUb+xX6A==",
+      "requires": {
+        "babel-helper-evaluate-path": "^0.5.0",
+        "babel-helper-flip-expressions": "^0.4.3",
+        "babel-helper-is-nodes-equiv": "^0.0.1",
+        "babel-helper-to-multiple-sequence-expressions": "^0.5.0"
+      }
+    },
+    "babel-plugin-minify-type-constructors": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.4.3.tgz",
+      "integrity": "sha1-G8bxW4f3qxCF1CszC3F2V6IVZQA=",
+      "requires": {
+        "babel-helper-is-void-0": "^0.4.3"
+      }
+    },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
+    },
+    "babel-plugin-transform-inline-consecutive-adds": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.4.3.tgz",
+      "integrity": "sha1-Mj1Ho+pjqDp6w8gRro5pQfrysNE="
+    },
+    "babel-plugin-transform-member-expression-literals": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.9.4.tgz",
+      "integrity": "sha1-NwOcmgwzE6OUlfqsL/OmtbnQOL8="
+    },
+    "babel-plugin-transform-merge-sibling-variables": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.9.4.tgz",
+      "integrity": "sha1-hbQi/DN3tEnJ0c3kQIcgNTJAHa4="
+    },
+    "babel-plugin-transform-minify-booleans": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.9.4.tgz",
+      "integrity": "sha1-rLs+VqNVXdI5KOS1gtKFFi3SsZg="
+    },
+    "babel-plugin-transform-property-literals": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.9.4.tgz",
+      "integrity": "sha1-mMHSHiVXNlc/k+zlRFn2ziSYXTk=",
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
+    "babel-plugin-transform-regexp-constructors": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.4.3.tgz",
+      "integrity": "sha1-WLd3W2OvzzMyj66aX4j71PsLSWU="
+    },
+    "babel-plugin-transform-remove-console": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz",
+      "integrity": "sha1-uYA2DAZzhOJLNXpYjYB9PINSd4A="
+    },
+    "babel-plugin-transform-remove-debugger": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.9.4.tgz",
+      "integrity": "sha1-QrcnYxyXl44estGZp67IShgznvI="
+    },
+    "babel-plugin-transform-remove-undefined": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.5.0.tgz",
+      "integrity": "sha512-+M7fJYFaEE/M9CXa0/IRkDbiV3wRELzA1kKQFCJ4ifhrzLKn/9VCCgj9OFmYWwBd8IB48YdgPkHYtbYq+4vtHQ==",
+      "requires": {
+        "babel-helper-evaluate-path": "^0.5.0"
+      }
+    },
+    "babel-plugin-transform-simplify-comparison-operators": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.9.4.tgz",
+      "integrity": "sha1-9ir+CWyrDh9ootdT/fKDiIRxzrk="
+    },
+    "babel-plugin-transform-undefined-to-void": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.4.tgz",
+      "integrity": "sha1-viQcqBQEAwZ4t0hxcyK4nQyP4oA="
+    },
+    "babel-preset-minify": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-minify/-/babel-preset-minify-0.5.1.tgz",
+      "integrity": "sha512-1IajDumYOAPYImkHbrKeiN5AKKP9iOmRoO2IPbIuVp0j2iuCcj0n7P260z38siKMZZ+85d3mJZdtW8IgOv+Tzg==",
+      "requires": {
+        "babel-plugin-minify-builtins": "^0.5.0",
+        "babel-plugin-minify-constant-folding": "^0.5.0",
+        "babel-plugin-minify-dead-code-elimination": "^0.5.1",
+        "babel-plugin-minify-flip-comparisons": "^0.4.3",
+        "babel-plugin-minify-guarded-expressions": "^0.4.4",
+        "babel-plugin-minify-infinity": "^0.4.3",
+        "babel-plugin-minify-mangle-names": "^0.5.0",
+        "babel-plugin-minify-numeric-literals": "^0.4.3",
+        "babel-plugin-minify-replace": "^0.5.0",
+        "babel-plugin-minify-simplify": "^0.5.1",
+        "babel-plugin-minify-type-constructors": "^0.4.3",
+        "babel-plugin-transform-inline-consecutive-adds": "^0.4.3",
+        "babel-plugin-transform-member-expression-literals": "^6.9.4",
+        "babel-plugin-transform-merge-sibling-variables": "^6.9.4",
+        "babel-plugin-transform-minify-booleans": "^6.9.4",
+        "babel-plugin-transform-property-literals": "^6.9.4",
+        "babel-plugin-transform-regexp-constructors": "^0.4.3",
+        "babel-plugin-transform-remove-console": "^6.9.4",
+        "babel-plugin-transform-remove-debugger": "^6.9.4",
+        "babel-plugin-transform-remove-undefined": "^0.5.0",
+        "babel-plugin-transform-simplify-comparison-operators": "^6.9.4",
+        "babel-plugin-transform-undefined-to-void": "^6.9.4",
+        "lodash": "^4.17.11"
+      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -3742,7 +3993,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -4390,7 +4640,6 @@
       "version": "1.17.4",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
       "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
-      "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
@@ -4409,7 +4658,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -5853,6 +6101,11 @@
         "universalify": "^0.1.0"
       }
     },
+    "fs-readdir-recursive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA=="
+    },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
@@ -5880,8 +6133,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -6228,7 +6480,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -6247,8 +6498,7 @@
     "has-symbols": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-      "dev": true
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
     },
     "has-to-string-tag-x": {
       "version": "1.4.1",
@@ -6800,8 +7050,7 @@
     "is-callable": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
-      "dev": true
+      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
     },
     "is-data-descriptor": {
       "version": "0.1.4",
@@ -6832,8 +7081,7 @@
     "is-date-object": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
-      "dev": true
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -6968,7 +7216,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
       "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
-      "dev": true,
       "requires": {
         "has": "^1.0.3"
       }
@@ -7003,7 +7250,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
       "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.1"
       }
@@ -10170,14 +10416,12 @@
     "object-inspect": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
-      "dev": true
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
     },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object-visit": {
       "version": "1.0.1",
@@ -10192,7 +10436,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "function-bind": "^1.1.1",
@@ -10228,7 +10471,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
       "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1"
@@ -12478,7 +12720,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
       "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "function-bind": "^1.1.1"
@@ -12488,7 +12729,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
       "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "function-bind": "^1.1.1"
@@ -13284,6 +13524,17 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "util.promisify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.1.tgz",
+      "integrity": "sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.2",
+        "has-symbols": "^1.0.1",
+        "object.getownpropertydescriptors": "^2.1.0"
+      }
     },
     "uuid": {
       "version": "7.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -123,22 +123,30 @@
       }
     },
     "@babel/generator": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.4.tgz",
-      "integrity": "sha512-PwhclGdRpNAf3IxZb0YVuITPZmmrXz9zf6fH8lT4XbrmfQKr6ryBzhv593P5C6poJRciFCL/eHGW2NuGrgEyxA==",
-      "dev": true,
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.6.tgz",
+      "integrity": "sha512-+htwWKJbH2bL72HRluF8zumBxzuX0ZZUFl3JLNyoUjM/Ho8wnVpPXM6aUz8cfKDqQ/h7zHqKt4xzJteUosckqQ==",
       "requires": {
-        "@babel/types": "^7.8.3",
+        "@babel/types": "^7.9.6",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.13",
         "source-map": "^0.5.0"
       },
       "dependencies": {
+        "@babel/types": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.6.tgz",
+          "integrity": "sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.9.5",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
@@ -178,14 +186,25 @@
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
-      "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
-      "dev": true,
+      "version": "7.9.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
+      "integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
       "requires": {
         "@babel/helper-get-function-arity": "^7.8.3",
         "@babel/template": "^7.8.3",
-        "@babel/types": "^7.8.3"
+        "@babel/types": "^7.9.5"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.6.tgz",
+          "integrity": "sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.9.5",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-get-function-arity": {
@@ -492,9 +511,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
-      "integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw=="
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.6.tgz",
+      "integrity": "sha512-AoeIEJn8vt+d/6+PXDRPaksYhnlbMIiejioBZvvMQsOjW/JYK6k/0dKnvvP3EhK5GfMBWDPtrxRtegWdAcdq9Q=="
     },
     "@babel/plugin-syntax-typescript": {
       "version": "7.8.3",
@@ -572,17 +591,16 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.4.tgz",
-      "integrity": "sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==",
-      "dev": true,
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.6.tgz",
+      "integrity": "sha512-b3rAHSjbxy6VEAvlxM8OV/0X4XrG72zoxme6q1MOoe2vd0bEc+TwayhuC1+Dfgqh1QEG+pj7atQqvUprHIccsg==",
       "requires": {
         "@babel/code-frame": "^7.8.3",
-        "@babel/generator": "^7.8.4",
-        "@babel/helper-function-name": "^7.8.3",
+        "@babel/generator": "^7.9.6",
+        "@babel/helper-function-name": "^7.9.5",
         "@babel/helper-split-export-declaration": "^7.8.3",
-        "@babel/parser": "^7.8.4",
-        "@babel/types": "^7.8.3",
+        "@babel/parser": "^7.9.6",
+        "@babel/types": "^7.9.6",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.13"
@@ -592,29 +610,28 @@
           "version": "7.8.3",
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
           "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-          "dev": true,
           "requires": {
             "@babel/highlight": "^7.8.3"
           }
         },
         "@babel/highlight": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-          "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-          "dev": true,
+          "version": "7.9.0",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
+          "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
           "requires": {
+            "@babel/helper-validator-identifier": "^7.9.0",
             "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
             "js-tokens": "^4.0.0"
           }
         },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
+        "@babel/types": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.6.tgz",
+          "integrity": "sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==",
           "requires": {
-            "ms": "^2.1.1"
+            "@babel/helper-validator-identifier": "^7.9.5",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
           }
         }
       }
@@ -5349,11 +5366,6 @@
           "dev": true
         }
       }
-    },
-    "estraverse": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.1.0.tgz",
-      "integrity": "sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw=="
     },
     "esutils": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -584,6 +584,7 @@
     "@mongosh/service-provider-server": "0.0.1-alpha.13",
     "@mongosh/shell-api": "0.0.1-alpha.13",
     "analytics-node": "^3.4.0-beta.1",
+    "babel-minify": "^0.5.1",
     "bson": "^4.0.3",
     "classnames": "^2.2.6",
     "debug": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -586,7 +586,6 @@
     "@mongosh/service-provider-server": "0.0.1-alpha.13",
     "@mongosh/shell-api": "0.0.1-alpha.13",
     "analytics-node": "^3.4.0-beta.1",
-    "babel-minify": "^0.5.1",
     "bson": "^4.0.3",
     "classnames": "^2.2.6",
     "debug": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -576,6 +576,8 @@
     }
   },
   "dependencies": {
+    "@babel/parser": "^7.9.6",
+    "@babel/traverse": "^7.9.6",
     "@fortawesome/fontawesome-svg-core": "^1.2.28",
     "@fortawesome/free-solid-svg-icons": "^5.13.0",
     "@fortawesome/react-fontawesome": "^0.1.9",
@@ -589,8 +591,6 @@
     "classnames": "^2.2.6",
     "debug": "^4.1.1",
     "dotenv": "^8.2.0",
-    "esprima": "^4.0.1",
-    "estraverse": "^5.1.0",
     "mongodb-connection-model": "^16.0.0",
     "mongodb-data-service": "^16.6.5",
     "mongodb-ns": "^2.2.0",

--- a/src/language/languageServerController.ts
+++ b/src/language/languageServerController.ts
@@ -104,7 +104,7 @@ export default class LanguageServerController {
     );
   }
 
-  activate(): void {
+  public activate(): void {
     // Start the client. This will also launch the server
     const disposable = this.client.start();
 
@@ -124,7 +124,7 @@ export default class LanguageServerController {
     });
   }
 
-  deactivate(): void {
+  public deactivate(): void {
     if (!this.client) {
       return undefined;
     }
@@ -133,7 +133,7 @@ export default class LanguageServerController {
     this.client.stop();
   }
 
-  executeAll(codeToEvaluate): Promise<any> {
+  public executeAll(codeToEvaluate: string): Promise<any> {
     return this.client.onReady().then(() => {
       // Instantiate a new CancellationTokenSource object
       // that generates a cancellation token for each run of a playground
@@ -152,7 +152,7 @@ export default class LanguageServerController {
     });
   }
 
-  connectToServiceProvider(params: {
+  public connectToServiceProvider(params: {
     connectionString?: string;
     connectionOptions?: any;
     extensionPath: string;
@@ -165,7 +165,7 @@ export default class LanguageServerController {
     });
   }
 
-  disconnectFromServiceProvider(): Promise<any> {
+  public disconnectFromServiceProvider(): Promise<any> {
     return this.client.onReady().then(async () => {
       return this.client.sendRequest(
         ServerCommands.DISCONNECT_TO_SERVICE_PROVIDER
@@ -173,7 +173,7 @@ export default class LanguageServerController {
     });
   }
 
-  startStreamLanguageServerLogs(): Promise<boolean> {
+  public startStreamLanguageServerLogs(): Promise<boolean> {
     const socketPort = workspace
       .getConfiguration('languageServerExample')
       .get('port', 7000);
@@ -183,7 +183,7 @@ export default class LanguageServerController {
     return Promise.resolve(true);
   }
 
-  cancelAll(): Promise<boolean> {
+  public cancelAll(): Promise<boolean> {
     return new Promise((resolve) => {
       // Send a request for cancellation. As a result
       // the associated CancellationToken will be notified of the cancellation,

--- a/src/language/mongoDBService.ts
+++ b/src/language/mongoDBService.ts
@@ -409,32 +409,40 @@ export default class MongoDBService {
         }
 
         if (state.isObjectKey) {
-          this._connection.console.log('ESPRIMA found field completion');
+          this._connection.console.log('ESPRIMA found field names completion');
 
           return resolve(this._cachedFields[namespace]);
         }
       }
 
       if (state.isShellMethod && state.collectionName) {
-        this._connection.console.log('ESPRIMA found shell completion');
+        this._connection.console.log(
+          'ESPRIMA found shell collection methods completion'
+        );
 
         return resolve(this._cachedShellSymbols['Collection']);
       }
 
       if (state.isAggregationCursor) {
-        this._connection.console.log('ESPRIMA found aggregation cursor');
+        this._connection.console.log(
+          'ESPRIMA found shell aggregation cursor methods completion'
+        );
 
         return resolve(this._cachedShellSymbols['AggregationCursor']);
       }
 
       if (state.isFindCursor) {
-        this._connection.console.log('ESPRIMA found cursor');
+        this._connection.console.log(
+          'ESPRIMA found shell cursor methods completion'
+        );
 
         return resolve(this._cachedShellSymbols['Cursor']);
       }
 
       if (state.isDbCallExpression) {
-        this._connection.console.log('ESPRIMA found collection db symbol');
+        this._connection.console.log(
+          'ESPRIMA found shell db methods completion'
+        );
 
         let dbCompletions: any = [...this._cachedShellSymbols['Database']];
 

--- a/src/language/mongoDBService.ts
+++ b/src/language/mongoDBService.ts
@@ -336,6 +336,10 @@ export default class MongoDBService {
     collections: Array<any>,
     position: { line: number; character: number }
   ): any {
+    if (!collections) {
+      return [];
+    }
+
     return collections.map((item) => {
       const line = position.line;
       const character = position.character;
@@ -411,6 +415,12 @@ export default class MongoDBService {
         }
       }
 
+      if (state.isShellMethod && state.collectionName) {
+        this._connection.console.log('ESPRIMA found shell completion');
+
+        return resolve(this._cachedShellSymbols['Collection']);
+      }
+
       if (state.isAggregationCursor) {
         this._connection.console.log('ESPRIMA found aggregation cursor');
 
@@ -421,12 +431,6 @@ export default class MongoDBService {
         this._connection.console.log('ESPRIMA found cursor');
 
         return resolve(this._cachedShellSymbols['Cursor']);
-      }
-
-      if (state.isMemberExpression && state.collectionName) {
-        this._connection.console.log('ESPRIMA found shell completion');
-
-        return resolve(this._cachedShellSymbols['Collection']);
       }
 
       if (state.isDbCallExpression) {
@@ -451,7 +455,7 @@ export default class MongoDBService {
         return resolve(dbCompletions);
       }
 
-      if (state.hasDbCallExpression && state.databaseName) {
+      if (state.isCollectionName && state.databaseName) {
         this._connection.console.log(
           'ESPRIMA found collection names completion'
         );

--- a/src/language/visitor.ts
+++ b/src/language/visitor.ts
@@ -127,10 +127,16 @@ export class Visitor {
       textFromEditor,
       position
     );
-    const ast = parser.parse(textWithPlaceholder, {
-      // Parse in strict mode and allow module declarations
-      sourceType: 'module'
-    });
+    let ast: any;
+
+    try {
+      ast = parser.parse(textWithPlaceholder, {
+        // Parse in strict mode and allow module declarations
+        sourceType: 'module'
+      });
+    } catch (error) {
+      return this._state;
+    }
 
     const self = this;
 

--- a/src/language/visitor.ts
+++ b/src/language/visitor.ts
@@ -1,5 +1,3 @@
-import * as util from 'util';
-
 import * as parser from '@babel/parser';
 import traverse from '@babel/traverse';
 
@@ -69,25 +67,9 @@ export class Visitor {
     }
   }
 
-  private visitSequenceExpression(node: any): void {
-    if (this.checkIsDbCall(node)) {
-      this._state.isDbCallExpression = true;
-    }
-
-    if (this.checkIsCollectionName(node)) {
-      this._state.isCollectionName = true;
-    }
-  }
-
   private visitObjectExpression(node: any): void {
     if (this.checkIsObjectKey(node)) {
       this._state.isObjectKey = true;
-    }
-  }
-
-  private visitVariableDeclaration(node: any): void {
-    if (this.checkIsDbCall(node)) {
-      this._state.isDbCallExpression = true;
     }
   }
 
@@ -96,7 +78,6 @@ export class Visitor {
     position: { line: number; character: number }
   ): string {
     const textLines = textFromEditor.split('\n');
-
     // Text before the current character
     const prefix =
       position.character === 0
@@ -142,8 +123,6 @@ export class Visitor {
 
     traverse(ast, {
       enter(path) {
-        // console.log(`node: ${util.inspect(path.node)}`);
-
         switch (path.node.type) {
           case 'CallExpression':
             self.visitCallExpression(path.node);
@@ -154,20 +133,12 @@ export class Visitor {
           case 'ExpressionStatement':
             self.visitExpressionStatement(path.node);
             break;
-          case 'SequenceExpression':
-            self.visitSequenceExpression(path.node);
-            break;
           case 'ObjectExpression':
             self.visitObjectExpression(path.node);
-            break;
-          case 'VariableDeclaration':
-            self.visitVariableDeclaration(path.node);
             break;
         }
       }
     });
-
-    // console.log(`BABEL completion state: ${util.inspect(this._state)}`);
 
     return this._state;
   }

--- a/src/language/visitor.ts
+++ b/src/language/visitor.ts
@@ -1,6 +1,8 @@
 import * as parser from '@babel/parser';
 import traverse from '@babel/traverse';
 
+const PLACEHOLDER = 'TRIGGER_CHARACTER';
+
 export type CompletionState = {
   databaseName: string | null;
   collectionName: string | null;
@@ -17,12 +19,10 @@ export class Visitor {
   _connection: any;
   _state: CompletionState;
   _position: { line: number; character: number };
-  _placeholder: string;
 
   constructor() {
     this._state = this.getDefaultNodesValues();
     this._position = { line: 0, character: 0 };
-    this._placeholder = 'TRIGGER_CHARACTER';
   }
 
   private visitCallExpression(node: any): void {
@@ -92,7 +92,7 @@ export class Visitor {
     // Use a placeholder to handle a trigger dot
     // and track of the current character position
     // TODO: check the absolute character position
-    textLines[position.line] = `${prefix}${this._placeholder}${postfix}`;
+    textLines[position.line] = `${prefix}${PLACEHOLDER}${postfix}`;
 
     return textLines.join('\n');
   }
@@ -165,7 +165,7 @@ export class Visitor {
         node.arguments[0] &&
         node.arguments[0].type === 'StringLiteral' &&
         node.arguments[0].value &&
-        node.arguments[0].value.includes(this._placeholder)) ||
+        node.arguments[0].value.includes(PLACEHOLDER)) ||
       (node.arguments &&
         node.arguments.length === 1 &&
         node.arguments[0] &&
@@ -173,7 +173,7 @@ export class Visitor {
         node.arguments[0].quasis &&
         node.arguments[0].quasis.length === 1 &&
         node.arguments[0].quasis[0].value?.raw &&
-        node.arguments[0].quasis[0].value?.raw.includes(this._placeholder))
+        node.arguments[0].quasis[0].value?.raw.includes(PLACEHOLDER))
     ) {
       return true;
     }
@@ -196,7 +196,7 @@ export class Visitor {
   private checkIsObjectKey(node: any): boolean {
     if (
       node.properties.find(
-        (item) => item.key.name && item.key.name.includes(this._placeholder)
+        (item) => item.key.name && item.key.name.includes(PLACEHOLDER)
       )
     ) {
       return true;
@@ -211,13 +211,13 @@ export class Visitor {
         node.object.name === 'db' &&
         node.property &&
         node.property.name &&
-        node.property.name.includes(this._placeholder)) ||
+        node.property.name.includes(PLACEHOLDER)) ||
       (node.callee &&
         node.callee.object &&
         node.callee.object.object &&
         node.callee.object.object.name === 'db' &&
         node.callee.object.property.name &&
-        node.callee.object.property.name.includes(this._placeholder) &&
+        node.callee.object.property.name.includes(PLACEHOLDER) &&
         node.callee.property)
     ) {
       return true;
@@ -231,7 +231,7 @@ export class Visitor {
       node.object &&
       node.object.type === 'CallExpression' &&
       node.property.name &&
-      node.property.name.includes(this._placeholder) &&
+      node.property.name.includes(PLACEHOLDER) &&
       node.object.callee &&
       node.object.callee.property.name === 'aggregate'
     ) {
@@ -246,7 +246,7 @@ export class Visitor {
       node.object &&
       node.object.type === 'CallExpression' &&
       node.property.name &&
-      node.property.name.includes(this._placeholder) &&
+      node.property.name.includes(PLACEHOLDER) &&
       node.object.callee &&
       node.object.callee.property.name === 'find'
     ) {
@@ -291,7 +291,7 @@ export class Visitor {
       node.object.object &&
       node.object.object.name === 'db' &&
       node.property.name &&
-      node.property.name.includes(this._placeholder)
+      node.property.name.includes(PLACEHOLDER)
     ) {
       return true;
     }

--- a/src/language/visitor.ts
+++ b/src/language/visitor.ts
@@ -84,10 +84,6 @@ export class Visitor {
 
     estraverse.traverse(ast, {
       enter: (node: any) => {
-        this._connection.console.log(
-          `ESPRIMA visit node ${util.inspect(node.type)}`
-        );
-
         switch (node.type) {
           case esprima.Syntax.CallExpression:
             this.visitCallExpression(node);

--- a/src/test/suite/language/mongoDBService.test.ts
+++ b/src/test/suite/language/mongoDBService.test.ts
@@ -882,6 +882,72 @@ suite('MongoDBService Test Suite', () => {
       );
     });
 
+    test('provide collection names completion at the same line block comment starts', async () => {
+      testMongoDBService.updateCurrentSessionCollections('test', [
+        {
+          name: 'collection'
+        }
+      ]);
+
+      const result = await testMongoDBService.provideCompletionItems(
+        ["use('test');", '', 'db. /*', '* Comment', '*/'].join('\n'),
+        { line: 2, character: 3 }
+      );
+      const findCollectionCompletion = result.find(
+        (itme: any) => itme.label === 'collection'
+      );
+
+      expect(findCollectionCompletion).to.have.property('label', 'collection');
+      expect(findCollectionCompletion).to.have.property(
+        'kind',
+        CompletionItemKind.Folder
+      );
+    });
+
+    test('provide collection names completion at the same line block comment ends', async () => {
+      testMongoDBService.updateCurrentSessionCollections('test', [
+        {
+          name: 'collection'
+        }
+      ]);
+
+      const result = await testMongoDBService.provideCompletionItems(
+        ["use('test')", '', '/*', '  * Comment', '*/ db.'].join('\n'),
+        { line: 4, character: 6 }
+      );
+      const findCollectionCompletion = result.find(
+        (itme: any) => itme.label === 'collection'
+      );
+
+      expect(findCollectionCompletion).to.have.property('label', 'collection');
+      expect(findCollectionCompletion).to.have.property(
+        'kind',
+        CompletionItemKind.Folder
+      );
+    });
+
+    test('provide collection names completion at the same line with end line comment', async () => {
+      testMongoDBService.updateCurrentSessionCollections('test', [
+        {
+          name: 'collection'
+        }
+      ]);
+
+      const result = await testMongoDBService.provideCompletionItems(
+        ["use('test')", '', 'db. // Comment'].join('\n'),
+        { line: 2, character: 3 }
+      );
+      const findCollectionCompletion = result.find(
+        (itme: any) => itme.label === 'collection'
+      );
+
+      expect(findCollectionCompletion).to.have.property('label', 'collection');
+      expect(findCollectionCompletion).to.have.property(
+        'kind',
+        CompletionItemKind.Folder
+      );
+    });
+
     test('provide collection names completion if code without a semicolon', async () => {
       testMongoDBService.updateCurrentSessionCollections('test', [
         {

--- a/src/test/suite/language/mongoDBService.test.ts
+++ b/src/test/suite/language/mongoDBService.test.ts
@@ -491,7 +491,7 @@ suite('MongoDBService Test Suite', () => {
 
       expect(findCollectionCompletion).to.have.property(
         'kind',
-        CompletionItemKind.Property
+        CompletionItemKind.Folder
       );
     });
 
@@ -512,15 +512,15 @@ suite('MongoDBService Test Suite', () => {
 
       expect(findCollectionCompletion).to.have.property(
         'kind',
-        CompletionItemKind.Property
+        CompletionItemKind.Folder
       );
 
       expect(findCollectionCompletion)
         .to.have.property('textEdit')
-        .that.has.property('newText', "db['coll-name']");
+        .that.has.property('newText', "use('berlin'); db['coll-name']");
     });
 
-    test('provide collection names and shell db symbol completion', async () => {
+    test('provide collection names and shell db symbol completion for db symbol', async () => {
       testMongoDBService.updateCurrentSessionCollections('berlin', [
         {
           name: 'coll-name'
@@ -540,12 +540,61 @@ suite('MongoDBService Test Suite', () => {
 
       expect(findCollectionCompletion).to.have.property(
         'kind',
-        CompletionItemKind.Property
+        CompletionItemKind.Folder
       );
       expect(findShellCompletion).to.have.property(
         'kind',
         CompletionItemKind.Method
       );
+    });
+
+    test('provide only collection names completion in the middle of expression', async () => {
+      testMongoDBService.updateCurrentSessionCollections('berlin', [
+        {
+          name: 'cocktails'
+        }
+      ]);
+
+      const result = await testMongoDBService.provideCompletionItems(
+        "use('berlin'); db..find().close()",
+        { line: 0, character: 18 }
+      );
+      const findCollectionCompletion = result.find(
+        (itme: any) => itme.label === 'cocktails'
+      );
+      const findShellCompletion = result.find(
+        (itme: any) => itme.label === 'getCollectionNames'
+      );
+      const findCursorCompletion = result.find(
+        (itme: any) => itme.label === 'close'
+      );
+
+      expect(findCollectionCompletion).to.have.property(
+        'kind',
+        CompletionItemKind.Folder
+      );
+      expect(findShellCompletion).to.be.undefined;
+      expect(findCursorCompletion).to.be.undefined;
+    });
+
+    test('provide collection names with dashes completion in the middle of expression', async () => {
+      testMongoDBService.updateCurrentSessionCollections('berlin', [
+        {
+          name: 'coll-name'
+        }
+      ]);
+
+      const result = await testMongoDBService.provideCompletionItems(
+        "use('berlin'); db..find()",
+        { line: 0, character: 18 }
+      );
+      const findCollectionCompletion = result.find(
+        (itme: any) => itme.label === 'coll-name'
+      );
+
+      expect(findCollectionCompletion)
+        .to.have.property('textEdit')
+        .that.has.property('newText', "use('berlin'); db['coll-name'].find()");
     });
   });
 


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
- Allow collection names completion in the middle of expression `db..find()`
- Convert collection name with dashes to array like format in the middle of expression `db.coll-name.find()` ->  `db['coll-name'].find()`
- Provide only collection names in the middle of expression (not shell methods)
- Provide cursor methods only after `find()` and `aggregate()`, not inside objects
- Use different icons for collection names and db methods suggestions
- Refactor Visitor class to use visit node methods instead of multiple condition statements in the AST parsing method
- Disable completions after disconnecting
- Provide collection names completion in variable declarations `const a = db.`
- Provide only collection names and shell db symbol completion after using a cursor and then using `db.`
- Provide completions for db names in string templates:

```
use(`

`)
```

- Provide completions when trigger dot at the next line

```
db
.
```
```
db.collection
.
```

- Provide completions when trigger dot after space

```
db .
```
```
db.collection .
```

- Provide completions when trigger dot after comment

```
// ggg

db.
```
```
// ggg \n

db.
```
```
/*
 * jjj
*/
db.
```
```
use('berlin'); // Comment
db.
```

- Provide completions when code without semicolons
```
use('test')
db
```

- Provide collection names completion at the same line block comment starts

```
use('test');

db. /*
 * Comment
*/
```

- Provide collection names completion at the same line block comment ends

```
use('test');

/*
 * Comment
*/ db.
```

- Provide collection names completion at the same line with end line comment

```
use('test');

db. // Comment
```

- The `window.activeTextEditor` by design returns not only a current active editor, but also an output channel in case of user moved focus to it to scroll the output or copy text from the output. The output editor ended up in `window.activeTextEditor` since the first public API release by accident. Plus `OutputChannel` is just a frontend of OutputService and "Output" pane is managed by OutputEditorInput. When we running a playground we get data from the active editor, since several playgrounds and other files can be open at the same time. To make sure we run data from playground editor only we listen for `vscode.window.onDidChangeActiveTextEditor` events and filter them to get the last active playground editor.

https://github.com/microsoft/vscode/issues/65108
https://github.com/Microsoft/vscode/issues/2857
https://github.com/Microsoft/vscode/issues/72162
https://github.com/microsoft/vscode/issues/58869

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
