### PR TITLE
Remove duplicate add connection command palette commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -420,6 +420,14 @@
       ],
       "commandPalette": [
         {
+          "command": "mdb.addConnection",
+          "when": "false"
+        },
+        {
+          "command": "mdb.addConnectionWithURI",
+          "when": "false"
+        },
+        {
           "command": "mdb.createNewPlaygroundFromViewAction",
           "when": "false"
         },


### PR DESCRIPTION
This PR removes a couple commands from the command palette which we are only using in the tree view.