### PR TITLE
Fix show more documents code lens argument passing

### DIFF
--- a/package.json
+++ b/package.json
@@ -432,6 +432,10 @@
           "when": "false"
         },
         {
+          "command": "mdb.showActiveConnectionInPlayground",
+          "when": "false"
+        },
+        {
           "command": "mdb.copyConnectionString",
           "when": "false"
         },

--- a/src/editors/collectionDocumentsCodeLensProvider.ts
+++ b/src/editors/collectionDocumentsCodeLensProvider.ts
@@ -89,7 +89,7 @@ export default class CollectionDocumentsCodeLensProvider implements vscode.CodeL
       title: commandTitle,
       tooltip: commandTooltip,
       command: 'mdb.codeLens.showMoreDocumentsClicked',
-      arguments: [operationId, connectionId, namespace]
+      arguments: [{ operationId, connectionId, namespace }]
     };
 
     return codeLens;

--- a/src/editors/documentProvider.ts
+++ b/src/editors/documentProvider.ts
@@ -41,11 +41,11 @@ export default class DocumentViewProvider implements vscode.TextDocumentContentP
       // Ensure we're still connected to the correct connection.
       if (connectionId !== this._connectionController.getActiveConnectionId()) {
         vscode.window.showErrorMessage(
-          `Unable to list documents: no longer connected to ${connectionId}`
+          `Unable to fetch document: no longer connected to ${connectionId}`
         );
         return reject(
           new Error(
-            `Unable to list documents: no longer connected to ${connectionId}`
+            `Unable to fetch document: no longer connected to ${connectionId}`
           )
         );
       }

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -154,7 +154,7 @@ export default class MDBExtensionController implements vscode.Disposable {
   registerEditorCommands(): void {
     this.registerCommand(
       'mdb.codeLens.showMoreDocumentsClicked',
-      (operationId, connectionId, namespace) => {
+      ({ operationId, connectionId, namespace }) => {
         return this._editorsController.onViewMoreCollectionDocuments(
           operationId,
           connectionId,


### PR DESCRIPTION
The `showMoreDocumentsClicked` receives a list of arguments. The behavior of this changed where its not passing the 2nd and 3rd arguments. This PR passes them all in the first argument to ensure vscode passes them correctly.

I'll write a quick test so this can't break in next pr.

Also in this pr, we hide the command `showActiveConnectionInPlayground` from the command palette since it's an internally used command.

Created https://jira.mongodb.org/browse/VSCODE-112 for better error messaging when disconnected.