### PR TITLE
VSCODE-90: Remove heartbeats from logger

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,8 @@ const log = createLogger('extension.ts');
  * etc. and write them to the extension's log output channel too.
  */
 import debug from 'debug';
-debug.enable('*');
+debug.enable('INFO');
+debug.enable('ERROR');
 debug.log = log.debug.bind(log);
 
 import MDBExtensionController from './mdbExtensionController';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,7 @@ const log = createLogger('extension.ts');
 import debug from 'debug';
 debug.enable('INFO');
 debug.enable('ERROR');
+debug.enable('WARN');
 debug.log = log.debug.bind(log);
 
 import MDBExtensionController from './mdbExtensionController';


### PR DESCRIPTION
https://jira.mongodb.org/browse/VSCODE-90

Currently we're outputting all (`*`) logs with the `debug` module.

This PR updates our logging namespaces to just `INFO`, `ERROR`, and `WARN`. This will silence the `DEBUG` logs which contain the heartbeats and some of the other connection messages. 

I'm looking into best practices for extension logging now, this update should at least put us in a better spot in terms of reporting messages with less credentials in them.