### PR TITLE
VSCODE-117: Fix file pathing for windows connect

### DIFF
--- a/src/test/suite/views/webviewController.test.ts
+++ b/src/test/suite/views/webviewController.test.ts
@@ -361,7 +361,7 @@ suite('Connect Form View Test Suite', () => {
       html: '',
       postMessage: (message: any): void => {
         assert(message.action === 'file_action');
-        assert(message.files[0] === './somefilepath/test.text');
+        assert(message.files[0] === 'somefilepath/test.text');
 
         testConnectionController.disconnect();
         done();
@@ -382,7 +382,7 @@ suite('Connect Form View Test Suite', () => {
 
     const fakeVSCodeOpenDialog = sinon.fake.resolves([
       {
-        path: './somefilepath/test.text'
+        path: '/somefilepath/test.text'
       }
     ]);
 
@@ -451,7 +451,9 @@ suite('Connect Form View Test Suite', () => {
 
     setTimeout(() => {
       assert(fakeVSCodeExecuteCommand.called);
-      assert(fakeVSCodeExecuteCommand.firstCall.args[0] === 'mdb.connectWithURI');
+      assert(
+        fakeVSCodeExecuteCommand.firstCall.args[0] === 'mdb.connectWithURI'
+      );
 
       done();
     }, 50);

--- a/src/views/webviewController.ts
+++ b/src/views/webviewController.ts
@@ -100,7 +100,7 @@ export default class WebviewController {
               action: message.action,
               files:
                 files && files.length > 0
-                  ? files.map((file) => file.path)
+                  ? files.map((file) => file.path.substr(1))
                   : undefined
             });
           });


### PR DESCRIPTION
https://jira.mongodb.org/browse/VSCODE-117

Our file paths are relative to the file system (/ at the beginning), when they're read in with node https://github.com/mongodb-js/connection-model/blob/master/lib/connect.js#L42 they are resolved in a way that was adding an extra system /. Linux handled this alright but on windows we were getting errors like `Cannot read file 'C:/C:/some_path_to_file.file'`. This fix just removes the leading / so they can resolve correctly in connect.

Tested manually on windows & linux opening CA & SSH files. Still thinking about how we can best integrated test ssl and ssh auth as they've been breaking points here and in compass.

Removed a bit of unused url code in connection model as well.