### PR TITLE
VSCODE-115: Launch mongoshell cross platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,6 +161,10 @@
         "title": "MongoDB: Launch MongoDB Shell"
       },
       {
+        "command": "mdb.treeViewOpenMongoDBShell",
+        "title": "Launch MongoDB Shell"
+      },
+      {
         "command": "mdb.createPlayground",
         "title": "MongoDB: Create MongoDB Playground"
       },
@@ -315,27 +319,32 @@
         {
           "command": "mdb.refreshConnection",
           "when": "view == mongoDB && viewItem == connectedConnectionTreeItem",
-          "group": "1@2"
+          "group": "1@3"
         },
         {
-          "command": "mdb.renameConnection",
+          "command": "mdb.treeViewOpenMongoDBShell",
           "when": "view == mongoDB && viewItem == connectedConnectionTreeItem",
           "group": "2@1"
         },
         {
-          "command": "mdb.copyConnectionString",
+          "command": "mdb.renameConnection",
           "when": "view == mongoDB && viewItem == connectedConnectionTreeItem",
           "group": "3@1"
         },
         {
-          "command": "mdb.disconnectFromConnectionTreeItem",
+          "command": "mdb.copyConnectionString",
           "when": "view == mongoDB && viewItem == connectedConnectionTreeItem",
           "group": "4@1"
         },
         {
+          "command": "mdb.disconnectFromConnectionTreeItem",
+          "when": "view == mongoDB && viewItem == connectedConnectionTreeItem",
+          "group": "5@1"
+        },
+        {
           "command": "mdb.treeItemRemoveConnection",
           "when": "view == mongoDB && viewItem == connectedConnectionTreeItem",
-          "group": "4@2"
+          "group": "5@2"
         },
         {
           "command": "mdb.connectToConnectionTreeItem",
@@ -453,6 +462,10 @@
         },
         {
           "command": "mdb.connectToConnectionTreeItem",
+          "when": "false"
+        },
+        {
+          "command": "mdb.treeViewOpenMongoDBShell",
           "when": "false"
         },
         {

--- a/package.json
+++ b/package.json
@@ -319,7 +319,7 @@
         {
           "command": "mdb.refreshConnection",
           "when": "view == mongoDB && viewItem == connectedConnectionTreeItem",
-          "group": "1@3"
+          "group": "1@2"
         },
         {
           "command": "mdb.treeViewOpenMongoDBShell",

--- a/src/commands/launchMongoShell.ts
+++ b/src/commands/launchMongoShell.ts
@@ -1,0 +1,128 @@
+import * as vscode from 'vscode';
+
+import ConnectionController from '../connectionController';
+
+function isSslConnection(activeConnectionModel: any): boolean {
+  return !!(
+    activeConnectionModel &&
+    activeConnectionModel.driverOptions &&
+    (activeConnectionModel.driverOptions.sslCA ||
+      activeConnectionModel.driverOptions.sslCert ||
+      activeConnectionModel.driverOptions.sslPass)
+  );
+}
+
+function getSslOptions(driverOptions: any, isWindowsBasedShell: boolean): string[] {
+  const mdbSslOptions = [ '--ssl' ];
+
+  if (!driverOptions.checkServerIdentity) {
+    mdbSslOptions.push('--sslAllowInvalidHostnames');
+  }
+
+  if (!driverOptions.sslValidate) {
+    mdbSslOptions.push('--sslAllowInvalidCertificates');
+  }
+
+  if (driverOptions.sslCA) {
+    mdbSslOptions.push(`--sslCAFile=${driverOptions.sslCA}`);
+  }
+
+  if (driverOptions.sslCert) {
+    mdbSslOptions.push(`--sslPEMKeyFile=${driverOptions.sslCert}`);
+  }
+
+  if (driverOptions.sslPass) {
+    mdbSslOptions.push(`--sslPEMKeyPassword=${isWindowsBasedShell ? '%MDB_SSL_CERTIFICATE_KEY_FILE_PASSWORD%' : '$MDB_SSL_CERTIFICATE_KEY_FILE_PASSWORD'}`);
+  }
+
+  return mdbSslOptions;
+}
+
+export default function openMongoDBShell(connectionController: ConnectionController): Promise<boolean> {
+  const mongoDBShellEnv: any = {};
+  let mdbSslOptions: string[] = [];
+
+  if (
+    !connectionController.isCurrentlyConnected()
+  ) {
+    vscode.window.showErrorMessage(
+      'You need to be connected before launching the MongoDB Shell.'
+    );
+
+    return Promise.resolve(false);
+  }
+
+  const userShell = vscode.env.shell;
+  const shellCommand: string | undefined = vscode.workspace.getConfiguration('mdb').get('shell');
+
+  if (!userShell) {
+    vscode.window.showErrorMessage(
+      'Error: No shell found, please set your default shell environment in vscode.'
+    );
+
+    return Promise.resolve(false);
+  }
+
+  if (!shellCommand) {
+    vscode.window.showErrorMessage(
+      'No MongoDB shell command found. Please set the shell command in the MongoDB extension settings.'
+    );
+    return Promise.resolve(false);
+  }
+
+  const isWindowsBasedShell = userShell.includes('cmd.exe') || userShell.includes('powershell.exe');
+
+  const activeConnectionModel = connectionController
+    .getActiveConnectionModel()
+    ?.getAttributes({ derived: true });
+
+  const mdbConnectionString = activeConnectionModel
+    ? activeConnectionModel.driverUrlWithSsh
+    : '';
+
+  if (activeConnectionModel && isSslConnection(activeConnectionModel)) {
+    mdbSslOptions = getSslOptions(
+      activeConnectionModel.driverOptions,
+      isWindowsBasedShell
+    );
+
+    if (activeConnectionModel.driverOptions.sslPass) {
+      mongoDBShellEnv.MDB_SSL_CERTIFICATE_KEY_FILE_PASSWORD =
+        activeConnectionModel.driverOptions.sslPass;
+    }
+  }
+
+  if (isWindowsBasedShell) {
+    mongoDBShellEnv.MDB_CONNECTION_STRING = mdbConnectionString;
+
+    const mongoDBShell = vscode.window.createTerminal({
+      name: 'MongoDB Shell',
+      env: mongoDBShellEnv
+    });
+
+    const mdbSslOptionsString = mdbSslOptions.length > 0
+      ? `${mdbSslOptions.join(' ')} `
+      : '';
+
+    mongoDBShell.sendText(
+      `${shellCommand} ${mdbSslOptionsString}%MDB_CONNECTION_STRING%;`
+    );
+    mongoDBShell.show();
+  } else {
+    // Assume it's a bash environment. This may fail on certain
+    // shells but should cover most cases.
+    const mongoDBShell = vscode.window.createTerminal({
+      name: 'MongoDB Shell',
+      shellPath: shellCommand,
+      env: mongoDBShellEnv,
+      shellArgs: [
+        mdbConnectionString,
+        ...mdbSslOptions
+      ]
+    });
+
+    mongoDBShell.show();
+  }
+
+  return Promise.resolve(true);
+}

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -1,7 +1,7 @@
 /**
  * Top-level controller for our extension.
  *
- * Activated from ./src/extension.ts
+ * Activated from `./src/extension.ts`
  */
 import * as vscode from 'vscode';
 
@@ -22,7 +22,7 @@ import WebviewController from './views/webviewController';
 const log = createLogger('commands');
 
 // This class is the top-level controller for our extension.
-// Commands which the extensions handles are defined in the function activate.
+// Commands which the extensions handles are defined in the function `activate`.
 export default class MDBExtensionController implements vscode.Disposable {
   _connectionController: ConnectionController;
   _context: vscode.ExtensionContext;

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -1,7 +1,7 @@
 /**
  * Top-level controller for our extension.
  *
- * Activated from `./src/extension.ts`
+ * Activated from ./src/extension.ts
  */
 import * as vscode from 'vscode';
 
@@ -22,7 +22,7 @@ import WebviewController from './views/webviewController';
 const log = createLogger('commands');
 
 // This class is the top-level controller for our extension.
-// Commands which the extensions handles are defined in the function `activate`.
+// Commands which the extensions handles are defined in the function activate.
 export default class MDBExtensionController implements vscode.Disposable {
   _connectionController: ConnectionController;
   _context: vscode.ExtensionContext;
@@ -407,35 +407,35 @@ export default class MDBExtensionController implements vscode.Disposable {
     );
   }
 
-  private getSslOptionsString(driverOptions: any): string {
-    let mdbSslOptionsString = '--ssl';
+  private getSslOptions(driverOptions: any): string[] {
+    const sslOptions = ['--ssl'];
 
     if (!driverOptions.checkServerIdentity) {
-      mdbSslOptionsString = `${mdbSslOptionsString} --sslAllowInvalidHostnames`;
+      sslOptions.push('--sslAllowInvalidHostnames');
     }
 
     if (!driverOptions.sslValidate) {
-      mdbSslOptionsString = `${mdbSslOptionsString} --sslAllowInvalidCertificates`;
+      sslOptions.push('--sslAllowInvalidCertificates');
     }
 
     if (driverOptions.sslCA) {
-      mdbSslOptionsString = `${mdbSslOptionsString} --sslCAFile ${driverOptions.sslCA}`;
+      sslOptions.push(`--sslCAFile=${driverOptions.sslCA}`);
     }
 
     if (driverOptions.sslCert) {
-      mdbSslOptionsString = `${mdbSslOptionsString} --sslPEMKeyFile ${driverOptions.sslCert}`;
+      sslOptions.push(`--sslPEMKeyFile=${driverOptions.sslCert}`);
     }
 
     if (driverOptions.sslPass) {
-      mdbSslOptionsString = `${mdbSslOptionsString} --sslPEMKeyPassword $MDB_SSL_CERTIFICATE_KEY_FILE_PASSWORD`;
+      sslOptions.push('--sslPEMKeyPassword=$MDB_SSL_CERTIFICATE_KEY_FILE_PASSWORD');
     }
 
-    return mdbSslOptionsString;
+    return sslOptions;
   }
 
   public openMongoDBShell(): Promise<boolean> {
     const mongoDBShellEnv: any = {};
-    const shellArgs: string[] = [];
+    let shellArgs: string[] = [];
 
     if (
       !this._connectionController ||
@@ -458,9 +458,10 @@ export default class MDBExtensionController implements vscode.Disposable {
     shellArgs.push(mdbConnectionString);
 
     if (activeConnectionModel && this.isSslConnection(activeConnectionModel)) {
-      shellArgs.push(this.getSslOptionsString(
-        activeConnectionModel.driverOptions
-      ));
+      shellArgs = [
+        ...shellArgs,
+        ...this.getSslOptions(activeConnectionModel.driverOptions)
+      ];
 
       if (activeConnectionModel.driverOptions.sslPass) {
         mongoDBShellEnv.MDB_SSL_CERTIFICATE_KEY_FILE_PASSWORD =

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -102,7 +102,12 @@ export default class MDBExtensionController implements vscode.Disposable {
       this._connectionController.onRemoveMongoDBConnection()
     );
 
-    this.registerCommand('mdb.openMongoDBShell', () => launchMongoShell(this._connectionController));
+    this.registerCommand('mdb.openMongoDBShell', () =>
+      launchMongoShell(this._connectionController)
+    );
+    this.registerCommand('mdb.treeViewOpenMongoDBShell', () =>
+      launchMongoShell(this._connectionController)
+    );
 
     this.registerCommand('mdb.createPlayground', () =>
       this._playgroundController.createPlayground()

--- a/src/test/suite/commands/launchMongoShell.test.ts
+++ b/src/test/suite/commands/launchMongoShell.test.ts
@@ -1,0 +1,211 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { beforeEach, afterEach } from 'mocha';
+import * as sinon from 'sinon';
+import Connection = require('mongodb-connection-model/lib/model');
+
+import MDBExtensionController from '../../../mdbExtensionController';
+import launchMongoShell from '../../../commands/launchMongoShell';
+
+import { TestExtensionContext } from '../stubs';
+
+suite('Commands Test Suite', () => {
+  vscode.window.showInformationMessage('Starting tests...');
+
+  const mockExtensionContext = new TestExtensionContext();
+  const mockMDBExtension = new MDBExtensionController(mockExtensionContext);
+  const mockConnectionController = mockMDBExtension._connectionController;
+  const sandbox = sinon.createSandbox();
+
+  let fakeShowErrorMessage: any;
+  let fakeGetActiveConnectionModel: any;
+  let fakeIsCurrentlyConnected: any;
+  let createTerminalStub: any;
+  let fakeSendTerminalText: any;
+
+  beforeEach(() => {
+    sandbox.stub(vscode.window, 'showInformationMessage');
+
+    fakeShowErrorMessage = sandbox.stub(vscode.window, 'showErrorMessage');
+    fakeGetActiveConnectionModel = sandbox.stub(
+      mockConnectionController,
+      'getActiveConnectionModel'
+    );
+
+    fakeIsCurrentlyConnected = sandbox.stub(
+      mockConnectionController,
+      'isCurrentlyConnected'
+    );
+
+    createTerminalStub = sandbox.stub();
+    fakeSendTerminalText = sandbox.stub();
+
+    createTerminalStub.returns({
+      sendText: fakeSendTerminalText,
+      show: () => {}
+    });
+    sandbox.replace(vscode.window, 'createTerminal', createTerminalStub);
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+    sinon.restore();
+
+    await mockConnectionController.disconnect();
+    mockConnectionController.clearAllConnections();
+  });
+
+  test('openMongoDBShell should display an error message when not connected', async () => {
+    const errorMessage =
+      'You need to be connected before launching the MongoDB Shell.';
+
+    fakeShowErrorMessage.resolves(errorMessage);
+
+    try {
+      await launchMongoShell(mockConnectionController);
+    } catch (error) {
+      sinon.assert.calledWith(fakeShowErrorMessage, errorMessage);
+    }
+  });
+
+  test('openMongoDBShell should open a terminal with the active connection driver url', async () => {
+    const driverUri =
+      'mongodb://localhost:27018/?readPreference=primary&ssl=false';
+
+    fakeGetActiveConnectionModel.returns(
+      new Connection({
+        hostname: 'localhost',
+        port: 27018
+      })
+    );
+    fakeIsCurrentlyConnected.returns(true);
+
+    await launchMongoShell(mockConnectionController);
+
+    assert(createTerminalStub.called);
+
+    const terminalOptions: vscode.TerminalOptions =
+      createTerminalStub.firstCall.args[0];
+
+    // assert(
+    //   terminalOptions.env?.MDB_CONNECTION_STRING === driverUri,
+    //   `Expected open terminal to set shell arg as driver url "${driverUri}" found "${terminalOptions.env?.MDB_CONNECTION_STRING}"`
+    // );
+    let shellArgs = terminalOptions.shellArgs;
+    assert(
+      shellArgs !== undefined,
+      'Expected shell arguments to exist'
+    );
+    shellArgs = shellArgs || [];
+
+    assert(
+      shellArgs[0] === driverUri,
+      `Expected open terminal to set shell arg as driver url "${driverUri}" found "${shellArgs[0]}"`
+    );
+  });
+
+  test('openMongoDBShell should open a terminal with ssh tunnel port injected', async () => {
+    fakeGetActiveConnectionModel.returns(
+      new Connection({
+        hostname: '127.0.0.1',
+        sshTunnel: 'USER_PASSWORD',
+        sshTunnelHostname: 'my.ssh-server.com',
+        sshTunnelUsername: 'my-user',
+        sshTunnelPassword: 'password'
+      })
+    );
+    fakeIsCurrentlyConnected.returns(true);
+
+    await launchMongoShell(mockConnectionController);
+
+    assert(createTerminalStub.called);
+
+    const terminalOptions: vscode.TerminalOptions =
+      createTerminalStub.firstCall.args[0];
+
+    let shellArgs = terminalOptions.shellArgs;
+    assert(
+      shellArgs !== undefined,
+      'Expected shell arguments to exist'
+    );
+    shellArgs = shellArgs || [];
+
+    assert(
+      shellArgs[0].includes('mongodb://127.0.0.1') &&
+      shellArgs[0].includes('/?readPreference=primary&ssl=false'),
+      `Expected open terminal to set shell arg as driver url with ssh tunnel port injected found "${shellArgs[0]}"`
+    );
+
+    // assert(
+    //   terminalOptions.env?.MDB_CONNECTION_STRING?.includes('mongodb://127.0.0.1') &&
+    //     terminalOptions.env?.MDB_CONNECTION_STRING.includes('/?readPreference=primary&ssl=false'),
+    //   `Expected open terminal to set shell arg as driver url with ssh tunnel port injected found "${terminalOptions.env?.MDB_CONNECTION_STRING}"`
+    // );
+  });
+
+  test('openMongoDBShell should open a terminal with ssl config injected', async () => {
+    const driverUri =
+      'mongodb://127.0.0.1:27017/?readPreference=primary&ssl=true';
+
+    fakeGetActiveConnectionModel.returns(
+      new Connection({
+        hostname: '127.0.0.1',
+        ssl: true,
+        sslMethod: 'SERVER',
+        sslCA: './path_to_some_file'
+      })
+    );
+    fakeIsCurrentlyConnected.returns(true);
+
+    await launchMongoShell(mockConnectionController);
+
+    assert(createTerminalStub.called);
+
+    const terminalOptions: vscode.TerminalOptions =
+      createTerminalStub.firstCall.args[0];
+
+    let shellArgs = terminalOptions.shellArgs;
+    assert(
+      shellArgs !== undefined,
+      'Expected shell arguments to exist'
+    );
+    shellArgs = shellArgs || [];
+
+    assert(
+      shellArgs[0] === driverUri,
+      `Expected open terminal to set shell arg as driver url with ssl injected "${driverUri}" found "${shellArgs[0]}"`
+    );
+
+    // assert(
+    //   terminalOptions.env?.MDB_CONNECTION_STRING === driverUri,
+    //   `Expected open terminal to set shell arg as driver url with ssl injected "${driverUri}" found "${terminalOptions.env?.MDB_CONNECTION_STRING}"`
+    // );
+
+    assert(
+      shellArgs[1] === '--ssl',
+      `Expected open terminal to set ssl arg "--ssl" found "${shellArgs[1]}"`
+    );
+    assert(
+      shellArgs[2] === '--sslAllowInvalidHostnames',
+      `Expected open terminal to set ssl arg "--sslAllowInvalidHostnames" found "${shellArgs[2]}"`
+    );
+    assert(
+      shellArgs[3] === '--sslCAFile=./path_to_some_file',
+      `Expected open terminal to set sslCAFile arg "--sslCAFile=./path_to_some_file" found "${shellArgs[3]}"`
+    );
+
+    // const shellCommandText = fakeSendTerminalText.firstCall.args[0];
+    // assert(
+    //   shellCommandText.includes('--ssl'),
+    //   `Expected open terminal to have ssl arg "--ssl" found "${shellCommandText}"`
+    // );
+    // assert(
+    //   shellCommandText.includes('--sslAllowInvalidHostnames'),
+    //   `Expected open terminal to have ssl arg "--sslAllowInvalidHostnames" found "${shellCommandText}"`
+    // );
+    // assert(
+    //   shellCommandText.includes('--sslCAFile=./path_to_some_file'),
+    //   `Expected open terminal to have sslCAFile arg "--sslCAFile=./path_to_some_file" found "${shellCommandText}"`
+    // );
+  });
+});

--- a/src/test/suite/commands/launchMongoShell.test.ts
+++ b/src/test/suite/commands/launchMongoShell.test.ts
@@ -55,157 +55,227 @@ suite('Commands Test Suite', () => {
     mockConnectionController.clearAllConnections();
   });
 
-  test('openMongoDBShell should display an error message when not connected', async () => {
-    const errorMessage =
-      'You need to be connected before launching the MongoDB Shell.';
+  suite('bash env shell', () => {
+    beforeEach(() => {
+      sandbox.replaceGetter(vscode.env, 'shell', () => 'bash');
+    });
 
-    fakeShowErrorMessage.resolves(errorMessage);
+    test('openMongoDBShell should display an error message when not connected', async () => {
+      const errorMessage =
+        'You need to be connected before launching the MongoDB Shell.';
 
-    try {
+      fakeShowErrorMessage.resolves(errorMessage);
+
+      try {
+        await launchMongoShell(mockConnectionController);
+      } catch (error) {
+        sinon.assert.calledWith(fakeShowErrorMessage, errorMessage);
+      }
+    });
+
+    test('openMongoDBShell should open a terminal with the active connection driver url', async () => {
+      const driverUri =
+        'mongodb://localhost:27018/?readPreference=primary&ssl=false';
+
+      fakeGetActiveConnectionModel.returns(
+        new Connection({
+          hostname: 'localhost',
+          port: 27018
+        })
+      );
+      fakeIsCurrentlyConnected.returns(true);
+
       await launchMongoShell(mockConnectionController);
-    } catch (error) {
-      sinon.assert.calledWith(fakeShowErrorMessage, errorMessage);
-    }
+
+      assert(createTerminalStub.called);
+
+      const terminalOptions: vscode.TerminalOptions =
+        createTerminalStub.firstCall.args[0];
+
+      let shellArgs = terminalOptions.shellArgs;
+      assert(shellArgs !== undefined, 'Expected shell arguments to exist');
+      shellArgs = shellArgs || [];
+
+      assert(
+        shellArgs[0] === driverUri,
+        `Expected open terminal to set shell arg as driver url "${driverUri}" found "${shellArgs[0]}"`
+      );
+    });
+
+    test('openMongoDBShell should open a terminal with ssh tunnel port injected', async () => {
+      fakeGetActiveConnectionModel.returns(
+        new Connection({
+          hostname: '127.0.0.1',
+          sshTunnel: 'USER_PASSWORD',
+          sshTunnelHostname: 'my.ssh-server.com',
+          sshTunnelUsername: 'my-user',
+          sshTunnelPassword: 'password'
+        })
+      );
+      fakeIsCurrentlyConnected.returns(true);
+
+      await launchMongoShell(mockConnectionController);
+
+      assert(createTerminalStub.called);
+
+      const terminalOptions: vscode.TerminalOptions =
+        createTerminalStub.firstCall.args[0];
+
+      let shellArgs = terminalOptions.shellArgs;
+      assert(shellArgs !== undefined, 'Expected shell arguments to exist');
+      shellArgs = shellArgs || [];
+
+      assert(
+        shellArgs[0].includes('mongodb://127.0.0.1') &&
+          shellArgs[0].includes('/?readPreference=primary&ssl=false'),
+        `Expected open terminal to set shell arg as driver url with ssh tunnel port injected found "${shellArgs[0]}"`
+      );
+    });
+
+    test('openMongoDBShell should open a terminal with ssl config injected', async () => {
+      const driverUri =
+        'mongodb://127.0.0.1:27017/?readPreference=primary&ssl=true';
+
+      fakeGetActiveConnectionModel.returns(
+        new Connection({
+          hostname: '127.0.0.1',
+          ssl: true,
+          sslMethod: 'SERVER',
+          sslCA: './path_to_some_file'
+        })
+      );
+      fakeIsCurrentlyConnected.returns(true);
+
+      await launchMongoShell(mockConnectionController);
+
+      assert(createTerminalStub.called);
+
+      const terminalOptions: vscode.TerminalOptions =
+        createTerminalStub.firstCall.args[0];
+
+      let shellArgs = terminalOptions.shellArgs;
+      assert(shellArgs !== undefined, 'Expected shell arguments to exist');
+      shellArgs = shellArgs || [];
+
+      assert(
+        shellArgs[0] === driverUri,
+        `Expected open terminal to set shell arg as driver url with ssl injected "${driverUri}" found "${shellArgs[0]}"`
+      );
+
+      assert(
+        shellArgs[1] === '--ssl',
+        `Expected open terminal to set ssl arg "--ssl" found "${shellArgs[1]}"`
+      );
+      assert(
+        shellArgs[2] === '--sslAllowInvalidHostnames',
+        `Expected open terminal to set ssl arg "--sslAllowInvalidHostnames" found "${shellArgs[2]}"`
+      );
+      assert(
+        shellArgs[3] === '--sslCAFile=./path_to_some_file',
+        `Expected open terminal to set sslCAFile arg "--sslCAFile=./path_to_some_file" found "${shellArgs[3]}"`
+      );
+    });
   });
 
-  test('openMongoDBShell should open a terminal with the active connection driver url', async () => {
-    const driverUri =
-      'mongodb://localhost:27018/?readPreference=primary&ssl=false';
+  suite('Windows cmd or powershell env shell', () => {
+    beforeEach(() => {
+      sandbox.replaceGetter(vscode.env, 'shell', () => 'cmd.exe');
+    });
 
-    fakeGetActiveConnectionModel.returns(
-      new Connection({
-        hostname: 'localhost',
-        port: 27018
-      })
-    );
-    fakeIsCurrentlyConnected.returns(true);
+    test('windows openMongoDBShell should open a terminal with the active connection driver url', async () => {
+      const driverUri =
+        'mongodb://localhost:27018/?readPreference=primary&ssl=false';
 
-    await launchMongoShell(mockConnectionController);
+      fakeGetActiveConnectionModel.returns(
+        new Connection({
+          hostname: 'localhost',
+          port: 27018
+        })
+      );
+      fakeIsCurrentlyConnected.returns(true);
 
-    assert(createTerminalStub.called);
+      await launchMongoShell(mockConnectionController);
 
-    const terminalOptions: vscode.TerminalOptions =
-      createTerminalStub.firstCall.args[0];
+      assert(createTerminalStub.called);
 
-    // assert(
-    //   terminalOptions.env?.MDB_CONNECTION_STRING === driverUri,
-    //   `Expected open terminal to set shell arg as driver url "${driverUri}" found "${terminalOptions.env?.MDB_CONNECTION_STRING}"`
-    // );
-    let shellArgs = terminalOptions.shellArgs;
-    assert(
-      shellArgs !== undefined,
-      'Expected shell arguments to exist'
-    );
-    shellArgs = shellArgs || [];
+      const terminalOptions: vscode.TerminalOptions =
+        createTerminalStub.firstCall.args[0];
 
-    assert(
-      shellArgs[0] === driverUri,
-      `Expected open terminal to set shell arg as driver url "${driverUri}" found "${shellArgs[0]}"`
-    );
-  });
+      assert(
+        terminalOptions.env?.MDB_CONNECTION_STRING === driverUri,
+        `Expected open terminal to set shell arg as driver url "${driverUri}" found "${terminalOptions.env?.MDB_CONNECTION_STRING}"`
+      );
+    });
 
-  test('openMongoDBShell should open a terminal with ssh tunnel port injected', async () => {
-    fakeGetActiveConnectionModel.returns(
-      new Connection({
-        hostname: '127.0.0.1',
-        sshTunnel: 'USER_PASSWORD',
-        sshTunnelHostname: 'my.ssh-server.com',
-        sshTunnelUsername: 'my-user',
-        sshTunnelPassword: 'password'
-      })
-    );
-    fakeIsCurrentlyConnected.returns(true);
+    test('windows openMongoDBShell should open a terminal with ssh tunnel port injected', async () => {
+      fakeGetActiveConnectionModel.returns(
+        new Connection({
+          hostname: '127.0.0.1',
+          sshTunnel: 'USER_PASSWORD',
+          sshTunnelHostname: 'my.ssh-server.com',
+          sshTunnelUsername: 'my-user',
+          sshTunnelPassword: 'password'
+        })
+      );
+      fakeIsCurrentlyConnected.returns(true);
 
-    await launchMongoShell(mockConnectionController);
+      await launchMongoShell(mockConnectionController);
 
-    assert(createTerminalStub.called);
+      assert(createTerminalStub.called);
 
-    const terminalOptions: vscode.TerminalOptions =
-      createTerminalStub.firstCall.args[0];
+      const terminalOptions: vscode.TerminalOptions =
+        createTerminalStub.firstCall.args[0];
 
-    let shellArgs = terminalOptions.shellArgs;
-    assert(
-      shellArgs !== undefined,
-      'Expected shell arguments to exist'
-    );
-    shellArgs = shellArgs || [];
+      assert(
+        terminalOptions.env?.MDB_CONNECTION_STRING?.includes(
+          'mongodb://127.0.0.1'
+        ) &&
+          terminalOptions.env?.MDB_CONNECTION_STRING.includes(
+            '/?readPreference=primary&ssl=false'
+          ),
+        `Expected open terminal to set shell arg as driver url with ssh tunnel port injected found "${terminalOptions.env?.MDB_CONNECTION_STRING}"`
+      );
+    });
 
-    assert(
-      shellArgs[0].includes('mongodb://127.0.0.1') &&
-      shellArgs[0].includes('/?readPreference=primary&ssl=false'),
-      `Expected open terminal to set shell arg as driver url with ssh tunnel port injected found "${shellArgs[0]}"`
-    );
+    test('windows openMongoDBShell should open a terminal with ssl config injected', async () => {
+      const driverUri =
+        'mongodb://127.0.0.1:27017/?readPreference=primary&ssl=true';
 
-    // assert(
-    //   terminalOptions.env?.MDB_CONNECTION_STRING?.includes('mongodb://127.0.0.1') &&
-    //     terminalOptions.env?.MDB_CONNECTION_STRING.includes('/?readPreference=primary&ssl=false'),
-    //   `Expected open terminal to set shell arg as driver url with ssh tunnel port injected found "${terminalOptions.env?.MDB_CONNECTION_STRING}"`
-    // );
-  });
+      fakeGetActiveConnectionModel.returns(
+        new Connection({
+          hostname: '127.0.0.1',
+          ssl: true,
+          sslMethod: 'SERVER',
+          sslCA: './path_to_some_file'
+        })
+      );
+      fakeIsCurrentlyConnected.returns(true);
 
-  test('openMongoDBShell should open a terminal with ssl config injected', async () => {
-    const driverUri =
-      'mongodb://127.0.0.1:27017/?readPreference=primary&ssl=true';
+      await launchMongoShell(mockConnectionController);
 
-    fakeGetActiveConnectionModel.returns(
-      new Connection({
-        hostname: '127.0.0.1',
-        ssl: true,
-        sslMethod: 'SERVER',
-        sslCA: './path_to_some_file'
-      })
-    );
-    fakeIsCurrentlyConnected.returns(true);
+      assert(createTerminalStub.called);
 
-    await launchMongoShell(mockConnectionController);
+      const terminalOptions: vscode.TerminalOptions =
+        createTerminalStub.firstCall.args[0];
 
-    assert(createTerminalStub.called);
+      assert(
+        terminalOptions.env?.MDB_CONNECTION_STRING === driverUri,
+        `Expected open terminal to set shell arg as driver url with ssl injected "${driverUri}" found "${terminalOptions.env?.MDB_CONNECTION_STRING}"`
+      );
 
-    const terminalOptions: vscode.TerminalOptions =
-      createTerminalStub.firstCall.args[0];
-
-    let shellArgs = terminalOptions.shellArgs;
-    assert(
-      shellArgs !== undefined,
-      'Expected shell arguments to exist'
-    );
-    shellArgs = shellArgs || [];
-
-    assert(
-      shellArgs[0] === driverUri,
-      `Expected open terminal to set shell arg as driver url with ssl injected "${driverUri}" found "${shellArgs[0]}"`
-    );
-
-    // assert(
-    //   terminalOptions.env?.MDB_CONNECTION_STRING === driverUri,
-    //   `Expected open terminal to set shell arg as driver url with ssl injected "${driverUri}" found "${terminalOptions.env?.MDB_CONNECTION_STRING}"`
-    // );
-
-    assert(
-      shellArgs[1] === '--ssl',
-      `Expected open terminal to set ssl arg "--ssl" found "${shellArgs[1]}"`
-    );
-    assert(
-      shellArgs[2] === '--sslAllowInvalidHostnames',
-      `Expected open terminal to set ssl arg "--sslAllowInvalidHostnames" found "${shellArgs[2]}"`
-    );
-    assert(
-      shellArgs[3] === '--sslCAFile=./path_to_some_file',
-      `Expected open terminal to set sslCAFile arg "--sslCAFile=./path_to_some_file" found "${shellArgs[3]}"`
-    );
-
-    // const shellCommandText = fakeSendTerminalText.firstCall.args[0];
-    // assert(
-    //   shellCommandText.includes('--ssl'),
-    //   `Expected open terminal to have ssl arg "--ssl" found "${shellCommandText}"`
-    // );
-    // assert(
-    //   shellCommandText.includes('--sslAllowInvalidHostnames'),
-    //   `Expected open terminal to have ssl arg "--sslAllowInvalidHostnames" found "${shellCommandText}"`
-    // );
-    // assert(
-    //   shellCommandText.includes('--sslCAFile=./path_to_some_file'),
-    //   `Expected open terminal to have sslCAFile arg "--sslCAFile=./path_to_some_file" found "${shellCommandText}"`
-    // );
+      const shellCommandText = fakeSendTerminalText.firstCall.args[0];
+      assert(
+        shellCommandText.includes('--ssl'),
+        `Expected open terminal to have ssl arg "--ssl" found "${shellCommandText}"`
+      );
+      assert(
+        shellCommandText.includes('--sslAllowInvalidHostnames'),
+        `Expected open terminal to have ssl arg "--sslAllowInvalidHostnames" found "${shellCommandText}"`
+      );
+      assert(
+        shellCommandText.includes('--sslCAFile=./path_to_some_file'),
+        `Expected open terminal to have sslCAFile arg "--sslCAFile=./path_to_some_file" found "${shellCommandText}"`
+      );
+    });
   });
 });

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -2,37 +2,16 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 import { beforeEach, afterEach } from 'mocha';
 import * as sinon from 'sinon';
-import Connection = require('mongodb-connection-model/lib/model');
-import MDBExtensionController from '../../mdbExtensionController';
-import { TestExtensionContext } from './stubs';
-
 suite('Extension Test Suite', () => {
   vscode.window.showInformationMessage('Starting tests...');
 
-  const mockExtensionContext = new TestExtensionContext();
-  const mockMDBExtension = new MDBExtensionController(mockExtensionContext);
   const sandbox = sinon.createSandbox();
 
-  let fakeShowErrorMessage: any;
-  let fakeGetActiveConnectionModel: any;
-  let fakeIsCurrentlyConnected: any;
   let createTerminalStub: any;
   let fakeSendTerminalText: any;
 
   beforeEach(() => {
     sandbox.stub(vscode.window, 'showInformationMessage');
-
-    fakeShowErrorMessage = sandbox.stub(vscode.window, 'showErrorMessage');
-    fakeGetActiveConnectionModel = sandbox.stub(
-      mockMDBExtension._connectionController,
-      'getActiveConnectionModel'
-    );
-
-
-    fakeIsCurrentlyConnected = sandbox.stub(
-      mockMDBExtension._connectionController,
-      'isCurrentlyConnected'
-    );
 
     createTerminalStub = sandbox.stub();
     fakeSendTerminalText = sandbox.stub();
@@ -93,120 +72,5 @@ suite('Extension Test Suite', () => {
         return;
       }
     }
-  });
-
-  test('openMongoDBShell should display an error message when not connected', async () => {
-    const errorMessage =
-      'You need to be connected before launching the MongoDB Shell.';
-
-    fakeShowErrorMessage.resolves(errorMessage);
-
-    try {
-      await mockMDBExtension.openMongoDBShell();
-    } catch (error) {
-      sinon.assert.calledWith(fakeShowErrorMessage, errorMessage);
-    }
-  });
-
-  test('openMongoDBShell should open a terminal with the active connection driver url', async () => {
-    const driverUri =
-      'mongodb://localhost:27018/?readPreference=primary&ssl=false';
-
-    fakeGetActiveConnectionModel.returns(
-      new Connection({
-        hostname: 'localhost',
-        port: 27018
-      })
-    );
-    fakeIsCurrentlyConnected.returns(true);
-
-    await mockMDBExtension.openMongoDBShell();
-
-    assert(createTerminalStub.called);
-
-    const terminalOptions: vscode.TerminalOptions =
-      createTerminalStub.firstCall.args[0];
-
-    assert(
-      terminalOptions.env?.MDB_CONNECTION_STRING === driverUri,
-      `Expected open terminal to set shell arg as driver url "${driverUri}" found "${terminalOptions.env?.MDB_CONNECTION_STRING}"`
-    );
-
-    await mockMDBExtension._connectionController.disconnect();
-    mockMDBExtension._connectionController.clearAllConnections();
-  });
-
-  test('openMongoDBShell should open a terminal with ssh tunnel port injected', async () => {
-    fakeGetActiveConnectionModel.returns(
-      new Connection({
-        hostname: '127.0.0.1',
-        sshTunnel: 'USER_PASSWORD',
-        sshTunnelHostname: 'my.ssh-server.com',
-        sshTunnelUsername: 'my-user',
-        sshTunnelPassword: 'password'
-      })
-    );
-    fakeIsCurrentlyConnected.returns(true);
-
-    await mockMDBExtension.openMongoDBShell();
-
-    assert(createTerminalStub.called);
-
-    const terminalOptions: vscode.TerminalOptions =
-      createTerminalStub.firstCall.args[0];
-
-    assert(
-      terminalOptions.env?.MDB_CONNECTION_STRING?.includes('mongodb://127.0.0.1') &&
-        terminalOptions.env?.MDB_CONNECTION_STRING.includes('/?readPreference=primary&ssl=false'),
-      `Expected open terminal to set shell arg as driver url with ssh tunnel port injected found "${terminalOptions.env?.MDB_CONNECTION_STRING}"`
-    );
-
-    await mockMDBExtension._connectionController.disconnect();
-    mockMDBExtension._connectionController.clearAllConnections();
-  });
-
-  test('openMongoDBShell should open a terminal with ssl config injected', async () => {
-    const driverUri =
-      'mongodb://127.0.0.1:27017/?readPreference=primary&ssl=true';
-
-    fakeGetActiveConnectionModel.returns(
-      new Connection({
-        hostname: '127.0.0.1',
-        ssl: true,
-        sslMethod: 'SERVER',
-        sslCA: './path_to_some_file'
-      })
-    );
-    fakeIsCurrentlyConnected.returns(true);
-
-    await mockMDBExtension.openMongoDBShell();
-
-    assert(createTerminalStub.called);
-    assert(fakeSendTerminalText.called);
-
-    const terminalOptions: vscode.TerminalOptions =
-      createTerminalStub.firstCall.args[0];
-
-    assert(
-      terminalOptions.env?.MDB_CONNECTION_STRING === driverUri,
-      `Expected open terminal to set shell arg as driver url with ssl injected "${driverUri}" found "${terminalOptions.env?.MDB_CONNECTION_STRING}"`
-    );
-
-    const shellCommandText = fakeSendTerminalText.firstCall.args[0];
-    assert(
-      shellCommandText.includes('--ssl'),
-      `Expected open terminal to have ssl arg "--ssl" found "${shellCommandText}"`
-    );
-    assert(
-      shellCommandText.includes('--sslAllowInvalidHostnames'),
-      `Expected open terminal to have ssl arg "--sslAllowInvalidHostnames" found "${shellCommandText}"`
-    );
-    assert(
-      shellCommandText.includes('--sslCAFile=./path_to_some_file'),
-      `Expected open terminal to have sslCAFile arg "--sslCAFile=./path_to_some_file" found "${shellCommandText}"`
-    );
-
-    await mockMDBExtension._connectionController.disconnect();
-    mockMDBExtension._connectionController.clearAllConnections();
   });
 });

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -204,10 +204,17 @@ suite('Extension Test Suite', () => {
       `Expected open terminal to set shell arg as driver url with ssl injected "${driverUri}" found "${shellArgs[0]}"`
     );
 
-    const expectedSSL = '--ssl --sslAllowInvalidHostnames --sslCAFile ./path_to_some_file';
     assert(
-      shellArgs[1] === expectedSSL,
-      `Expected open terminal to set ssl args as "${expectedSSL}" found "${shellArgs[1]}"`
+      shellArgs[1] === '--ssl',
+      `Expected open terminal to set ssl arg "--ssl" found "${shellArgs[1]}"`
+    );
+    assert(
+      shellArgs[2] === '--sslAllowInvalidHostnames',
+      `Expected open terminal to set ssl arg "--sslAllowInvalidHostnames" found "${shellArgs[2]}"`
+    );
+    assert(
+      shellArgs[3] === '--sslCAFile=./path_to_some_file',
+      `Expected open terminal to set sslCAFile arg "--sslCAFile=./path_to_some_file" found "${shellArgs[3]}"`
     );
 
     await mockMDBExtension._connectionController.disconnect();

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -18,7 +18,7 @@ suite('Extension Test Suite', () => {
 
     createTerminalStub.returns({
       sendText: fakeSendTerminalText,
-      show: () => {}
+      show: () => {},
     });
     sandbox.replace(vscode.window, 'createTerminal', createTerminalStub);
   });
@@ -46,6 +46,7 @@ suite('Extension Test Suite', () => {
       'mdb.addConnectionWithURI',
       'mdb.copyConnectionString',
       'mdb.treeItemRemoveConnection',
+      'mdb.treeViewOpenMongoDBShell',
       'mdb.addDatabase',
       'mdb.refreshConnection',
       'mdb.copyDatabaseName',
@@ -57,7 +58,7 @@ suite('Extension Test Suite', () => {
       'mdb.refreshSchema',
 
       // Editor commands.
-      'mdb.codeLens.showMoreDocumentsClicked'
+      'mdb.codeLens.showMoreDocumentsClicked',
     ];
 
     for (let i = 0; i < expectedCommands.length; i++) {

--- a/src/test/suite/views/webviewController.test.ts
+++ b/src/test/suite/views/webviewController.test.ts
@@ -361,7 +361,7 @@ suite('Connect Form View Test Suite', () => {
       html: '',
       postMessage: (message: any): void => {
         assert(message.action === 'file_action');
-        assert(message.files[0] === path.resolve('/somefilepath/test.text'));
+        assert(message.files[0] === path.resolve('somefilepath/test.text'));
 
         testConnectionController.disconnect();
         done();

--- a/src/views/webview-app/components/connect-form/connection-form.tsx
+++ b/src/views/webview-app/components/connect-form/connection-form.tsx
@@ -28,8 +28,6 @@ type stateProps = {
   isConnected: boolean;
   isConnecting: boolean;
   isUriConnected: boolean;
-  isHostChanged: boolean;
-  isPortChanged: boolean;
   isValid: boolean;
   syntaxErrorMessage: string;
   uriConnectionMessage: string;
@@ -55,17 +53,17 @@ class ConnectionForm extends React.Component<props> {
    * @returns {React.Component}
    */
   renderPort(): React.ReactNode {
-    const { currentConnection, isPortChanged } = this.props;
+    const { currentConnection } = this.props;
 
     const { isSrvRecord, port } = currentConnection;
 
     if (!isSrvRecord) {
-      return <PortInput port={port} isPortChanged={isPortChanged} />;
+      return <PortInput port={port} />;
     }
   }
 
   renderHostnameArea(): React.ReactNode {
-    const { currentConnection, isHostChanged, isValid } = this.props;
+    const { currentConnection, isValid } = this.props;
 
     const {
       authStrategy,
@@ -86,7 +84,7 @@ class ConnectionForm extends React.Component<props> {
     return (
       <div>
         <FormGroup id="connection-host-information" separator>
-          <HostInput hostname={hostname} isHostChanged={isHostChanged} />
+          <HostInput hostname={hostname} />
           {this.renderPort()}
           <SRVInput isSrvRecord={isSrvRecord} />
         </FormGroup>
@@ -199,8 +197,6 @@ const mapStateToProps = (state: AppState): stateProps => {
     isConnected: state.isConnected,
     isConnecting: state.isConnecting,
     isUriConnected: state.isUriConnected,
-    isHostChanged: state.isHostChanged,
-    isPortChanged: state.isPortChanged,
     isValid: state.isValid,
     syntaxErrorMessage: state.syntaxErrorMessage,
     uriConnectionMessage: state.uriConnectionMessage

--- a/src/views/webview-app/components/connect-form/host/host-input.tsx
+++ b/src/views/webview-app/components/connect-form/host/host-input.tsx
@@ -10,7 +10,6 @@ type dispatchProps = {
 
 type props = {
   hostname: string;
-  isHostChanged: boolean;
 } & dispatchProps;
 
 class HostInput extends React.PureComponent<props> {
@@ -31,10 +30,6 @@ class HostInput extends React.PureComponent<props> {
    * @returns {String} hostname.
    */
   getHostname(): string {
-    if (this.props.isHostChanged === false) {
-      return '';
-    }
-
     return this.props.hostname;
   }
 

--- a/src/views/webview-app/components/connect-form/host/port-input.tsx
+++ b/src/views/webview-app/components/connect-form/host/port-input.tsx
@@ -10,7 +10,6 @@ type dispatchProps = {
 
 type props = {
   port: number;
-  isPortChanged: boolean;
 } & dispatchProps;
 
 class PortInput extends React.PureComponent<props> {
@@ -31,10 +30,6 @@ class PortInput extends React.PureComponent<props> {
    * @returns {String} port.
    */
   getPort(): string {
-    if (this.props.isPortChanged === false) {
-      return '';
-    }
-
     return `${this.props.port}`;
   }
 

--- a/src/views/webview-app/store/store.ts
+++ b/src/views/webview-app/store/store.ts
@@ -18,8 +18,6 @@ export interface AppState {
   isUriConnected: boolean;
   errorMessage: string;
   syntaxErrorMessage: string;
-  isHostChanged: boolean;
-  isPortChanged: boolean;
   savedMessage: string;
   uriConnectionMessage: string;
 }
@@ -32,8 +30,6 @@ export const initialState = {
   isUriConnected: false,
   errorMessage: '',
   syntaxErrorMessage: '',
-  isHostChanged: false,
-  isPortChanged: false,
   savedMessage: '',
   uriConnectionMessage: ''
 };
@@ -147,7 +143,6 @@ export const rootReducer = (
     case ActionTypes.HOSTNAME_CHANGED:
       return {
         ...state,
-        isHostChanged: true,
         currentConnection: {
           ...state.currentConnection,
           hostname: action.hostname.trim(),
@@ -251,7 +246,6 @@ export const rootReducer = (
     case ActionTypes.PORT_CHANGED:
       return {
         ...state,
-        isPortChanged: true,
         currentConnection: {
           ...state.currentConnection,
           port: action.port

--- a/src/views/webviewController.ts
+++ b/src/views/webviewController.ts
@@ -100,7 +100,7 @@ export default class WebviewController {
               action: message.action,
               files:
                 files && files.length > 0
-                  ? files.map((file) => path.toNamespacedPath(file.path))
+                  ? files.map((file) => path.resolve(file.path.substr(1)))
                   : undefined
             });
           });

--- a/src/views/webviewController.ts
+++ b/src/views/webviewController.ts
@@ -100,7 +100,7 @@ export default class WebviewController {
               action: message.action,
               files:
                 files && files.length > 0
-                  ? files.map((file) => path.resolve(file.path))
+                  ? files.map((file) => path.toNamespacedPath(file.path))
                   : undefined
             });
           });


### PR DESCRIPTION
https://jira.mongodb.org/browse/VSCODE-115

This PR tweaks our usage of `createTerminal` so that we pass the `mongosh` arguments as part of the command. This lets us not have to set/unset environment variables, while keeping the connection string credentials not showing in plain text in the console. This will also help the shell run across platforms since we're not relying on shell syntax for any commands.

- [x] Tested with SSL connection.
- [x] Tested on windows.
- [x] Tested on SSH Tunnel connection.

I think it would be nice to move the launching mongo shell and helpers into another file for organization. Didn't plan on doing it in this PR, we could though.

![Jun-08-2020 14-07-53](https://user-images.githubusercontent.com/1791149/84028733-8d0ccd80-a991-11ea-8f3e-e5cf10185d53.gif)
