### PR TITLE
Bump connection model version to pull in reference tag fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7803,9 +7803,9 @@
       }
     },
     "localforage": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.7.3.tgz",
-      "integrity": "sha512-1TulyYfc4udS7ECSBT2vwJksWbkwwTX8BzeUIiq8Y07Riy7bDAAnxDaPU/tWyOVmQAcWJIEIFP9lPfBGqVoPgQ==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.7.4.tgz",
+      "integrity": "sha512-3EmVZatmNVeCo/t6Te7P06h2alGwbq8wXlSkcSXMvDE2/edPmsVqTPlzGnZaqwZZDBs6v+kxWpqjVsqsNJT8jA==",
       "requires": {
         "lie": "3.1.1"
       }
@@ -9191,9 +9191,9 @@
       }
     },
     "mongodb-connection-model": {
-      "version": "16.1.2",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-model/-/mongodb-connection-model-16.1.2.tgz",
-      "integrity": "sha512-05rCV05dLOYrZ55Zle5fi3YZIkzRH17c0vWRxaP+ueB/2EwbtUIWZ/jxFPqHjoqaJPTHeElHN1X5lxEJ6pPrxQ==",
+      "version": "16.1.3",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-model/-/mongodb-connection-model-16.1.3.tgz",
+      "integrity": "sha512-X+7DsO4QhI8hvdJ86dfo7BHdhTDpMgacJzBupDmt55tuDX0ob2/A70Rn4pxIEnkccqo9sQX2wblhZsZRnGBmQg==",
       "requires": {
         "ampersand-model": "^8.0.0",
         "ampersand-rest-collection": "^6.0.0",
@@ -9212,9 +9212,9 @@
           "integrity": "sha512-S/yKGU1syOMzO86+dGpg2qGoDL0zvzcb262G+gqEy6TgP6rt6z6qxSFX/8X6vLC91P7G7C3nLs0+bvDzmvBA3Q=="
         },
         "mongodb": {
-          "version": "3.5.7",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.5.7.tgz",
-          "integrity": "sha512-lMtleRT+vIgY/JhhTn1nyGwnSMmJkJELp+4ZbrjctrnBxuLbj6rmLuJFz8W2xUzUqWmqoyVxJLYuC58ZKpcTYQ==",
+          "version": "3.5.9",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.5.9.tgz",
+          "integrity": "sha512-vXHBY1CsGYcEPoVWhwgxIBeWqP3dSu9RuRDsoLRPTITrcrgm1f0Ubu1xqF9ozMwv53agmEiZm0YGo+7WL3Nbug==",
           "requires": {
             "bl": "^2.2.0",
             "bson": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -618,7 +618,7 @@
     "dotenv": "^8.2.0",
     "encoding": "^0.1.12",
     "mongodb-cloud-info": "^1.1.2",
-    "mongodb-connection-model": "^16.1.2",
+    "mongodb-connection-model": "^16.1.3",
     "mongodb-data-service": "^16.8.0",
     "mongodb-ns": "^2.2.0",
     "mongodb-schema": "^8.2.5",


### PR DESCRIPTION
https://jira.mongodb.org/browse/COMPASS-4278

This pulls in the readPreferenceTag fix on connection model which should fix urls with readPreferenceTag groups.