### PR TITLE
VSCODE-116: Automate vscode publishing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,7 +73,16 @@ steps:
       echo "##vso[task.setvariable variable=extension_version]`npx json -f package.json version`"
     displayName: 'Set extension_version variable from package.json version'
   - bash: |
-      ls -alh mongodb-vscode-$(extension_version).vsix
+      vsixFilename=./mongodb-vscode-$(extension_version).vsix
+      maxsize=5000000 # 5MB
+      filesize=$(stat -c%s "$vsixFilename")
+
+      echo "Size of $vsixFilename = $filesize bytes."
+
+      if (( filesize > maxsize )); then
+        echo "File is over 5MB."
+        exit 1
+      fi
     displayName: 'Check .vsix filesize'
 
   # On linux create and publish a .vsix artifact for the build.
@@ -85,7 +94,7 @@ steps:
     condition: in(variables['agent.os'], 'Linux')
   - task: PublishPipelineArtifact@1
     inputs:
-      artifact: mongodb-vscode
-      targetPath: $(Build.ArtifactStagingDirectory)
+      ArtifactName: vsix
+      PathtoPublish: $(Build.ArtifactStagingDirectory)
     displayName: 'Publish .vsix artifact'
     condition: in(variables['agent.os'], 'Linux')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,7 +92,7 @@ steps:
       Contents: '**/*.vsix'
       TargetFolder: '$(build.artifactstagingdirectory)'
     condition: in(variables['agent.os'], 'Linux')
-  - task: PublishPipelineArtifact@1
+  - task: PublishBuildArtifacts@1
     displayName: 'Publish vsix artifact'
     inputs:
       PathtoPublish: '$(build.artifactstagingdirectory)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,7 +74,7 @@ steps:
     displayName: 'Set extension_version variable from package.json version'
   - bash: |
       vsixFilename=./mongodb-vscode-$(extension_version).vsix
-      maxsize=5000000 # 5MB
+      maxsize=3000000 # 5MB
       filesize=$(stat -c%s "$vsixFilename")
 
       echo "Size of $vsixFilename = $filesize bytes."
@@ -94,7 +94,7 @@ steps:
     condition: in(variables['agent.os'], 'Linux')
   - task: PublishPipelineArtifact@1
     inputs:
+      PathtoPublish: '$(build.artifactstagingdirectory)'
       ArtifactName: vsix
-      PathtoPublish: $(Build.ArtifactStagingDirectory)
     displayName: 'Publish .vsix artifact'
     condition: in(variables['agent.os'], 'Linux')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,7 +74,7 @@ steps:
     displayName: 'Set extension_version variable from package.json version'
   - bash: |
       vsixFilename=./mongodb-vscode-$(extension_version).vsix
-      maxsize=3000000 # 5MB
+      maxsize=5000000 # 5MB
       filesize=$(stat -c%s "$vsixFilename")
 
       echo "Size of $vsixFilename = $filesize bytes."

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,11 +90,11 @@ steps:
     displayName: 'Copy vsix to staging directory'
     inputs:
       Contents: '**/*.vsix'
-      TargetFolder: '$(Build.ArtifactStagingDirectory)'
+      TargetFolder: '$(build.artifactstagingdirectory)'
     condition: in(variables['agent.os'], 'Linux')
   - task: PublishPipelineArtifact@1
+    displayName: 'Publish vsix artifact'
     inputs:
       PathtoPublish: '$(build.artifactstagingdirectory)'
       ArtifactName: vsix
-    displayName: 'Publish .vsix artifact'
     condition: in(variables['agent.os'], 'Linux')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,10 +14,7 @@ strategy:
     mac:
       imageName: 'macos-latest'
     windows:
-      # NOTE (lucas): Also blocked on Windows 2019 by
-      # https://jira.mongodb.org/browse/NODE-2465
-      # imageName: 'windows-latest'
-      imageName: 'vs2017-win2016'
+      imageName: 'windows-latest'
 pool:
   vmImage: $(imageName)
 
@@ -78,3 +75,17 @@ steps:
   - bash: |
       ls -alh mongodb-vscode-$(extension_version).vsix
     displayName: 'Check .vsix filesize'
+
+  # On linux create and publish a .vsix artifact for the build.
+  - task: CopyFiles@2
+    displayName: 'Copy vsix to staging directory'
+    inputs:
+      Contents: '**/*.vsix'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)'
+    condition: in(variables['agent.os'], 'Linux')
+  - task: PublishPipelineArtifact@1
+    inputs:
+      artifact: mongodb-vscode
+      targetPath: $(Build.ArtifactStagingDirectory)
+    displayName: 'Publish .vsix artifact'
+    condition: in(variables['agent.os'], 'Linux')


### PR DESCRIPTION
https://jira.mongodb.org/browse/VSCODE-116

This PR adds a filesize check in our pipeline to make sure the bundle stays under 5MB. It also adds the built .vsix as a build artifact so we can more easily test and share builds.

These docs are very useful: https://code.visualstudio.com/api/working-with-extensions/continuous-integration https://code.visualstudio.com/api/working-with-extensions/publishing-extension

Also doing a bit of double checking/cleanup with this PR.
- Going over our .vscodeignore
- Looking at easy wins for making our extension size a bit smaller / faster


To download the artifact that each build creates on linux:
On the azure pipeline page there's an artifacts link:
<img width="688" alt="Screen Shot 2020-06-24 at 10 54 51 AM" src="https://user-images.githubusercontent.com/1791149/85525368-511c6e00-b609-11ea-8e5a-5678532e49c3.png">
And then the download is in the dropdown on the right:
<img width="1502" alt="Screen Shot 2020-06-24 at 10 55 07 AM" src="https://user-images.githubusercontent.com/1791149/85525380-537ec800-b609-11ea-8bbe-f78880ff03e5.png">

To publish, we have a token for the marketplace, so we can use `vsce publish [minor/major/patch]`. This will bump the package json and tag the release with a commit for the version as well as update the marketplace. We should ideally include our change log changes before doing this. https://code.visualstudio.com/api/working-with-extensions/publishing-extension#autoincrementing-the-extension-version