### PR TITLE
Launch mongo shell powershell fix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,8 +42,8 @@ steps:
   # TODO (lucas): Caching `./.vscode-test` in the future would be nice
   # so vscode-test isn't downloading the vscode zip everytime. same goes for mongoddb-runner.
   - bash: |
-      npm i -g npm@latest;
-      npm install -dd;
+      npm i -g npm@6.13.4;
+      npm ci;
     displayName: 'Install dependencies from npm'
 
   - bash: npm run test

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,7 +43,7 @@ steps:
   # so vscode-test isn't downloading the vscode zip everytime. same goes for mongoddb-runner.
   - bash: |
       npm i -g npm@latest;
-      npm ci;
+      npm install -dd;
     displayName: 'Install dependencies from npm'
 
   - bash: npm run test

--- a/src/commands/launchMongoShell.ts
+++ b/src/commands/launchMongoShell.ts
@@ -55,7 +55,7 @@ function launchMongoDBShellOnPowershell(
     : '';
 
   mongoDBShell.sendText(
-    `${shellCommand} ${mdbSslOptionsString}"$MDB_CONNECTION_STRING";`
+    `${shellCommand} ${mdbSslOptionsString}$Env:MDB_CONNECTION_STRING;`
   );
   mongoDBShell.show();
 }

--- a/src/commands/launchMongoShell.ts
+++ b/src/commands/launchMongoShell.ts
@@ -38,6 +38,67 @@ function getSslOptions(driverOptions: any): string[] {
   return mdbSslOptions;
 }
 
+function launchMongoDBShellOnPowershell(
+  shellCommand: string,
+  mdbConnectionString: string,
+  mdbSslOptions: string[]
+): void {
+  const mongoDBShell = vscode.window.createTerminal({
+    name: 'MongoDB Shell',
+    env: {
+      MDB_CONNECTION_STRING: mdbConnectionString
+    }
+  });
+
+  const mdbSslOptionsString = mdbSslOptions.length > 0
+    ? `${mdbSslOptions.join(' ')} `
+    : '';
+
+  mongoDBShell.sendText(
+    `${shellCommand} ${mdbSslOptionsString}"$MDB_CONNECTION_STRING";`
+  );
+  mongoDBShell.show();
+}
+
+function launchMongoDBShellOnCmd(
+  shellCommand: string,
+  mdbConnectionString: string,
+  mdbSslOptions: string[]
+): void {
+  const mongoDBShell = vscode.window.createTerminal({
+    name: 'MongoDB Shell',
+    env: {
+      MDB_CONNECTION_STRING: mdbConnectionString
+    }
+  });
+
+  const mdbSslOptionsString = mdbSslOptions.length > 0
+    ? `${mdbSslOptions.join(' ')} `
+    : '';
+
+  mongoDBShell.sendText(
+    `${shellCommand} ${mdbSslOptionsString}%MDB_CONNECTION_STRING%;`
+  );
+  mongoDBShell.show();
+}
+
+function launchMongoDBShellOnBash(
+  shellCommand: string,
+  mdbConnectionString: string,
+  mdbSslOptions: string[]
+): void {
+  const mongoDBShell = vscode.window.createTerminal({
+    name: 'MongoDB Shell',
+    shellPath: shellCommand,
+    shellArgs: [
+      mdbConnectionString,
+      ...mdbSslOptions
+    ]
+  });
+
+  mongoDBShell.show();
+}
+
 export default function openMongoDBShell(connectionController: ConnectionController): Promise<boolean> {
   let mdbSslOptions: string[] = [];
 
@@ -81,36 +142,14 @@ export default function openMongoDBShell(connectionController: ConnectionControl
     mdbSslOptions = getSslOptions(activeConnectionModel.driverOptions);
   }
 
-  const isWindowsBasedShell = userShell.includes('cmd.exe') || userShell.includes('powershell.exe');
-  if (isWindowsBasedShell) {
-    const mongoDBShell = vscode.window.createTerminal({
-      name: 'MongoDB Shell',
-      env: {
-        MDB_CONNECTION_STRING: mdbConnectionString
-      }
-    });
-
-    const mdbSslOptionsString = mdbSslOptions.length > 0
-      ? `${mdbSslOptions.join(' ')} `
-      : '';
-
-    mongoDBShell.sendText(
-      `${shellCommand} ${mdbSslOptionsString}%MDB_CONNECTION_STRING%;`
-    );
-    mongoDBShell.show();
+  if (userShell.includes('powershell.exe')) {
+    launchMongoDBShellOnPowershell(shellCommand, mdbConnectionString, mdbSslOptions);
+  } else if (userShell.includes('cmd.exe')) {
+    launchMongoDBShellOnCmd(shellCommand, mdbConnectionString, mdbSslOptions);
   } else {
     // Assume it's a bash environment. This may fail on certain
     // shells but should cover most cases.
-    const mongoDBShell = vscode.window.createTerminal({
-      name: 'MongoDB Shell',
-      shellPath: shellCommand,
-      shellArgs: [
-        mdbConnectionString,
-        ...mdbSslOptions
-      ]
-    });
-
-    mongoDBShell.show();
+    launchMongoDBShellOnBash(shellCommand, mdbConnectionString, mdbSslOptions);
   }
 
   return Promise.resolve(true);


### PR DESCRIPTION
Looks like the recent launch MongoDB shell work didn't cover `powershell.exe`, just `cmd.exe` windows shells. I thought I tested with powershell on the windows support ticket for this, I must have missed it or used a wrong version 😭  This PR adds custom support for powershell variable syntax.

Added tests for powershell and manually tested external connections on the 3 shells.

Bug report: https://github.com/mongodb-js/vscode/issues/142