### PR TITLE
VSCODE-97: Connect with code lenses

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,8 +173,8 @@
         "title": "Create MongoDB Playground"
       },
       {
-        "command": "mdb.showActiveConnectionInPlayground",
-        "title": "MongoDB: Show Active Connection In Playground"
+        "command": "mdb.changeActiveConnection",
+        "title": "MongoDB: Change Active Connection"
       },
       {
         "command": "mdb.runSelectedPlaygroundBlocks",
@@ -465,7 +465,7 @@
           "when": "false"
         },
         {
-          "command": "mdb.showActiveConnectionInPlayground",
+          "command": "mdb.changeActiveConnection",
           "when": "false"
         },
         {

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -783,7 +783,7 @@ export default class ConnectionController {
     this._disconnecting = disconnecting;
   }
 
-  private getСonnectionQuickPicks(): any[] {
+  public getСonnectionQuickPicks(): any[] {
     if (!this._connections) {
       return [
         {
@@ -803,22 +803,16 @@ export default class ConnectionController {
         }
       },
       ...Object.values(this._connections)
-        .map((item) => ({
+        .sort((connectionA: any, connectionB: any) =>
+          (connectionA.name || '').localeCompare(connectionB.name || '')
+        )
+        .map((item: any) => ({
           label: item.name,
           data: {
             type: NewConnectionType.SAVED_CONNECTION,
             connectionId: item.id
           }
         }))
-        .sort((collectionA: any, collectionB: any) => {
-          if (collectionA.name < collectionB.name) {
-            return -1;
-          }
-          if (collectionA.name > collectionB.name) {
-            return 1;
-          }
-          return 0;
-        })
     ];
   }
 

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -37,6 +37,11 @@ export type SavedConnectionInformation = {
 // A loaded connection contains connection information.
 export type LoadedConnection = SavedConnection & SavedConnectionInformation;
 
+export enum NewConnectionType {
+  NEW_CONNECTION = 'NEW_CONNECTION',
+  SAVED_CONNECTION = 'SAVED_CONNECTION'
+}
+
 export default class ConnectionController {
   // This is a map of connection ids to their configurations.
   // These connections can be saved on the session (runtime),
@@ -586,13 +591,13 @@ export default class ConnectionController {
     const connectionNameToRemove:
       | string
       | undefined = await vscode.window.showQuickPick(
-        connectionIds.map(
-          (id, index) => `${index + 1}: ${this._connections[id].name}`
-        ),
-        {
-          placeHolder: 'Choose a connection to remove...'
-        }
-      );
+      connectionIds.map(
+        (id, index) => `${index + 1}: ${this._connections[id].name}`
+      ),
+      {
+        placeHolder: 'Choose a connection to remove...'
+      }
+    );
 
     if (!connectionNameToRemove) {
       return Promise.resolve(false);
@@ -776,5 +781,70 @@ export default class ConnectionController {
 
   public setDisconnecting(disconnecting: boolean): void {
     this._disconnecting = disconnecting;
+  }
+
+  private getСonnectionQuickPicks(): any[] {
+    if (!this._connections) {
+      return [
+        {
+          label: 'Add new connection',
+          data: {
+            type: NewConnectionType.NEW_CONNECTION
+          }
+        }
+      ];
+    }
+
+    return [
+      {
+        label: 'Add new connection',
+        data: {
+          type: NewConnectionType.NEW_CONNECTION
+        }
+      },
+      ...Object.values(this._connections)
+        .map((item) => ({
+          label: item.name,
+          data: {
+            type: NewConnectionType.SAVED_CONNECTION,
+            connectionId: item.id
+          }
+        }))
+        .sort((collectionA: any, collectionB: any) => {
+          if (collectionA.name < collectionB.name) {
+            return -1;
+          }
+          if (collectionA.name > collectionB.name) {
+            return 1;
+          }
+          return 0;
+        })
+    ];
+  }
+
+  public changeActiveConnection(): Promise<boolean> {
+    return new Promise(async (resolve) => {
+      const selectedQuickPickItem = await vscode.window.showQuickPick(
+        this.getСonnectionQuickPicks(),
+        {
+          placeHolder: 'Select new connection...'
+        }
+      );
+
+      if (!selectedQuickPickItem) {
+        return resolve(true);
+      }
+
+      if (
+        selectedQuickPickItem.data.type === NewConnectionType.NEW_CONNECTION
+      ) {
+        return this.connectWithURI();
+      }
+
+      // Get the saved connection by id and return as the current connection.
+      return this.connectWithConnectionId(
+        selectedQuickPickItem.data.connectionId
+      );
+    });
   }
 }

--- a/src/editors/activeConnectionCodeLensProvider.ts
+++ b/src/editors/activeConnectionCodeLensProvider.ts
@@ -23,10 +23,15 @@ export default class ActiveConnectionCodeLensProvider
 
   public provideCodeLenses(): vscode.CodeLens[] {
     const codeLens = new vscode.CodeLens(new vscode.Range(0, 0, 0, 0));
-    const activeConnection = this._connectionController.getActiveDataService();
-    const message = activeConnection
-      ? `Currently connected to ${this._connectionController.getActiveConnectionName()}. Click here to change connection.`
-      : 'Disconnected. Click here to add connection.';
+    let message = '';
+
+    if (this._connectionController.isConnecting()) {
+      message = 'Connecting...';
+    } else if (this._connectionController.getActiveDataService()) {
+      message = `Currently connected to ${this._connectionController.getActiveConnectionName()}. Click here to change connection.`;
+    } else {
+      message = 'Disconnected. Click here to connect.';
+    }
 
     codeLens.command = {
       title: message,

--- a/src/editors/activeConnectionCodeLensProvider.ts
+++ b/src/editors/activeConnectionCodeLensProvider.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 
-export default class ActiveConnectionCodeLensProvider implements vscode.CodeLensProvider {
-  private _codeLenses: vscode.CodeLens[] = [];
+export default class ActiveConnectionCodeLensProvider
+  implements vscode.CodeLensProvider {
   private _connectionController: any;
   private _onDidChangeCodeLenses: vscode.EventEmitter<
     void
@@ -22,27 +22,18 @@ export default class ActiveConnectionCodeLensProvider implements vscode.CodeLens
   }
 
   public provideCodeLenses(): vscode.CodeLens[] {
+    const codeLens = new vscode.CodeLens(new vscode.Range(0, 0, 0, 0));
     const activeConnection = this._connectionController.getActiveDataService();
-
-    if (!activeConnection) {
-      return [];
-    }
-
-    this._codeLenses = [new vscode.CodeLens(new vscode.Range(0, 0, 0, 0))];
-
-    return this._codeLenses;
-  }
-
-  public resolveCodeLens?(codeLens: vscode.CodeLens): vscode.CodeLens {
-    const name = this._connectionController.getActiveConnectionName();
-    const message = `Currently connected to ${name}`;
+    const message = activeConnection
+      ? `Currently connected to ${this._connectionController.getActiveConnectionName()}. Click here to change connection.`
+      : 'Disconnected. Click here to add connection.';
 
     codeLens.command = {
       title: message,
-      command: "mdb.showActiveConnectionInPlayground",
-      arguments: [message]
+      command: 'mdb.changeActiveConnection',
+      arguments: []
     };
 
-    return codeLens;
+    return [codeLens];
   }
 }

--- a/src/editors/playgroundController.ts
+++ b/src/editors/playgroundController.ts
@@ -12,11 +12,6 @@ import { createLogger } from '../logging';
 
 const log = createLogger('playground controller');
 
-export enum NewConnectionType {
-  NEW_CONNECTION = 'NEW_CONNECTION',
-  SAVED_CONNECTION = 'SAVED_CONNECTION'
-}
-
 /**
  * This controller manages playground.
  */
@@ -173,70 +168,6 @@ export default class PlaygroundController {
           vscode.window.showTextDocument(document);
           resolve(true);
         }, reject);
-    });
-  }
-
-  private getСonnectionQuickPicks(): any[] {
-    if (!this._connectionController._connections) {
-      return [
-        {
-          label: 'Add new connection',
-          data: {
-            type: NewConnectionType.NEW_CONNECTION
-          }
-        }
-      ];
-    }
-
-    return [
-      {
-        label: 'Add new connection',
-        data: {
-          type: NewConnectionType.NEW_CONNECTION
-        }
-      },
-      ...Object.values(this._connectionController._connections)
-        .map((item) => ({
-          label: item.name,
-          data: {
-            type: NewConnectionType.SAVED_CONNECTION,
-            connectionModel: item.connectionModel
-          }
-        }))
-        .sort((collectionA: any, collectionB: any) => {
-          if (collectionA.name < collectionB.name) {
-            return -1;
-          }
-          if (collectionA.name > collectionB.name) {
-            return 1;
-          }
-          return 0;
-        })
-    ];
-  }
-
-  public changeActiveConnection(): Promise<boolean> {
-    return new Promise(async (resolve) => {
-      const selectedQuickPickItem = await vscode.window.showQuickPick(
-        this.getСonnectionQuickPicks(),
-        {
-          placeHolder: 'Select new connection...'
-        }
-      );
-
-      if (!selectedQuickPickItem) {
-        return resolve(true);
-      }
-
-      if (
-        selectedQuickPickItem.data.type === NewConnectionType.NEW_CONNECTION
-      ) {
-        return this._connectionController.connectWithURI();
-      }
-
-      return this._connectionController.parseNewConnectionAndConnect(
-        selectedQuickPickItem.data.connectionModel
-      );
     });
   }
 

--- a/src/explorer/databaseTreeItem.ts
+++ b/src/explorer/databaseTreeItem.ts
@@ -106,15 +106,9 @@ export default class DatabaseTreeItem extends vscode.TreeItem
       // Create new collection tree items, using previously cached items
       // where possible.
       collections
-        .sort((collectionA: any, collectionB: any) => {
-          if (collectionA.name < collectionB.name) {
-            return -1;
-          }
-          if (collectionA.name > collectionB.name) {
-            return 1;
-          }
-          return 0;
-        })
+        .sort((collectionA: any, collectionB: any) =>
+          (collectionA.name || '').localeCompare(collectionB.name || '')
+        )
         .forEach((collection: any) => {
           if (pastChildrenCache[collection.name]) {
             this._childrenCache[collection.name] = new CollectionTreeItem(

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -126,10 +126,8 @@ export default class MDBExtensionController implements vscode.Disposable {
     this.registerCommand('mdb.runPlayground', () =>
       this._playgroundController.runAllOrSelectedPlaygroundBlocks()
     );
-    this.registerCommand(
-      'mdb.showActiveConnectionInPlayground',
-      (message: string) =>
-        this._playgroundController.showActiveConnectionInPlayground(message)
+    this.registerCommand('mdb.changeActiveConnection', () =>
+      this._playgroundController.changeActiveConnection()
     );
 
     this.registerCommand('mdb.startStreamLanguageServerLogs', () =>
@@ -315,8 +313,9 @@ export default class MDBExtensionController implements vscode.Disposable {
           return false;
         }
 
-        const successfullyAddedCollection = await element
-          .onAddCollectionClicked(this._context);
+        const successfullyAddedCollection = await element.onAddCollectionClicked(
+          this._context
+        );
         if (successfullyAddedCollection) {
           vscode.window.showInformationMessage(
             'Collection successfully created.'
@@ -398,9 +397,7 @@ export default class MDBExtensionController implements vscode.Disposable {
     this.registerCommand(
       'mdb.copySchemaFieldName',
       async (fieldTreeItem: FieldTreeItem): Promise<boolean> => {
-        await vscode.env.clipboard.writeText(
-          fieldTreeItem.getFieldName()
-        );
+        await vscode.env.clipboard.writeText(fieldTreeItem.getFieldName());
         vscode.window.showInformationMessage('Copied to clipboard.');
 
         return true;

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -127,7 +127,7 @@ export default class MDBExtensionController implements vscode.Disposable {
       this._playgroundController.runAllOrSelectedPlaygroundBlocks()
     );
     this.registerCommand('mdb.changeActiveConnection', () =>
-      this._playgroundController.changeActiveConnection()
+      this._connectionController.changeActiveConnection()
     );
 
     this.registerCommand('mdb.startStreamLanguageServerLogs', () =>

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -841,6 +841,10 @@ suite('Connection Controller Test Suite', function () {
       await testConnectionController.addNewConnectionStringAndConnect(
         TEST_DATABASE_URI
       );
+      await testConnectionController.disconnect();
+
+      testConnectionController.clearAllConnections();
+
       await testConnectionController.loadSavedConnections();
 
       let connections = testConnectionController._connections;

--- a/src/test/suite/editors/activeDBCodeLensProvider.test.ts
+++ b/src/test/suite/editors/activeDBCodeLensProvider.test.ts
@@ -1,10 +1,15 @@
-import * as assert from 'assert';
+import * as vscode from 'vscode';
 import ConnectionController from '../../../connectionController';
 import { StatusView } from '../../../views';
 import ActiveDBCodeLensProvider from '../../../editors/activeConnectionCodeLensProvider';
-import { TestExtensionContext, mockVSCodeTextDocument } from '../stubs';
+import { TestExtensionContext } from '../stubs';
 import { StorageController } from '../../../storage';
 import TelemetryController from '../../../telemetry/telemetryController';
+import { beforeEach, afterEach } from 'mocha';
+
+const sinon = require('sinon');
+const chai = require('chai');
+const expect = chai.expect;
 
 suite('Active DB CodeLens Provider Test Suite', () => {
   const mockExtensionContext = new TestExtensionContext();
@@ -14,7 +19,7 @@ suite('Active DB CodeLens Provider Test Suite', () => {
     mockExtensionContext
   );
 
-  test('expected provideCodeLenses to return empty array when user is not connected', () => {
+  suite('user is not connected', () => {
     const testConnectionController = new ConnectionController(
       new StatusView(mockExtensionContext),
       mockStorageController,
@@ -23,13 +28,30 @@ suite('Active DB CodeLens Provider Test Suite', () => {
     const testCodeLensProvider = new ActiveDBCodeLensProvider(
       testConnectionController
     );
-    const codeLens = testCodeLensProvider.provideCodeLenses();
+    const mockShowQuickPick = sinon.fake.resolves();
 
-    assert(!!codeLens);
-    assert(codeLens.length === 0);
+    beforeEach(() => {
+      sinon.replace(vscode.window, 'showQuickPick', mockShowQuickPick);
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    test('show disconnected message in code lenses', () => {
+      const codeLens = testCodeLensProvider.provideCodeLenses();
+
+      expect(codeLens).to.be.an('array');
+      expect(codeLens.length).to.be.equal(1);
+      expect(codeLens[0].command?.title).to.be.equal(
+        'Disconnected. Click here to add connection.'
+      );
+      expect(codeLens[0].range.start.line).to.be.equal(0);
+      expect(codeLens[0].range.end.line).to.be.equal(0);
+    });
   });
 
-  test('expected provideCodeLenses to return a code lens with positions at the first line of the document', () => {
+  suite('user is connected', () => {
     const testConnectionController = new ConnectionController(
       new StatusView(mockExtensionContext),
       mockStorageController,
@@ -44,22 +66,34 @@ suite('Active DB CodeLens Provider Test Suite', () => {
       },
       client: {}
     };
+
     testConnectionController.setActiveConnection(mockActiveConnection);
 
-    const codeLens = testCodeLensProvider.provideCodeLenses();
+    beforeEach(() => {
+      sinon.replace(
+        testConnectionController,
+        'getActiveConnectionName',
+        sinon.fake.returns('fakeName')
+      );
+    });
 
-    assert(!!codeLens);
-    assert(codeLens.length === 1);
-    const range = codeLens[0].range;
-    const expectedStartLine = 0;
-    assert(
-      range.start.line === expectedStartLine,
-      `Expected a codeLens position to be at line ${expectedStartLine}, found ${range.start.line}`
-    );
-    const expectedEnd = 0;
-    assert(
-      range.end.line === expectedEnd,
-      `Expected a codeLens position to be at line ${expectedEnd}, found ${range.end.line}`
-    );
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    test('show active connection in code lenses', () => {
+      const codeLens = testCodeLensProvider.provideCodeLenses();
+
+      expect(codeLens).to.be.an('array');
+      expect(codeLens.length).to.be.equal(1);
+      expect(codeLens[0].command?.title).to.be.equal(
+        'Currently connected to fakeName. Click here to change connection.'
+      );
+      expect(codeLens[0].range.start.line).to.be.equal(0);
+      expect(codeLens[0].range.end.line).to.be.equal(0);
+      expect(codeLens[0].command?.command).to.be.equal(
+        'mdb.changeActiveConnection'
+      );
+    });
   });
 });

--- a/src/test/suite/editors/activeDBCodeLensProvider.test.ts
+++ b/src/test/suite/editors/activeDBCodeLensProvider.test.ts
@@ -44,7 +44,7 @@ suite('Active DB CodeLens Provider Test Suite', () => {
       expect(codeLens).to.be.an('array');
       expect(codeLens.length).to.be.equal(1);
       expect(codeLens[0].command?.title).to.be.equal(
-        'Disconnected. Click here to add connection.'
+        'Disconnected. Click here to connect.'
       );
       expect(codeLens[0].range.start.line).to.be.equal(0);
       expect(codeLens[0].range.end.line).to.be.equal(0);

--- a/src/test/suite/explorer/databaseTreeItem.test.ts
+++ b/src/test/suite/explorer/databaseTreeItem.test.ts
@@ -151,7 +151,7 @@ suite('DatabaseTreeItem Test Suite', () => {
     );
   });
 
-  test('collections are displayed in the alphanumerical order', (done) => {
+  test('collections are displayed in the alphanumerical case insensitive order', (done) => {
     const testDatabaseTreeItem = new DatabaseTreeItem(
       mockDatabaseNames[2],
       new DataServiceStub(),
@@ -163,10 +163,10 @@ suite('DatabaseTreeItem Test Suite', () => {
     const expectedCollectionsOrder = [
       '111_abc',
       '222_abc',
-      'AAA',
-      'ZZZ',
       'aaa',
-      'zzz'
+      'AAA',
+      'zzz',
+      'ZZZ'
     ];
 
     testDatabaseTreeItem

--- a/src/test/suite/mdbExtensionController.test.ts
+++ b/src/test/suite/mdbExtensionController.test.ts
@@ -1331,7 +1331,7 @@ suite('MDBExtensionController Test Suite', () => {
   test('mdb.changeActiveConnection command should call changeActiveConnection on the playground controller', (done) => {
     const mockChangeActiveConnection = sinon.fake.resolves();
     sinon.replace(
-      mdbTestExtension.testExtensionController._playgroundController,
+      mdbTestExtension.testExtensionController._connectionController,
       'changeActiveConnection',
       mockChangeActiveConnection
     );

--- a/src/test/suite/mdbExtensionController.test.ts
+++ b/src/test/suite/mdbExtensionController.test.ts
@@ -1328,20 +1328,20 @@ suite('MDBExtensionController Test Suite', () => {
       .then(done, done);
   });
 
-  test('mdb.showActiveConnectionInPlayground command should call showActiveConnectionInPlayground on the playground controller', (done) => {
-    const mockShowActiveConnectionInPlayground = sinon.fake.resolves();
+  test('mdb.changeActiveConnection command should call changeActiveConnection on the playground controller', (done) => {
+    const mockChangeActiveConnection = sinon.fake.resolves();
     sinon.replace(
       mdbTestExtension.testExtensionController._playgroundController,
-      'showActiveConnectionInPlayground',
-      mockShowActiveConnectionInPlayground
+      'changeActiveConnection',
+      mockChangeActiveConnection
     );
 
     vscode.commands
-      .executeCommand('mdb.showActiveConnectionInPlayground')
+      .executeCommand('mdb.changeActiveConnection')
       .then(() => {
         assert(
-          mockShowActiveConnectionInPlayground.called,
-          'Expected "showActiveConnectionInPlayground" to be called on the playground controller.'
+          mockChangeActiveConnection.called,
+          'Expected "changeActiveConnection" to be called on the playground controller.'
         );
       })
       .then(done, done);

--- a/src/test/suite/telemetry/telemetryController.test.ts
+++ b/src/test/suite/telemetry/telemetryController.test.ts
@@ -103,12 +103,9 @@ suite('Telemetry Controller Test Suite', () => {
 
   test('track command run event', (done) => {
     vscode.commands
-      .executeCommand('mdb.showActiveConnectionInPlayground', 'Test')
+      .executeCommand('mdb.addConnection')
       .then(() => {
-        sinon.assert.calledWith(
-          mockTrackCommandRun,
-          'mdb.showActiveConnectionInPlayground'
-        );
+        sinon.assert.calledWith(mockTrackCommandRun, 'mdb.addConnection');
       })
       .then(done, done);
   });


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
Use code lenses to connect to the new or saved connection:
- If a user is not connected show code lenses with a disconnected message. The code lenses' message is a link that opens a command palette with a list of saved connections started with the 'Add new connection' item.
- Clicking on the 'Add new connection' item opens a quick input to enter a new connection string.
- Clicking on any other connection item starts the connection process to the selected connection.
- After connecting the code lenses message shows the current connection host and port.
- If the user is connected and click on the code lenses again the same connection will be shown to allow the user select another connection or create a new connection.

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
