### PR TITLE
VSCODE-155: Allow connecting to a new connection when already connecting

### DIFF
--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -336,11 +336,6 @@ export default class ConnectionController {
       }).instanceId
     );
 
-    // TODO:
-    // 1. Version the connect.
-    // 2. Allow disconnecting while connecting.
-    // 3. Allow adding / connecting to a new database when connecting.
-
     // Store a version of this connection, so we can see when the conection
     // is successful if it is still the most recent connection attempt.
     this._connectingVersion++;
@@ -372,7 +367,9 @@ export default class ConnectionController {
           // If the current attempt is no longer the most recent attempt
           // or the connection no longer exists we silently end the connection
           // and return.
-          newDataService.disconnect(() => {});
+          try {
+            newDataService.disconnect(() => {});
+          } catch (e) { /* */ }
 
           return resolve(false);
         }
@@ -734,6 +731,11 @@ export default class ConnectionController {
     this._connecting = false;
     this._disconnecting = false;
     this._connectingConnectionId = '';
+    this._connectingVersion = 0;
+  }
+
+  public getConnectingVersion(): number {
+    return this._connectingVersion;
   }
 
   public setActiveConnection(newActiveConnection: any): void {

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -25,7 +25,7 @@ export enum DataServiceEventTypes {
 export enum ConnectionTypes {
   CONNECTION_FORM = 'CONNECTION_FORM',
   CONNECTION_STRING = 'CONNECTION_STRING',
-  CONNECTION_ID = 'CONNECTION_ID',
+  CONNECTION_ID = 'CONNECTION_ID'
 }
 
 export type SavedConnectionInformation = {
@@ -38,7 +38,7 @@ export type LoadedConnection = SavedConnection & SavedConnectionInformation;
 
 export enum NewConnectionType {
   NEW_CONNECTION = 'NEW_CONNECTION',
-  SAVED_CONNECTION = 'SAVED_CONNECTION',
+  SAVED_CONNECTION = 'SAVED_CONNECTION'
 }
 
 export default class ConnectionController {

--- a/src/explorer/mdbConnectionsTreeItem.ts
+++ b/src/explorer/mdbConnectionsTreeItem.ts
@@ -88,28 +88,6 @@ export default class MDBConnectionsTreeItem extends vscode.TreeItem
       );
     });
 
-    if (
-      this._connectionController.isConnecting() &&
-      !this._connectionController.isConnectionWithIdSaved(
-        this._connectionController.getConnectingConnectionId()
-      )
-    ) {
-      const notYetEstablishConnectionTreeItem = new vscode.TreeItem(
-        this._connectionController.getConnectingConnectionName() ||
-          'New Connection'
-      );
-
-      notYetEstablishConnectionTreeItem.description = 'connecting...';
-
-      // When we're connecting to a new connection we add simple node showing the connecting status.
-      return Promise.resolve(
-        sortTreeItemsByLabel([
-          ...Object.values(this._connectionTreeItems),
-          notYetEstablishConnectionTreeItem
-        ])
-      );
-    }
-
     return Promise.resolve(
       sortTreeItemsByLabel(Object.values(this._connectionTreeItems))
     );

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -927,7 +927,7 @@ suite('Connection Controller Test Suite', function () {
     testConnectionController.connectWithConnectionId(connectionId);
 
     // Ensure the connection starts but doesn't time out yet.
-    await sleep(2);
+    await sleep(0);
 
     assert(testConnectionController.isConnecting());
 

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -61,89 +61,83 @@ suite('Connection Controller Test Suite', function () {
   });
 
   test('it connects to mongodb', async () => {
-    try {
-      const succesfullyConnected = await testConnectionController.addNewConnectionStringAndConnect(
-        TEST_DATABASE_URI
-      );
-      const connnectionId =
-        testConnectionController.getActiveConnectionId() || '';
-      const name = testConnectionController._connections[connnectionId].name;
-      const connectionModel = testConnectionController.getActiveConnectionModel();
-      const dataService = testConnectionController.getActiveDataService();
+    const succesfullyConnected = await testConnectionController.addNewConnectionStringAndConnect(
+      TEST_DATABASE_URI
+    );
+    const connnectionId =
+      testConnectionController.getActiveConnectionId() || '';
+    const name = testConnectionController._connections[connnectionId].name;
+    const connectionModel = testConnectionController.getActiveConnectionModel();
+    const dataService = testConnectionController.getActiveDataService();
 
-      assert(
-        succesfullyConnected === true,
-        'Expected a successful connection response.'
-      );
-      assert(
-        testConnectionController.getSavedConnections().length === 1,
-        'Expected there to be 1 connection in the connection list.'
-      );
-      assert(
-        name === 'localhost:27018',
-        `Expected active connection to be 'localhost:27018' found ${name}`
-      );
-      assert(connectionModel !== null);
-      assert(
-        connectionModel?.getAttributes({
-          derived: true
-        }).instanceId === 'localhost:27018'
-      );
-      assert(dataService !== null);
-      assert(
-        testConnectionController._activeConnectionModel?.appname.startsWith(
-          'mongodb-vscode'
-        )
-      );
-      assert(testConnectionController.isCurrentlyConnected());
-    } catch (error) {
-      assert(false);
-    }
+    assert(
+      succesfullyConnected === true,
+      'Expected a successful connection response.'
+    );
+    assert(
+      testConnectionController.getSavedConnections().length === 1,
+      'Expected there to be 1 connection in the connection list.'
+    );
+    assert(
+      name === 'localhost:27018',
+      `Expected active connection to be 'localhost:27018' found ${name}`
+    );
+    assert(connectionModel !== null);
+    assert(
+      connectionModel?.getAttributes({
+        derived: true
+      }).instanceId === 'localhost:27018'
+    );
+    assert(dataService !== null);
+    assert(
+      testConnectionController._activeConnectionModel?.appname.startsWith(
+        'mongodb-vscode'
+      )
+    );
+    assert(testConnectionController.isCurrentlyConnected());
   });
 
   test('"disconnect()" disconnects from the active connection', async () => {
-    try {
-      const succesfullyConnected = await testConnectionController.addNewConnectionStringAndConnect(
-        TEST_DATABASE_URI
-      );
+    const succesfullyConnected = await testConnectionController.addNewConnectionStringAndConnect(
+      TEST_DATABASE_URI
+    );
 
-      assert(
-        succesfullyConnected === true,
-        'Expected a successful (true) connection response.'
-      );
+    assert(
+      succesfullyConnected === true,
+      'Expected a successful (true) connection response.'
+    );
 
-      const successfullyDisconnected = await testConnectionController.disconnect();
+    const successfullyDisconnected = await testConnectionController.disconnect();
 
-      // Disconnecting should keep the connection contract, just disconnected.
-      const connectionsCount = testConnectionController.getSavedConnections()
-        .length;
-      const connnectionId = testConnectionController.getActiveConnectionId();
-      const connectionModel = testConnectionController.getActiveConnectionModel();
-      const dataService = testConnectionController.getActiveDataService();
+    // Disconnecting should keep the connection contract, just disconnected.
+    const connectionsCount = testConnectionController.getSavedConnections()
+      .length;
+    const connnectionId = testConnectionController.getActiveConnectionId();
+    const connectionModel = testConnectionController.getActiveConnectionModel();
+    const dataService = testConnectionController.getActiveDataService();
 
-      assert(
-        successfullyDisconnected === true,
-        'Expected a successful (true) disconnect response.'
-      );
-      assert(
-        connectionsCount === 1,
-        `Expected the amount of connections to be 1 found ${connectionsCount}.`
-      );
-      assert(
-        connnectionId === null,
-        `Expected the active connection id to be null, found ${connnectionId}`
-      );
-      assert(connectionModel === null);
-      assert(dataService === null);
-      assert(!testConnectionController.isCurrentlyConnected());
-    } catch (error) {
-      assert(false);
-    }
+    assert(
+      successfullyDisconnected === true,
+      'Expected a successful (true) disconnect response.'
+    );
+    assert(
+      connectionsCount === 1,
+      `Expected the amount of connections to be 1 found ${connectionsCount}.`
+    );
+    assert(
+      connnectionId === null,
+      `Expected the active connection id to be null, found ${connnectionId}`
+    );
+    assert(connectionModel === null);
+    assert(dataService === null);
+    assert(!testConnectionController.isCurrentlyConnected());
   });
 
   test('"removeMongoDBConnection()" returns a reject promise when there is no active connection', async () => {
     try {
       await testConnectionController.onRemoveMongoDBConnection();
+
+      assert(false, 'Expected to error.');
     } catch (error) {
       assert(!!error, `Expected an error response, recieved ${error}.`);
     }
@@ -168,23 +162,21 @@ suite('Connection Controller Test Suite', function () {
   });
 
   test('when adding a new connection it disconnects from the current connection', async () => {
-    try {
-      const succesfullyConnected = await testConnectionController.addNewConnectionStringAndConnect(
-        TEST_DATABASE_URI
-      );
+    const succesfullyConnected = await testConnectionController.addNewConnectionStringAndConnect(
+      TEST_DATABASE_URI
+    );
 
-      assert(
-        succesfullyConnected,
-        'Expected a successful (true) connection response.'
-      );
-    } catch (error) {
-      assert(false);
-    }
+    assert(
+      succesfullyConnected,
+      'Expected a successful (true) connection response.'
+    );
 
     try {
       await testConnectionController.addNewConnectionStringAndConnect(
         testDatabaseURI2WithTimeout
       );
+
+      assert(false, 'Expected to fail the connection and succeeded.');
     } catch (error) {
       const expectedError = 'Failed to connect';
 
@@ -203,80 +195,6 @@ suite('Connection Controller Test Suite', function () {
     }
   });
 
-  test('"connect()" failed when we are currently connecting', async () => {
-    testConnectionController.setConnnecting(true);
-
-    try {
-      await testConnectionController.addNewConnectionStringAndConnect(
-        TEST_DATABASE_URI
-      );
-    } catch (error) {
-      const expectedMessage = 'Unable to connect: already connecting.';
-
-      assert(
-        error.message === expectedMessage,
-        `Expected "${expectedMessage}" when connecting when already connecting, recieved "${error.message}"`
-      );
-    }
-  });
-
-  test('"connect()" failed when we are currently disconnecting', async () => {
-    testConnectionController.setDisconnecting(true);
-
-    try {
-      await testConnectionController.addNewConnectionStringAndConnect(
-        TEST_DATABASE_URI
-      );
-    } catch (error) {
-      const expectedMessage = 'Unable to connect: currently disconnecting.';
-
-      assert(
-        error.message === expectedMessage,
-        `Expected "${expectedMessage}" when connecting while disconnecting, recieved "${error.message}"`
-      );
-    }
-  });
-
-  test('"disconnect()" fails when we are currently connecting', async () => {
-    const expectedMessage =
-      'Unable to disconnect: currently connecting to an instance.';
-    const fakeVscodeErrorMessage = sinon.fake();
-
-    testConnectionController.setConnnecting(true);
-    sinon.replace(vscode.window, 'showErrorMessage', fakeVscodeErrorMessage);
-
-    try {
-      await testConnectionController.disconnect();
-
-      assert(
-        fakeVscodeErrorMessage.firstCall.args[0] === expectedMessage,
-        `Expected "${expectedMessage}" when disconnecting while connecting, recieved "${fakeVscodeErrorMessage.firstCall.args[0]}"`
-      );
-    } catch (error) {
-      assert(!!error, 'Expected an error disconnect response.');
-    }
-  });
-
-  test('"disconnect()" fails when we are currently disconnecting', async () => {
-    const expectedMessage =
-      'Unable to disconnect: already disconnecting from an instance.';
-    const fakeVscodeErrorMessage = sinon.fake();
-
-    testConnectionController.setDisconnecting(true);
-    sinon.replace(vscode.window, 'showErrorMessage', fakeVscodeErrorMessage);
-
-    try {
-      await testConnectionController.disconnect();
-
-      assert(
-        fakeVscodeErrorMessage.firstCall.args[0] === expectedMessage,
-        `Expected "${expectedMessage}" when disconnecting while already disconnecting, recieved "${fakeVscodeErrorMessage.firstCall.args[0]}"`
-      );
-    } catch (error) {
-      assert(!!error, 'Expected an error disconnect response.');
-    }
-  });
-
   test('"connect()" should fire a CONNECTIONS_DID_CHANGE event', async () => {
     let isConnectionChanged: any = false;
 
@@ -287,16 +205,12 @@ suite('Connection Controller Test Suite', function () {
       }
     );
 
-    try {
-      await testConnectionController.addNewConnectionStringAndConnect(
-        TEST_DATABASE_URI
-      );
-      await sleep(50);
+    await testConnectionController.addNewConnectionStringAndConnect(
+      TEST_DATABASE_URI
+    );
+    await sleep(50);
 
-      assert(isConnectionChanged === true);
-    } catch (error) {
-      assert(false);
-    }
+    assert(isConnectionChanged === true);
   });
 
   const expectedTimesToFire = 3;
@@ -311,182 +225,162 @@ suite('Connection Controller Test Suite', function () {
       }
     );
 
-    try {
-      await testConnectionController.addNewConnectionStringAndConnect(
-        TEST_DATABASE_URI
-      );
-      await testConnectionController.disconnect();
-      await sleep(500);
+    await testConnectionController.addNewConnectionStringAndConnect(
+      TEST_DATABASE_URI
+    );
+    await testConnectionController.disconnect();
+    await sleep(500);
 
-      assert(
-        connectionEventFiredCount === expectedTimesToFire,
-        `Expected connection event to be fired ${expectedTimesToFire} times, got ${connectionEventFiredCount}.`
-      );
-    } catch (error) {
-      assert(false);
-    }
+    assert(
+      connectionEventFiredCount === expectedTimesToFire,
+      `Expected connection event to be fired ${expectedTimesToFire} times, got ${connectionEventFiredCount}.`
+    );
   });
 
   test('when there are no existing connections in the store and the connection controller loads connections', async () => {
-    try {
-      await testConnectionController.loadSavedConnections();
+    await testConnectionController.loadSavedConnections();
 
-      const connectionsCount = testConnectionController.getSavedConnections()
-        .length;
+    const connectionsCount = testConnectionController.getSavedConnections()
+      .length;
 
-      assert(
-        connectionsCount === 0,
-        `Expected connections to be 0 found ${connectionsCount}`
-      );
-    } catch (error) {
-      assert(false);
-    }
+    assert(
+      connectionsCount === 0,
+      `Expected connections to be 0 found ${connectionsCount}`
+    );
   });
 
   test('the connection model loads both global and workspace stored connection models', async () => {
     const expectedDriverUri =
       'mongodb://localhost:27018/?readPreference=primary&ssl=false';
 
-    try {
-      await vscode.workspace
-        .getConfiguration('mdb.connectionSaving')
-        .update(
-          'defaultConnectionSavingLocation',
-          DefaultSavingLocations.Global
-        );
-      await testConnectionController.addNewConnectionStringAndConnect(
-        TEST_DATABASE_URI
+    await vscode.workspace
+      .getConfiguration('mdb.connectionSaving')
+      .update(
+        'defaultConnectionSavingLocation',
+        DefaultSavingLocations.Global
       );
-      await testConnectionController.addNewConnectionStringAndConnect(
-        TEST_DATABASE_URI
+    await testConnectionController.addNewConnectionStringAndConnect(
+      TEST_DATABASE_URI
+    );
+    await testConnectionController.addNewConnectionStringAndConnect(
+      TEST_DATABASE_URI
+    );
+    await vscode.workspace
+      .getConfiguration('mdb.connectionSaving')
+      .update(
+        'defaultConnectionSavingLocation',
+        DefaultSavingLocations.Workspace
       );
-      await vscode.workspace
-        .getConfiguration('mdb.connectionSaving')
-        .update(
-          'defaultConnectionSavingLocation',
-          DefaultSavingLocations.Workspace
-        );
-      await testConnectionController.addNewConnectionStringAndConnect(
-        TEST_DATABASE_URI
-      );
-      await testConnectionController.addNewConnectionStringAndConnect(
-        TEST_DATABASE_URI
-      );
-      await testConnectionController.disconnect();
-      testConnectionController.clearAllConnections();
-      await testConnectionController.loadSavedConnections();
+    await testConnectionController.addNewConnectionStringAndConnect(
+      TEST_DATABASE_URI
+    );
+    await testConnectionController.addNewConnectionStringAndConnect(
+      TEST_DATABASE_URI
+    );
+    await testConnectionController.disconnect();
+    testConnectionController.clearAllConnections();
+    await testConnectionController.loadSavedConnections();
 
-      const connections = testConnectionController._connections;
+    const connections = testConnectionController._connections;
 
-      assert(
-        Object.keys(connections).length === 4,
-        `Expected 4 connection configurations found ${
-          Object.keys(connections).length
-        }`
-      );
-      assert(
-        connections[Object.keys(connections)[0]].name === 'localhost:27018',
-        "Expected loaded connection to include name 'localhost:27018'"
-      );
-      assert(
-        connections[Object.keys(connections)[2]].driverUrl ===
-          expectedDriverUri,
-        `Expected loaded connection to include driver url '${expectedDriverUri}' found '${
-          connections[Object.keys(connections)[2]].driverUrl
-        }'`
-      );
-    } catch (error) {
-      assert(false);
-    }
+    assert(
+      Object.keys(connections).length === 4,
+      `Expected 4 connection configurations found ${
+        Object.keys(connections).length
+      }`
+    );
+    assert(
+      connections[Object.keys(connections)[0]].name === 'localhost:27018',
+      "Expected loaded connection to include name 'localhost:27018'"
+    );
+    assert(
+      connections[Object.keys(connections)[2]].driverUrl ===
+        expectedDriverUri,
+      `Expected loaded connection to include driver url '${expectedDriverUri}' found '${
+        connections[Object.keys(connections)[2]].driverUrl
+      }'`
+    );
   });
 
   test('when a connection is added it is saved to the global store', async () => {
-    try {
-      await testConnectionController.loadSavedConnections();
-      await vscode.workspace
-        .getConfiguration('mdb.connectionSaving')
-        .update(
-          'defaultConnectionSavingLocation',
-          DefaultSavingLocations.Global
-        );
-      await testConnectionController.addNewConnectionStringAndConnect(
-        TEST_DATABASE_URI
+    await testConnectionController.loadSavedConnections();
+    await vscode.workspace
+      .getConfiguration('mdb.connectionSaving')
+      .update(
+        'defaultConnectionSavingLocation',
+        DefaultSavingLocations.Global
       );
+    await testConnectionController.addNewConnectionStringAndConnect(
+      TEST_DATABASE_URI
+    );
 
-      const globalStoreConnections = mockStorageController.get(
-        StorageVariables.GLOBAL_SAVED_CONNECTIONS
-      );
+    const globalStoreConnections = mockStorageController.get(
+      StorageVariables.GLOBAL_SAVED_CONNECTIONS
+    );
 
-      assert(
-        Object.keys(globalStoreConnections).length === 1,
-        `Expected global store connections to have 1 connection found ${
-          Object.keys(globalStoreConnections).length
-        }`
-      );
+    assert(
+      Object.keys(globalStoreConnections).length === 1,
+      `Expected global store connections to have 1 connection found ${
+        Object.keys(globalStoreConnections).length
+      }`
+    );
 
-      const id = Object.keys(globalStoreConnections)[0];
+    const id = Object.keys(globalStoreConnections)[0];
 
-      assert(
-        globalStoreConnections[id].name === testDatabaseInstanceId,
-        `Expected global stored connection to have correct name '${testDatabaseInstanceId}' found ${globalStoreConnections[id].name}`
-      );
+    assert(
+      globalStoreConnections[id].name === testDatabaseInstanceId,
+      `Expected global stored connection to have correct name '${testDatabaseInstanceId}' found ${globalStoreConnections[id].name}`
+    );
 
-      const workspaceStoreConnections = mockStorageController.get(
-        StorageVariables.WORKSPACE_SAVED_CONNECTIONS
-      );
+    const workspaceStoreConnections = mockStorageController.get(
+      StorageVariables.WORKSPACE_SAVED_CONNECTIONS
+    );
 
-      assert(
-        workspaceStoreConnections === undefined,
-        `Expected workspace store connections to be 'undefined' found ${workspaceStoreConnections}`
-      );
-    } catch (error) {
-      assert(false);
-    }
+    assert(
+      workspaceStoreConnections === undefined,
+      `Expected workspace store connections to be 'undefined' found ${workspaceStoreConnections}`
+    );
   });
 
   test('when a connection is added it is saved to the workspace store', async () => {
-    try {
-      await testConnectionController.loadSavedConnections();
-      await vscode.workspace
-        .getConfiguration('mdb.connectionSaving')
-        .update(
-          'defaultConnectionSavingLocation',
-          DefaultSavingLocations.Workspace
-        );
-      await testConnectionController.addNewConnectionStringAndConnect(
-        TEST_DATABASE_URI
+    await testConnectionController.loadSavedConnections();
+    await vscode.workspace
+      .getConfiguration('mdb.connectionSaving')
+      .update(
+        'defaultConnectionSavingLocation',
+        DefaultSavingLocations.Workspace
       );
+    await testConnectionController.addNewConnectionStringAndConnect(
+      TEST_DATABASE_URI
+    );
 
-      const workspaceStoreConnections = mockStorageController.get(
-        StorageVariables.WORKSPACE_SAVED_CONNECTIONS,
-        StorageScope.WORKSPACE
-      );
+    const workspaceStoreConnections = mockStorageController.get(
+      StorageVariables.WORKSPACE_SAVED_CONNECTIONS,
+      StorageScope.WORKSPACE
+    );
 
-      assert(
-        Object.keys(workspaceStoreConnections).length === 1,
-        `Expected workspace store connections to have 1 connection found ${
-          Object.keys(workspaceStoreConnections).length
-        }`
-      );
+    assert(
+      Object.keys(workspaceStoreConnections).length === 1,
+      `Expected workspace store connections to have 1 connection found ${
+        Object.keys(workspaceStoreConnections).length
+      }`
+    );
 
-      const id = Object.keys(workspaceStoreConnections)[0];
+    const id = Object.keys(workspaceStoreConnections)[0];
 
-      assert(
-        workspaceStoreConnections[id].name === testDatabaseInstanceId,
-        `Expected workspace stored connection to have correct name '${testDatabaseInstanceId}' found ${workspaceStoreConnections[id].name}`
-      );
+    assert(
+      workspaceStoreConnections[id].name === testDatabaseInstanceId,
+      `Expected workspace stored connection to have correct name '${testDatabaseInstanceId}' found ${workspaceStoreConnections[id].name}`
+    );
 
-      const globalStoreConnections = mockStorageController.get(
-        StorageVariables.GLOBAL_SAVED_CONNECTIONS
-      );
+    const globalStoreConnections = mockStorageController.get(
+      StorageVariables.GLOBAL_SAVED_CONNECTIONS
+    );
 
-      assert(
-        globalStoreConnections === undefined,
-        `Expected global store connections to be 'undefined' found ${globalStoreConnections}`
-      );
-    } catch (error) {
-      assert(false);
-    }
+    assert(
+      globalStoreConnections === undefined,
+      `Expected global store connections to be 'undefined' found ${globalStoreConnections}`
+    );
   });
 
   test('a connection can be connected to by id', async () => {
@@ -501,330 +395,302 @@ suite('Connection Controller Test Suite', function () {
         });
       });
 
-    try {
-      const connectionModel = await getConnection(TEST_DATABASE_URI);
+    const connectionModel = await getConnection(TEST_DATABASE_URI);
 
-      testConnectionController._connections = {
-        '25': {
-          id: '25',
-          driverUrl: TEST_DATABASE_URI,
-          name: 'tester',
-          connectionModel,
-          storageLocation: StorageScope.NONE
-        }
-      };
+    testConnectionController._connections = {
+      '25': {
+        id: '25',
+        driverUrl: TEST_DATABASE_URI,
+        name: 'tester',
+        connectionModel,
+        storageLocation: StorageScope.NONE
+      }
+    };
 
-      const successfulConnection = await testConnectionController.connectWithConnectionId(
-        '25'
-      );
+    const successfulConnection = await testConnectionController.connectWithConnectionId(
+      '25'
+    );
 
-      assert(successfulConnection);
-      assert(testConnectionController.getActiveConnectionId() === '25');
-    } catch (error) {
-      assert(false);
-    }
+    assert(successfulConnection);
+    assert(testConnectionController.getActiveConnectionId() === '25');
   });
 
   test('a saved connection can be loaded and connected to', async () => {
-    try {
-      await testConnectionController.loadSavedConnections();
-      await vscode.workspace
-        .getConfiguration('mdb.connectionSaving')
-        .update(
-          'defaultConnectionSavingLocation',
-          DefaultSavingLocations.Workspace
-        );
-      await testConnectionController.addNewConnectionStringAndConnect(
-        TEST_DATABASE_URI
+    await testConnectionController.loadSavedConnections();
+    await vscode.workspace
+      .getConfiguration('mdb.connectionSaving')
+      .update(
+        'defaultConnectionSavingLocation',
+        DefaultSavingLocations.Workspace
       );
+    await testConnectionController.addNewConnectionStringAndConnect(
+      TEST_DATABASE_URI
+    );
 
-      const workspaceStoreConnections = mockStorageController.get(
-        StorageVariables.WORKSPACE_SAVED_CONNECTIONS,
-        StorageScope.WORKSPACE
-      );
+    const workspaceStoreConnections = mockStorageController.get(
+      StorageVariables.WORKSPACE_SAVED_CONNECTIONS,
+      StorageScope.WORKSPACE
+    );
 
-      assert(
-        Object.keys(workspaceStoreConnections).length === 1,
-        `Expected workspace store connections to have 1 connection found ${
-          Object.keys(workspaceStoreConnections).length
-        }`
-      );
+    assert(
+      Object.keys(workspaceStoreConnections).length === 1,
+      `Expected workspace store connections to have 1 connection found ${
+        Object.keys(workspaceStoreConnections).length
+      }`
+    );
 
-      await testConnectionController.disconnect();
-      testConnectionController.clearAllConnections();
+    await testConnectionController.disconnect();
+    testConnectionController.clearAllConnections();
 
-      assert(
-        testConnectionController.getSavedConnections().length === 0,
-        'Expected no connection configs.'
-      );
+    assert(
+      testConnectionController.getSavedConnections().length === 0,
+      'Expected no connection configs.'
+    );
 
-      // Activate (which will load the past connection).
-      await testConnectionController.loadSavedConnections();
+    // Activate (which will load the past connection).
+    await testConnectionController.loadSavedConnections();
 
-      assert(
-        testConnectionController.getSavedConnections().length === 1,
-        `Expected 1 connection config, found ${
-          testConnectionController.getSavedConnections().length
-        }.`
-      );
+    assert(
+      testConnectionController.getSavedConnections().length === 1,
+      `Expected 1 connection config, found ${
+        testConnectionController.getSavedConnections().length
+      }.`
+    );
 
-      const id = testConnectionController.getSavedConnections()[0].id;
+    const id = testConnectionController.getSavedConnections()[0].id;
 
-      await testConnectionController.connectWithConnectionId(id);
+    await testConnectionController.connectWithConnectionId(id);
 
-      const activeId = testConnectionController.getActiveConnectionId();
-      const name = testConnectionController._connections[activeId || ''].name;
+    const activeId = testConnectionController.getActiveConnectionId();
+    const name = testConnectionController._connections[activeId || ''].name;
 
-      assert(
-        activeId === id,
-        `Expected the active connection to be '${id}', found ${activeId}.`
-      );
-      assert(
-        name === 'localhost:27018',
-        `Expected the active connection name to be 'localhost:27018', found ${name}.`
-      );
+    assert(
+      activeId === id,
+      `Expected the active connection to be '${id}', found ${activeId}.`
+    );
+    assert(
+      name === 'localhost:27018',
+      `Expected the active connection name to be 'localhost:27018', found ${name}.`
+    );
 
-      const port =
-        testConnectionController._connections[activeId || ''].connectionModel
-          .port;
+    const port =
+      testConnectionController._connections[activeId || ''].connectionModel
+        .port;
 
-      assert(
-        port === 27018,
-        `Expected the active connection port to be '27018', found ${port}.`
-      );
-    } catch (error) {
-      assert(false);
-    }
+    assert(
+      port === 27018,
+      `Expected the active connection port to be '27018', found ${port}.`
+    );
   });
 
   test('"getConnectionStringFromConnectionId" returns the driver uri of a connection', async () => {
     const expectedDriverUri =
       'mongodb://localhost:27018/?readPreference=primary&ssl=false';
 
-    try {
-      await testConnectionController.loadSavedConnections();
-      await testConnectionController.addNewConnectionStringAndConnect(
-        TEST_DATABASE_URI
-      );
+    await testConnectionController.loadSavedConnections();
+    await testConnectionController.addNewConnectionStringAndConnect(
+      TEST_DATABASE_URI
+    );
 
-      const activeConnectionId = testConnectionController.getActiveConnectionId();
+    const activeConnectionId = testConnectionController.getActiveConnectionId();
 
-      assert(
-        activeConnectionId !== null,
-        'Expected active connection to not be null'
-      );
+    assert(
+      activeConnectionId !== null,
+      'Expected active connection to not be null'
+    );
 
-      const testDriverUri = testConnectionController.getConnectionStringFromConnectionId(
-        activeConnectionId || ''
-      );
+    const testDriverUri = testConnectionController.getConnectionStringFromConnectionId(
+      activeConnectionId || ''
+    );
 
-      assert(
-        testDriverUri === expectedDriverUri,
-        `Expected to be returned the driver uri "${expectedDriverUri}" found ${testDriverUri}`
-      );
-    } catch (error) {
-      assert(false);
-    }
+    assert(
+      testDriverUri === expectedDriverUri,
+      `Expected to be returned the driver uri "${expectedDriverUri}" found ${testDriverUri}`
+    );
   });
 
   test('when a connection is added and the user has set it to not save on default it is not saved', async () => {
-    try {
-      await testConnectionController.loadSavedConnections();
+    await testConnectionController.loadSavedConnections();
 
-      // Don't save connections on default.
-      await vscode.workspace
-        .getConfiguration('mdb.connectionSaving')
-        .update(
-          'defaultConnectionSavingLocation',
-          DefaultSavingLocations['Session Only']
-        );
-      await testConnectionController.addNewConnectionStringAndConnect(
-        TEST_DATABASE_URI
+    // Don't save connections on default.
+    await vscode.workspace
+      .getConfiguration('mdb.connectionSaving')
+      .update(
+        'defaultConnectionSavingLocation',
+        DefaultSavingLocations['Session Only']
       );
+    await testConnectionController.addNewConnectionStringAndConnect(
+      TEST_DATABASE_URI
+    );
 
-      const objectString = JSON.stringify(undefined);
-      const globalStoreConnections = mockStorageController.get(
-        StorageVariables.GLOBAL_SAVED_CONNECTIONS
-      );
+    const objectString = JSON.stringify(undefined);
+    const globalStoreConnections = mockStorageController.get(
+      StorageVariables.GLOBAL_SAVED_CONNECTIONS
+    );
 
-      assert(
-        JSON.stringify(globalStoreConnections) === objectString,
-        `Expected global store connections to be an empty object found ${globalStoreConnections}`
-      );
+    assert(
+      JSON.stringify(globalStoreConnections) === objectString,
+      `Expected global store connections to be an empty object found ${globalStoreConnections}`
+    );
 
-      const workspaceStoreConnections = mockStorageController.get(
-        StorageVariables.WORKSPACE_SAVED_CONNECTIONS,
-        StorageScope.WORKSPACE
-      );
+    const workspaceStoreConnections = mockStorageController.get(
+      StorageVariables.WORKSPACE_SAVED_CONNECTIONS,
+      StorageScope.WORKSPACE
+    );
 
-      assert(
-        JSON.stringify(workspaceStoreConnections) === objectString,
-        `Expected workspace store connections to be an empty object found ${JSON.stringify(
-          workspaceStoreConnections
-        )}`
-      );
-    } catch (error) {
-      assert(false);
-    }
+    assert(
+      JSON.stringify(workspaceStoreConnections) === objectString,
+      `Expected workspace store connections to be an empty object found ${JSON.stringify(
+        workspaceStoreConnections
+      )}`
+    );
   });
 
   test('when a connection is removed it is also removed from workspace storage', async () => {
-    try {
-      await testConnectionController.loadSavedConnections();
-      await vscode.workspace
-        .getConfiguration('mdb.connectionSaving')
-        .update(
-          'defaultConnectionSavingLocation',
-          DefaultSavingLocations.Workspace
-        );
-      await testConnectionController.addNewConnectionStringAndConnect(
-        TEST_DATABASE_URI
+    await testConnectionController.loadSavedConnections();
+    await vscode.workspace
+      .getConfiguration('mdb.connectionSaving')
+      .update(
+        'defaultConnectionSavingLocation',
+        DefaultSavingLocations.Workspace
       );
+    await testConnectionController.addNewConnectionStringAndConnect(
+      TEST_DATABASE_URI
+    );
 
-      const workspaceStoreConnections = mockStorageController.get(
-        StorageVariables.WORKSPACE_SAVED_CONNECTIONS,
-        StorageScope.WORKSPACE
-      );
+    const workspaceStoreConnections = mockStorageController.get(
+      StorageVariables.WORKSPACE_SAVED_CONNECTIONS,
+      StorageScope.WORKSPACE
+    );
 
-      assert(
-        Object.keys(workspaceStoreConnections).length === 1,
-        `Expected workspace store connections to have 1 connection found ${
-          Object.keys(workspaceStoreConnections).length
-        }`
-      );
+    assert(
+      Object.keys(workspaceStoreConnections).length === 1,
+      `Expected workspace store connections to have 1 connection found ${
+        Object.keys(workspaceStoreConnections).length
+      }`
+    );
 
-      const connectionId =
-        testConnectionController.getActiveConnectionId() || 'a';
+    const connectionId =
+      testConnectionController.getActiveConnectionId() || 'a';
 
-      await testConnectionController.disconnect();
-      await testConnectionController.removeSavedConnection(connectionId);
+    await testConnectionController.disconnect();
+    await testConnectionController.removeSavedConnection(connectionId);
 
-      const postWorkspaceStoreConnections = mockStorageController.get(
-        StorageVariables.WORKSPACE_SAVED_CONNECTIONS,
-        StorageScope.WORKSPACE
-      );
+    const postWorkspaceStoreConnections = mockStorageController.get(
+      StorageVariables.WORKSPACE_SAVED_CONNECTIONS,
+      StorageScope.WORKSPACE
+    );
 
-      assert(
-        Object.keys(postWorkspaceStoreConnections).length === 0,
-        `Expected workspace store connections to have 0 connections found ${
-          Object.keys(postWorkspaceStoreConnections).length
-        }`
-      );
-    } catch (error) {
-      assert(false);
-    }
+    assert(
+      Object.keys(postWorkspaceStoreConnections).length === 0,
+      `Expected workspace store connections to have 0 connections found ${
+        Object.keys(postWorkspaceStoreConnections).length
+      }`
+    );
   });
 
   test('when a connection is removed it is also removed from global storage', async () => {
-    try {
-      await testConnectionController.loadSavedConnections();
-      await vscode.workspace
-        .getConfiguration('mdb.connectionSaving')
-        .update(
-          'defaultConnectionSavingLocation',
-          DefaultSavingLocations.Global
-        );
-      await testConnectionController.addNewConnectionStringAndConnect(
-        TEST_DATABASE_URI
+    await testConnectionController.loadSavedConnections();
+    await vscode.workspace
+      .getConfiguration('mdb.connectionSaving')
+      .update(
+        'defaultConnectionSavingLocation',
+        DefaultSavingLocations.Global
       );
+    await testConnectionController.addNewConnectionStringAndConnect(
+      TEST_DATABASE_URI
+    );
 
-      const globalStoreConnections = mockStorageController.get(
-        StorageVariables.GLOBAL_SAVED_CONNECTIONS
-      );
+    const globalStoreConnections = mockStorageController.get(
+      StorageVariables.GLOBAL_SAVED_CONNECTIONS
+    );
 
-      assert(
-        Object.keys(globalStoreConnections).length === 1,
-        `Expected workspace store connections to have 1 connection found ${
-          Object.keys(globalStoreConnections).length
-        }`
-      );
+    assert(
+      Object.keys(globalStoreConnections).length === 1,
+      `Expected workspace store connections to have 1 connection found ${
+        Object.keys(globalStoreConnections).length
+      }`
+    );
 
-      const connectionId =
-        testConnectionController.getActiveConnectionId() || 'a';
-      await testConnectionController.removeSavedConnection(connectionId);
+    const connectionId =
+      testConnectionController.getActiveConnectionId() || 'a';
+    await testConnectionController.removeSavedConnection(connectionId);
 
-      const postGlobalStoreConnections = mockStorageController.get(
-        StorageVariables.GLOBAL_SAVED_CONNECTIONS
-      );
+    const postGlobalStoreConnections = mockStorageController.get(
+      StorageVariables.GLOBAL_SAVED_CONNECTIONS
+    );
 
-      assert(
-        Object.keys(postGlobalStoreConnections).length === 0,
-        `Expected global store connections to have 0 connections found ${
-          Object.keys(postGlobalStoreConnections).length
-        }`
-      );
-    } catch (error) {
-      assert(false);
-    }
+    assert(
+      Object.keys(postGlobalStoreConnections).length === 0,
+      `Expected global store connections to have 0 connections found ${
+        Object.keys(postGlobalStoreConnections).length
+      }`
+    );
   });
 
   test('a saved connection can be renamed and loaded', async () => {
-    try {
-      await testConnectionController.loadSavedConnections();
-      await vscode.workspace
-        .getConfiguration('mdb.connectionSaving')
-        .update(
-          'defaultConnectionSavingLocation',
-          DefaultSavingLocations.Workspace
-        );
-      await testConnectionController.addNewConnectionStringAndConnect(
-        TEST_DATABASE_URI
+    await testConnectionController.loadSavedConnections();
+    await vscode.workspace
+      .getConfiguration('mdb.connectionSaving')
+      .update(
+        'defaultConnectionSavingLocation',
+        DefaultSavingLocations.Workspace
       );
+    await testConnectionController.addNewConnectionStringAndConnect(
+      TEST_DATABASE_URI
+    );
 
-      const workspaceStoreConnections = mockStorageController.get(
-        StorageVariables.WORKSPACE_SAVED_CONNECTIONS,
-        StorageScope.WORKSPACE
-      );
+    const workspaceStoreConnections = mockStorageController.get(
+      StorageVariables.WORKSPACE_SAVED_CONNECTIONS,
+      StorageScope.WORKSPACE
+    );
 
-      assert(
-        Object.keys(workspaceStoreConnections).length === 1,
-        `Expected workspace store connections to have 1 connection found ${
-          Object.keys(workspaceStoreConnections).length
-        }`
-      );
+    assert(
+      Object.keys(workspaceStoreConnections).length === 1,
+      `Expected workspace store connections to have 1 connection found ${
+        Object.keys(workspaceStoreConnections).length
+      }`
+    );
 
-      const connectionId =
-        testConnectionController.getActiveConnectionId() || 'zz';
-      const mockInputBoxResolves = sinon.stub();
+    const connectionId =
+      testConnectionController.getActiveConnectionId() || 'zz';
+    const mockInputBoxResolves = sinon.stub();
 
-      mockInputBoxResolves.onCall(0).resolves('new connection name');
-      sinon.replace(vscode.window, 'showInputBox', mockInputBoxResolves);
+    mockInputBoxResolves.onCall(0).resolves('new connection name');
+    sinon.replace(vscode.window, 'showInputBox', mockInputBoxResolves);
 
-      const renameSuccess = await testConnectionController.renameConnection(
-        connectionId
-      );
+    const renameSuccess = await testConnectionController.renameConnection(
+      connectionId
+    );
 
-      assert(renameSuccess);
+    assert(renameSuccess);
 
-      await testConnectionController.disconnect();
+    await testConnectionController.disconnect();
 
-      testConnectionController.clearAllConnections();
+    testConnectionController.clearAllConnections();
 
-      assert(
-        testConnectionController.getSavedConnections().length === 0,
-        'Expected no saved connection.'
-      );
+    assert(
+      testConnectionController.getSavedConnections().length === 0,
+      'Expected no saved connection.'
+    );
 
-      // Activate (which will load the past connection).
-      await testConnectionController.loadSavedConnections();
+    // Activate (which will load the past connection).
+    await testConnectionController.loadSavedConnections();
 
-      assert(
-        testConnectionController.getSavedConnections().length === 1,
-        `Expected 1 connection config, found ${
-          testConnectionController.getSavedConnections().length
-        }.`
-      );
+    assert(
+      testConnectionController.getSavedConnections().length === 1,
+      `Expected 1 connection config, found ${
+        testConnectionController.getSavedConnections().length
+      }.`
+    );
 
-      const id = testConnectionController.getSavedConnections()[0].id;
-      const name = testConnectionController._connections[id || 'x'].name;
+    const id = testConnectionController.getSavedConnections()[0].id;
+    const name = testConnectionController._connections[id || 'x'].name;
 
-      assert(
-        name === 'new connection name',
-        `Expected the active connection name to be 'new connection name', found '${name}'.`
-      );
-    } catch (error) {
-      assert(false);
-    }
+    assert(
+      name === 'new connection name',
+      `Expected the active connection name to be 'new connection name', found '${name}'.`
+    );
   });
 
   test('СonnectionQuickPicks list is displayed in the alphanumerical case insensitive order', async () => {

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -694,85 +694,115 @@ suite('Connection Controller Test Suite', function () {
   });
 
   test('СonnectionQuickPicks list is displayed in the alphanumerical case insensitive order', async () => {
-    try {
-      await vscode.workspace
-        .getConfiguration('mdb.connectionSaving')
-        .update(
-          'defaultConnectionSavingLocation',
-          DefaultSavingLocations.Workspace
-        );
-      await testConnectionController.addNewConnectionStringAndConnect(
-        TEST_DATABASE_URI
+    await vscode.workspace
+      .getConfiguration('mdb.connectionSaving')
+      .update(
+        'defaultConnectionSavingLocation',
+        DefaultSavingLocations.Workspace
       );
-      await testConnectionController.addNewConnectionStringAndConnect(
-        TEST_DATABASE_URI
-      );
-      await testConnectionController.disconnect();
+    await testConnectionController.addNewConnectionStringAndConnect(
+      TEST_DATABASE_URI
+    );
+    await testConnectionController.addNewConnectionStringAndConnect(
+      TEST_DATABASE_URI
+    );
+    await testConnectionController.disconnect();
 
-      testConnectionController.clearAllConnections();
+    testConnectionController.clearAllConnections();
 
-      await testConnectionController.loadSavedConnections();
+    await testConnectionController.loadSavedConnections();
 
-      let connections = testConnectionController._connections;
-      let connectionIds = Object.keys(connections);
+    let connections = testConnectionController._connections;
+    const connectionIds = Object.keys(connections);
 
-      assert(
-        connectionIds.length === 2,
-        `Expected 2 connection configurations found ${connectionIds.length}`
-      );
-      assert(
-        connections[connectionIds[0]].name === 'localhost:27018',
-        `Expected the first connection name to be 'localhost:27018', found '${
-          connections[connectionIds[0]].name
-        }'.`
-      );
-      assert(
-        connections[connectionIds[1]].name === 'localhost:27018',
-        `Expected the second connection name to be 'localhost:27018', found '${
-          connections[connectionIds[1]].name
-        }'.`
-      );
+    assert(
+      connectionIds.length === 2,
+      `Expected 2 connection configurations found ${connectionIds.length}`
+    );
+    assert(
+      connections[connectionIds[0]].name === 'localhost:27018',
+      `Expected the first connection name to be 'localhost:27018', found '${
+        connections[connectionIds[0]].name
+      }'.`
+    );
+    assert(
+      connections[connectionIds[1]].name === 'localhost:27018',
+      `Expected the second connection name to be 'localhost:27018', found '${
+        connections[connectionIds[1]].name
+      }'.`
+    );
 
-      const mockInputBoxResolves = sinon.stub();
+    const mockInputBoxResolves = sinon.stub();
 
-      mockInputBoxResolves.onCall(0).resolves('Lynx');
-      sinon.replace(vscode.window, 'showInputBox', mockInputBoxResolves);
+    mockInputBoxResolves.onCall(0).resolves('Lynx');
+    sinon.replace(vscode.window, 'showInputBox', mockInputBoxResolves);
 
-      const renameSuccess = await testConnectionController.renameConnection(
-        connectionIds[0]
-      );
+    const renameSuccess = await testConnectionController.renameConnection(
+      connectionIds[0]
+    );
 
-      assert(renameSuccess);
+    assert(renameSuccess);
 
-      await testConnectionController.loadSavedConnections();
+    await testConnectionController.loadSavedConnections();
 
-      connections = testConnectionController._connections;
+    connections = testConnectionController._connections;
 
-      assert(
-        connectionIds.length === 2,
-        `Expected 2 connection configurations found ${connectionIds.length}`
-      );
+    assert(
+      connectionIds.length === 2,
+      `Expected 2 connection configurations found ${connectionIds.length}`
+    );
 
-      const connectionQuickPicks = testConnectionController.getСonnectionQuickPicks();
+    const connectionQuickPicks = testConnectionController.getСonnectionQuickPicks();
 
-      assert(
-        connectionQuickPicks.length === 3,
-        `Expected 3 connections found ${connectionIds.length} in connectionQuickPicks`
-      );
-      assert(
-        connectionQuickPicks[0].label === 'Add new connection',
-        `Expected the first quick pick label to be 'Add new connection', found '${connectionQuickPicks[0].name}'.`
-      );
-      assert(
-        connectionQuickPicks[1].label === 'localhost:27018',
-        `Expected the second quick pick label to be 'localhost:27018', found '${connectionQuickPicks[1].name}'.`
-      );
-      assert(
-        connectionQuickPicks[2].label === 'Lynx',
-        `Expected the third quick pick labele to be 'Lynx', found '${connectionQuickPicks[2].name}'.`
-      );
-    } catch (error) {
-      assert(false);
-    }
+    assert(
+      connectionQuickPicks.length === 3,
+      `Expected 3 connections found ${connectionIds.length} in connectionQuickPicks`
+    );
+    assert(
+      connectionQuickPicks[0].label === 'Add new connection',
+      `Expected the first quick pick label to be 'Add new connection', found '${connectionQuickPicks[0].name}'.`
+    );
+    assert(
+      connectionQuickPicks[1].label === 'localhost:27018',
+      `Expected the second quick pick label to be 'localhost:27018', found '${connectionQuickPicks[1].name}'.`
+    );
+    assert(
+      connectionQuickPicks[2].label === 'Lynx',
+      `Expected the third quick pick labele to be 'Lynx', found '${connectionQuickPicks[2].name}'.`
+    );
+  });
+
+  suite('connecting to a new connection when already connecting', () => {
+    test('connects to the new connection', async () => {
+      // todo
+    });
+
+    test('updates the connecting version', async () => {
+      // todo
+    });
+
+    test('disconnects the first attempt', async () => {
+      // todo
+    });
+  });
+
+  test('two disconnects on one connection at once', async () => {
+    // todo
+  });
+
+  test('two disconnects on one connection at once', async () => {
+    // todo
   });
 });
+
+/*
+To test:
+- Disconnect when connecting.
+- Remove when connecting.
+- Remove not active connecting.
+- Remove when disconnecting.
+- Connect to 5 connections.
+
+- todo Create ticket for the db user connecting.
+*/
+

--- a/src/test/suite/views/webviewController.test.ts
+++ b/src/test/suite/views/webviewController.test.ts
@@ -286,7 +286,7 @@ suite('Connect Form View Test Suite', () => {
     });
   });
 
-  test('web view sends an successful connect result on an overridden unsuccessful connection', (done) => {
+  test('web view sends an unsuccessful connect result on an attempt that is overridden', (done) => {
     const testExtensionContext = new TestExtensionContext();
     const testStorageController = new StorageController(testExtensionContext);
     const testTelemetryController = new TelemetryController(
@@ -302,8 +302,8 @@ suite('Connect Form View Test Suite', () => {
     const fakeWebview = {
       html: '',
       postMessage: (message: any): void => {
-        assert(message.connectionSuccess);
-        assert(message.connectionMessage.includes('Successfully connected.'));
+        assert(!message.connectionSuccess);
+        assert(message.connectionMessage.includes('Unable to connect.'));
 
         testConnectionController.disconnect();
         done();

--- a/src/test/suite/views/webviewController.test.ts
+++ b/src/test/suite/views/webviewController.test.ts
@@ -181,7 +181,11 @@ suite('Connect Form View Test Suite', () => {
       html: '',
       postMessage: (message: any): void => {
         assert(message.connectionSuccess);
-        assert(message.connectionMessage === 'Successfully connected.');
+        const expectedMessage = 'Successfully connected to localhost:27018.';
+        assert(
+          message.connectionMessage === expectedMessage,
+          `Expected connection message "${message.connectionMessage}" to equal ${expectedMessage}`
+        );
 
         testConnectionController.disconnect();
         done();
@@ -286,7 +290,7 @@ suite('Connect Form View Test Suite', () => {
     });
   });
 
-  test('web view sends an unsuccessful connect result on an attempt that is overridden', (done) => {
+  test('web view sends an successful connect result on an attempt that is overridden', (done) => {
     const testExtensionContext = new TestExtensionContext();
     const testStorageController = new StorageController(testExtensionContext);
     const testTelemetryController = new TelemetryController(
@@ -302,8 +306,12 @@ suite('Connect Form View Test Suite', () => {
     const fakeWebview = {
       html: '',
       postMessage: (message: any): void => {
-        assert(!message.connectionSuccess);
-        assert(message.connectionMessage.includes('Unable to connect.'));
+        assert(message.connectionSuccess);
+        const expectedMessage = 'Successfully connected to localhost:27018.';
+        assert(
+          message.connectionMessage === expectedMessage,
+          `Expected connection message "${message.connectionMessage}" to equal ${expectedMessage}`
+        );
 
         testConnectionController.disconnect();
         done();

--- a/src/views/webview-app/components/app.tsx
+++ b/src/views/webview-app/components/app.tsx
@@ -8,8 +8,7 @@ import {
   ActionTypes,
   ConnectionEventOccuredAction,
   FilePickerActions,
-  FilePickerActionTypes,
-  UriConnectionEventOccuredAction
+  FilePickerActionTypes
 } from '../store/actions';
 import {
   MESSAGE_TYPES,
@@ -28,10 +27,6 @@ type props = {
     action: FilePickerActionTypes,
     files: string[] | undefined
   ) => void;
-  onUriConnectedEvent: (
-    successfullyConnected: boolean,
-    connectionMessage: string
-  ) => void;
 };
 
 class App extends React.Component<props> {
@@ -42,17 +37,10 @@ class App extends React.Component<props> {
 
       switch (message.command) {
         case MESSAGE_TYPES.CONNECT_RESULT:
-          if (message.isUriConnection) {
-            this.props.onUriConnectedEvent(
-              message.connectionSuccess,
-              message.connectionMessage
-            );
-          } else {
-            this.props.onConnectedEvent(
-              message.connectionSuccess,
-              message.connectionMessage
-            );
-          }
+          this.props.onConnectedEvent(
+            message.connectionSuccess,
+            message.connectionMessage
+          );
 
           return;
         case MESSAGE_TYPES.FILE_PICKER_RESULTS:
@@ -90,14 +78,6 @@ const mapDispatchToProps: props = {
   ): FilePickerActions => ({
     type: action,
     files
-  }),
-  onUriConnectedEvent: (
-    successfullyConnected: boolean,
-    connectionMessage: string
-  ): UriConnectionEventOccuredAction => ({
-    type: ActionTypes.URI_CONNECTION_EVENT_OCCURED,
-    successfullyConnected,
-    connectionMessage
   })
 };
 

--- a/src/views/webview-app/components/connect-form/connection-form.tsx
+++ b/src/views/webview-app/components/connect-form/connection-form.tsx
@@ -23,14 +23,13 @@ import { AppState } from '../../store/store';
 const styles = require('../../connect.module.less');
 
 type stateProps = {
+  connectionMessage: string;
   currentConnection: ConnectionModel;
   errorMessage: string;
   isConnected: boolean;
   isConnecting: boolean;
-  isUriConnected: boolean;
   isValid: boolean;
   syntaxErrorMessage: string;
-  uriConnectionMessage: string;
 };
 
 type dispatchProps = {
@@ -133,16 +132,16 @@ class ConnectionForm extends React.Component<props> {
    *
    * @returns {React.Component}
    */
-  renderURIConnectionMessage(): React.ReactNode {
-    const { isUriConnected, uriConnectionMessage } = this.props;
+  renderConnectionMessage(): React.ReactNode {
+    const { isConnected, connectionMessage } = this.props;
 
-    if (isUriConnected) {
+    if (isConnected && connectionMessage) {
       return (
         <div className={styles['connection-message-container']}>
           <div className={styles['connection-message-container-success']}>
             <div
               className={styles['connection-message']}
-            >{`${uriConnectionMessage} You may now close this window.`}</div>
+            >{connectionMessage}</div>
           </div>
         </div>
       );
@@ -151,6 +150,7 @@ class ConnectionForm extends React.Component<props> {
 
   render(): React.ReactNode {
     const {
+      connectionMessage,
       currentConnection,
       errorMessage,
       isConnected,
@@ -172,12 +172,13 @@ class ConnectionForm extends React.Component<props> {
             connect with a connection string
           </a>
         </div>
-        {this.renderURIConnectionMessage()}
+        {this.renderConnectionMessage()}
         <div className={classnames(styles.fields)}>
           {this.renderHostnameArea()}
           {this.renderConnectionOptionsArea()}
         </div>
         <FormActions
+          connectionMessage={connectionMessage}
           currentConnection={currentConnection}
           errorMessage={errorMessage}
           isConnected={isConnected}
@@ -192,14 +193,13 @@ class ConnectionForm extends React.Component<props> {
 
 const mapStateToProps = (state: AppState): stateProps => {
   return {
+    connectionMessage: state.connectionMessage,
     currentConnection: state.currentConnection,
     errorMessage: state.errorMessage,
     isConnected: state.isConnected,
     isConnecting: state.isConnecting,
-    isUriConnected: state.isUriConnected,
     isValid: state.isValid,
-    syntaxErrorMessage: state.syntaxErrorMessage,
-    uriConnectionMessage: state.uriConnectionMessage
+    syntaxErrorMessage: state.syntaxErrorMessage
   };
 };
 

--- a/src/views/webview-app/components/connect-form/form-actions.tsx
+++ b/src/views/webview-app/components/connect-form/form-actions.tsx
@@ -13,6 +13,7 @@ type dispatchProps = {
 };
 
 type props = {
+  connectionMessage: string;
   currentConnection: ConnectionModel;
   errorMessage: string;
   isConnected: boolean;
@@ -86,9 +87,7 @@ class FormActions extends React.Component<props> {
    * @returns {React.Component}
    */
   renderMessage(): React.ReactNode {
-    const connection = this.props.currentConnection;
-    const server = `${connection.hostname}:${connection.port}`;
-    let message: React.ReactNode = `Success! Connected to ${server}. You may now close this window.`;
+    let message: React.ReactNode = this.props.connectionMessage;
     let colorStyle = styles['connection-message-container-success'];
     let hasMessage = false;
 

--- a/src/views/webview-app/extension-app-message-constants.ts
+++ b/src/views/webview-app/extension-app-message-constants.ts
@@ -23,7 +23,6 @@ export interface ConnectResultsMessage extends BasicWebviewMessage {
   command: MESSAGE_TYPES.CONNECT_RESULT;
   connectionSuccess: boolean;
   connectionMessage: string;
-  isUriConnection: boolean;
 }
 
 export interface OpenConnectionStringInputMessage extends BasicWebviewMessage {

--- a/src/views/webview-app/store/actions.ts
+++ b/src/views/webview-app/store/actions.ts
@@ -34,9 +34,8 @@ export enum ActionTypes {
   SSL_CERT_CHANGED = 'SSL_CERT_CHANGED',
   SSL_METHOD_CHANGED = 'SSL_METHOD_CHANGED',
   SSL_PASS_CHANGED = 'SSL_PASS_CHANGED',
-  URI_CONNECTION_EVENT_OCCURED = 'URI_CONNECTION_EVENT_OCCURED',
   USERNAME_CHANGED = 'USERNAME_CHANGED',
-  X509_USERNAME_CHANGED = 'X509_USERNAME_CHANGED'
+  X509_USERNAME_CHANGED = 'X509_USERNAME_CHANGED',
 }
 
 export type FilePickerActionTypes =
@@ -206,12 +205,6 @@ export interface SSLPassChangedAction extends BaseAction {
   sslPass: string;
 }
 
-export interface UriConnectionEventOccuredAction extends BaseAction {
-  type: ActionTypes.URI_CONNECTION_EVENT_OCCURED;
-  successfullyConnected: boolean;
-  connectionMessage: string;
-}
-
 export interface UsernameChangedAction extends BaseAction {
   type: ActionTypes.USERNAME_CHANGED;
   mongodbUsername: string;
@@ -258,6 +251,5 @@ export type Actions =
   | SSLCertChangedAction
   | SSLMethodChangedAction
   | SSLPassChangedAction
-  | UriConnectionEventOccuredAction
   | UsernameChangedAction
   | X509UsernameChangedAction;

--- a/src/views/webview-app/store/store.ts
+++ b/src/views/webview-app/store/store.ts
@@ -11,27 +11,25 @@ declare var acquireVsCodeApi: any;
 const vscode = acquireVsCodeApi();
 
 export interface AppState {
+  connectionMessage: string;
   currentConnection: ConnectionModel;
   isValid: boolean;
   isConnecting: boolean;
   isConnected: boolean;
-  isUriConnected: boolean;
   errorMessage: string;
   syntaxErrorMessage: string;
   savedMessage: string;
-  uriConnectionMessage: string;
 }
 
 export const initialState = {
+  connectionMessage: '',
   currentConnection: new ConnectionModel(),
   isValid: true,
   isConnecting: false,
   isConnected: false,
-  isUriConnected: false,
   errorMessage: '',
   syntaxErrorMessage: '',
-  savedMessage: '',
-  uriConnectionMessage: ''
+  savedMessage: ''
 };
 
 const showFilePicker = (
@@ -89,14 +87,6 @@ export const rootReducer = (
         };
       }
 
-      if (state.isConnecting) {
-        return {
-          ...state,
-          errorMessage: 'Already connecting, please wait.',
-          isValid: false
-        };
-      }
-
       vscode.postMessage({
         command: MESSAGE_TYPES.CONNECT,
         connectionModel: state.currentConnection
@@ -122,10 +112,10 @@ export const rootReducer = (
     case ActionTypes.CONNECTION_FORM_CHANGED:
       return {
         ...state,
+        connectionMessage: '',
+        errorMessage: '',
         isValid: true,
         isConnected: false,
-        isUriConnected: false,
-        errorMessage: '',
         syntaxErrorMessage: ''
       };
 
@@ -135,9 +125,8 @@ export const rootReducer = (
         isConnecting: false,
         isConnected: action.successfullyConnected,
         isValid: action.successfullyConnected ? state.isValid : false,
-        errorMessage: action.successfullyConnected
-          ? state.errorMessage
-          : action.connectionMessage
+        errorMessage: action.successfullyConnected ? '' : action.connectionMessage,
+        connectionMessage: action.connectionMessage
       };
 
     case ActionTypes.HOSTNAME_CHANGED:
@@ -231,7 +220,7 @@ export const rootReducer = (
 
       return {
         ...state,
-        isUriConnected: false
+        isConnected: false
       };
 
     case ActionTypes.PASSWORD_CHANGED:
@@ -381,13 +370,6 @@ export const rootReducer = (
           ...state.currentConnection,
           sslPass: action.sslPass
         }
-      };
-
-    case ActionTypes.URI_CONNECTION_EVENT_OCCURED:
-      return {
-        ...state,
-        isUriConnected: action.successfullyConnected,
-        uriConnectionMessage: action.connectionMessage
       };
 
     case ActionTypes.USERNAME_CHANGED:

--- a/src/views/webviewController.ts
+++ b/src/views/webviewController.ts
@@ -70,7 +70,12 @@ export default class WebviewController {
         this._connectionController
           .parseNewConnectionAndConnect(message.connectionModel)
           .then(
-            (connectionSuccess) => {
+            () => {
+              // Because this connection attempt could have been overriden
+              // while it was being made, we return the connection controller's
+              // overall connected state to show if a connection was made.
+              const connectionSuccess = this._connectionController.isCurrentlyConnected();
+
               panel.webview.postMessage({
                 command: MESSAGE_TYPES.CONNECT_RESULT,
                 connectionSuccess,

--- a/src/views/webviewController.ts
+++ b/src/views/webviewController.ts
@@ -70,12 +70,7 @@ export default class WebviewController {
         this._connectionController
           .parseNewConnectionAndConnect(message.connectionModel)
           .then(
-            () => {
-              // Because this connection attempt could have been overriden
-              // while it was being made, we return the connection controller's
-              // overall connected state to show if a connection was made.
-              const connectionSuccess = this._connectionController.isCurrentlyConnected();
-
+            (connectionSuccess) => {
               panel.webview.postMessage({
                 command: MESSAGE_TYPES.CONNECT_RESULT,
                 connectionSuccess,


### PR DESCRIPTION
VSCODE-155

This PR adds versioning to connecting so that a new connection can be attempted while there's already a connection in progress. Only the most recent connection attempt will successfully open the connection to be used.

This PR also allows users to remove connections while they're currently connecting. I think this PR adds a bit of complexity to how we connect to new connections and disconnect, so there can be some risk of introducing a possible race condition in future, it's something we should be aware of.

Something that happens sometimes when connecting to a connection is the connection string is misformed or the database is currently offline. In these cases we would freeze up for 30s waiting for the connection to resolve. This might confuse a user and is frustrating when it's a small issue like an incorrect port number. I think there's also a chance that the connection never resolves with some ssh connections, I haven't been able to reproduce, but this PR should also address that case. 

![many connections](https://user-images.githubusercontent.com/1791149/88804806-b76b5200-d1ae-11ea-9116-a3d17ebb5600.gif)
