### PR TITLE
VSCODE-138: Quick index creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -297,6 +297,18 @@
         "title": "Copy Field Name"
       },
       {
+        "command": "mdb.refreshIndexes",
+        "title": "Refresh"
+      },
+      {
+        "command": "mdb.createIndexFromTreeView",
+        "title": "Create New Index...",
+        "icon": {
+          "light": "images/light/plus-circle.svg",
+          "dark": "images/dark/plus-circle.svg"
+        }
+      },
+      {
         "command": "mdb.startStreamLanguageServerLogs",
         "title": "LSP Inspector: Start Stream LSP Logs"
       }
@@ -462,6 +474,19 @@
         {
           "command": "mdb.copySchemaFieldName",
           "when": "view == mongoDB && viewItem == fieldTreeItem"
+        },
+        {
+          "command": "mdb.createIndexFromTreeView",
+          "when": "view == mongoDB && viewItem == indexListTreeItem",
+          "group": "inline"
+        },
+        {
+          "command": "mdb.refreshIndexes",
+          "when": "view == mongoDB && viewItem == indexListTreeItem"
+        },
+        {
+          "command": "mdb.createIndexFromTreeView",
+          "when": "view == mongoDB && viewItem == indexListTreeItem"
         }
       ],
       "editor/title": [
@@ -566,6 +591,14 @@
         },
         {
           "command": "mdb.runPlayground",
+          "when": "false"
+        },
+        {
+          "command": "mdb.createIndexFromTreeView",
+          "when": "false"
+        },
+        {
+          "command": "mdb.refreshIndexes",
           "when": "false"
         },
         {

--- a/src/editors/playgroundController.ts
+++ b/src/editors/playgroundController.ts
@@ -9,6 +9,7 @@ import PartialExecutionCodeLensProvider from './partialExecutionCodeLensProvider
 import { OutputChannel, ProgressLocation, TextEditor } from 'vscode';
 import playgroundTemplate from '../templates/playgroundTemplate';
 import playgroundSearchTemplate from '../templates/playgroundSearchTemplate';
+import playgroundCreateIndexTemplate from '../templates/playgroundCreateIndexTemplate';
 import { createLogger } from '../logging';
 
 const log = createLogger('playground controller');
@@ -96,7 +97,7 @@ export default class PlaygroundController {
         editor.textEditor.document &&
         editor.textEditor.document.languageId === 'mongodb'
       ) {
-        this._selectedText = (editor.selections as Array<any>)
+        this._selectedText = (editor.selections as Array<vscode.Selection>)
           .sort((a, b) => (a.start.line > b.start.line ? 1 : -1)) // Sort lines selected as alt+click
           .map((item, index) => {
             if (index === editor.selections.length - 1) {
@@ -153,15 +154,10 @@ export default class PlaygroundController {
     return this._languageServerController.disconnectFromServiceProvider();
   }
 
-  public createPlaygroundForSearch(
-    databaseName: string,
-    collectionName: string
+  private createPlaygroundFileWithContent(
+    content: string | undefined
   ): Promise<boolean> {
     return new Promise((resolve, reject) => {
-      const content = playgroundSearchTemplate
-        .replace('CURRENT_DATABASE', databaseName)
-        .replace('CURRENT_COLLECTION', collectionName);
-
       vscode.workspace
         .openTextDocument({
           language: 'mongodb',
@@ -173,6 +169,27 @@ export default class PlaygroundController {
           resolve(true);
         }, reject);
     });
+  }
+
+  public createPlaygroundForSearch(
+    databaseName: string,
+    collectionName: string
+  ): Promise<boolean> {
+    const content = playgroundSearchTemplate
+      .replace('CURRENT_DATABASE', databaseName)
+      .replace('CURRENT_COLLECTION', collectionName);
+
+    return this.createPlaygroundFileWithContent(content);
+  }
+
+  public createPlaygroundForNewIndex(databaseName: string,
+    collectionName: string
+  ): Promise<boolean> {
+    const content = playgroundCreateIndexTemplate
+      .replace('CURRENT_DATABASE', databaseName)
+      .replace('CURRENT_COLLECTION', collectionName);
+
+    return this.createPlaygroundFileWithContent(content);
   }
 
   public createPlayground(): Promise<boolean> {
@@ -214,7 +231,7 @@ export default class PlaygroundController {
     return this._activeTextEditor?.document.getText() || '';
   }
 
-  private getSelectedText(selection: any): string {
+  private getSelectedText(selection: vscode.Range): string {
     return this._activeTextEditor?.document.getText(selection) || '';
   }
 
@@ -234,7 +251,7 @@ export default class PlaygroundController {
             cancellable: true
           },
           async (progress, token) => {
-            token.onCancellationRequested(async () => {
+            token.onCancellationRequested(() => {
               // If a user clicked the cancel button terminate all playground scripts.
               this._languageServerController.cancelAll();
               this._outputChannel.clear();
@@ -301,7 +318,7 @@ export default class PlaygroundController {
     });
   }
 
-  public runSelectedPlaygroundBlocks() {
+  public runSelectedPlaygroundBlocks(): Promise<boolean> {
     if (this._activeTextEditor && this._activeTextEditor.document) {
       const selections = this._activeTextEditor.selections;
 
@@ -324,7 +341,7 @@ export default class PlaygroundController {
     return this.evaluatePlayground();
   }
 
-  public runAllPlaygroundBlocks() {
+  public runAllPlaygroundBlocks(): Promise<boolean> {
     if (this._activeTextEditor) {
       this._isPartialRun = false;
       this._codeToEvaluate = this.getAllText();
@@ -333,7 +350,7 @@ export default class PlaygroundController {
     return this.evaluatePlayground();
   }
 
-  public runAllOrSelectedPlaygroundBlocks() {
+  public runAllOrSelectedPlaygroundBlocks(): Promise<boolean> {
     if (this._activeTextEditor && this._activeTextEditor.document) {
       const selections = this._activeTextEditor.selections;
 

--- a/src/editors/playgroundController.ts
+++ b/src/editors/playgroundController.ts
@@ -182,7 +182,8 @@ export default class PlaygroundController {
     return this.createPlaygroundFileWithContent(content);
   }
 
-  public createPlaygroundForNewIndex(databaseName: string,
+  public createPlaygroundForNewIndex(
+    databaseName: string,
     collectionName: string
   ): Promise<boolean> {
     const content = playgroundCreateIndexTemplate

--- a/src/explorer/indexListTreeItem.ts
+++ b/src/explorer/indexListTreeItem.ts
@@ -131,6 +131,11 @@ export default class IndexListTreeItem extends vscode.TreeItem
     return [];
   }
 
+  resetCache(): void {
+    this.cacheIsUpToDate = false;
+    this._childrenCache = [];
+  }
+
   get iconPath():
     | string
     | vscode.Uri

--- a/src/explorer/indexListTreeItem.ts
+++ b/src/explorer/indexListTreeItem.ts
@@ -14,7 +14,7 @@ const ITEM_LABEL = 'Indexes';
 export default class IndexListTreeItem extends vscode.TreeItem
   implements TreeItemParent, vscode.TreeDataProvider<IndexListTreeItem> {
   cacheIsUpToDate = false;
-  private _childrenCache: vscode.TreeItem[] = [];
+  private _childrenCache: IndexTreeItem[] = [];
 
   contextValue = 'indexListTreeItem';
 
@@ -32,7 +32,7 @@ export default class IndexListTreeItem extends vscode.TreeItem
     dataService: any,
     isExpanded: boolean,
     cacheIsUpToDate: boolean,
-    existingCache: vscode.TreeItem[]
+    existingCache: IndexTreeItem[]
   ) {
     super(
       ITEM_LABEL,
@@ -89,6 +89,20 @@ export default class IndexListTreeItem extends vscode.TreeItem
     }
 
     if (this.cacheIsUpToDate) {
+      const pastChildrenCache = this._childrenCache;
+      this._childrenCache = [];
+
+      // We manually rebuild each node to ensure we update the expanded state.
+      pastChildrenCache.forEach((cachedItem: IndexTreeItem) => {
+        this._childrenCache.push(
+          new IndexTreeItem(
+            cachedItem.index,
+            cachedItem.namespace,
+            cachedItem.isExpanded
+          )
+        );
+      });
+
       return this._childrenCache;
     }
 
@@ -101,9 +115,9 @@ export default class IndexListTreeItem extends vscode.TreeItem
 
       this._childrenCache = sortTreeItemsByLabel(
         indexes.map((index) => {
-          return new IndexTreeItem(index, namespace);
+          return new IndexTreeItem(index, namespace, false /* Not expanded. */);
         })
-      );
+      ) as IndexTreeItem[];
     } else {
       this._childrenCache = [];
     }
@@ -123,7 +137,7 @@ export default class IndexListTreeItem extends vscode.TreeItem
     return Promise.resolve(true);
   }
 
-  getChildrenCache(): vscode.TreeItem[] {
+  getChildrenCache(): IndexTreeItem[] {
     if (this.cacheIsUpToDate) {
       return this._childrenCache;
     }

--- a/src/explorer/indexListTreeItem.ts
+++ b/src/explorer/indexListTreeItem.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 const path = require('path');
 
 import { createLogger } from '../logging';
-import IndexTreeItem from './indexTreeItem';
+import IndexTreeItem, { IndexModel } from './indexTreeItem';
 import TreeItemParent from './treeItemParentInterface';
 import { sortTreeItemsByLabel } from './treeItemUtils';
 import { getImagesPath } from '../extensionConstants';
@@ -61,7 +61,7 @@ export default class IndexListTreeItem extends vscode.TreeItem
     return element;
   }
 
-  getIndexes(): Promise<any> {
+  getIndexes(): Promise<IndexModel[]> {
     const namespace = this.namespace;
 
     log.info(`fetching indexes from namespace ${namespace}`);
@@ -72,7 +72,7 @@ export default class IndexListTreeItem extends vscode.TreeItem
         {
           /* No options */
         },
-        (err: Error, indexes: any[]) => {
+        (err: Error, indexes: IndexModel[]) => {
           if (err) {
             return reject(err);
           }
@@ -114,7 +114,7 @@ export default class IndexListTreeItem extends vscode.TreeItem
       const namespace = this.namespace;
 
       this._childrenCache = sortTreeItemsByLabel(
-        indexes.map((index) => {
+        indexes.map((index: IndexModel) => {
           return new IndexTreeItem(index, namespace, false /* Not expanded. */);
         })
       ) as IndexTreeItem[];

--- a/src/explorer/indexTreeItem.ts
+++ b/src/explorer/indexTreeItem.ts
@@ -11,10 +11,10 @@ export enum IndexKeyType {
   HASHED = 'hashed',
   GEO = '2d', // flat, cartesian geometry
   GEOSPHERE = '2dsphere', // index assuming a spherical geometry
-  GEOHAYSTACK = 'geoHaystack'
+  GEOHAYSTACK = 'geoHaystack',
 }
 
-type IndexModel = {
+export type IndexModel = {
   v: number;
   key: {
     [key: string]: IndexKeyType;

--- a/src/explorer/indexTreeItem.ts
+++ b/src/explorer/indexTreeItem.ts
@@ -11,7 +11,7 @@ export enum IndexKeyType {
   HASHED = 'hashed',
   GEO = '2d', // flat, cartesian geometry
   GEOSPHERE = '2dsphere', // index assuming a spherical geometry
-  GEOHAYSTACK = 'geoHaystack',
+  GEOHAYSTACK = 'geoHaystack'
 }
 
 export type IndexModel = {

--- a/src/explorer/indexTreeItem.ts
+++ b/src/explorer/indexTreeItem.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 const path = require('path');
 
 import { getImagesPath } from '../extensionConstants';
+import TreeItemParent from './treeItemParentInterface';
 
 export enum IndexKeyType {
   ASCENDING = 1,
@@ -91,10 +92,10 @@ export class IndexFieldTreeItem extends vscode.TreeItem
 }
 
 export default class IndexTreeItem extends vscode.TreeItem
-  implements vscode.TreeDataProvider<IndexTreeItem> {
+  implements vscode.TreeDataProvider<IndexTreeItem>, TreeItemParent {
   contextValue = 'indexTreeItem';
 
-  private index: IndexModel;
+  index: IndexModel;
 
   namespace: string;
 
@@ -103,14 +104,24 @@ export default class IndexTreeItem extends vscode.TreeItem
   // asynchronous resources.
   doesNotRequireTreeUpdate = true;
 
-  constructor(index: IndexModel, namespace: string) {
-    super(index.name, vscode.TreeItemCollapsibleState.Collapsed);
+  isExpanded: boolean;
+  cacheIsUpToDate = true;
+
+  constructor(index: IndexModel, namespace: string, isExpanded: boolean) {
+    super(
+      index.name,
+      isExpanded
+        ? vscode.TreeItemCollapsibleState.Expanded
+        : vscode.TreeItemCollapsibleState.Collapsed
+    );
 
     this.index = index;
 
     this.namespace = namespace;
 
     this.id = `${index.name}-${namespace}`;
+
+    this.isExpanded = isExpanded;
   }
 
   get tooltip(): string {
@@ -131,5 +142,15 @@ export default class IndexTreeItem extends vscode.TreeItem
         (indexKey) => new IndexFieldTreeItem(indexKey, this.index.key[indexKey])
       )
     );
+  }
+
+  onDidCollapse(): void {
+    this.isExpanded = false;
+  }
+
+  onDidExpand(): Promise<boolean> {
+    this.isExpanded = true;
+
+    return Promise.resolve(true);
   }
 }

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -21,6 +21,7 @@ import DocumentListTreeItem from './explorer/documentListTreeItem';
 import DocumentTreeItem from './explorer/documentTreeItem';
 import WebviewController from './views/webviewController';
 import FieldTreeItem from './explorer/fieldTreeItem';
+import IndexListTreeItem from './explorer/indexListTreeItem';
 
 const log = createLogger('commands');
 
@@ -272,20 +273,11 @@ export default class MDBExtensionController implements vscode.Disposable {
     );
     this.registerCommand(
       'mdb.searchForDocuments',
-      async (element: DocumentListTreeItem): Promise<boolean> => {
-        if (this._connectionController.isDisconnecting()) {
-          vscode.window.showErrorMessage(
-            'Unable to add collection: currently disconnecting.'
-          );
-          return false;
-        }
-
-        this._playgroundController.createPlaygroundForSearch(
+      (element: DocumentListTreeItem): Promise<boolean> => {
+        return this._playgroundController.createPlaygroundForSearch(
           element.databaseName,
           element.collectionName
         );
-
-        return true;
       }
     );
     this.registerCommand(
@@ -419,6 +411,22 @@ export default class MDBExtensionController implements vscode.Disposable {
         vscode.window.showInformationMessage('Copied to clipboard.');
 
         return true;
+      }
+    );
+    this.registerCommand(
+      'mdb.refreshIndexes',
+      (indexListTreeItem: IndexListTreeItem): Promise<boolean> => {
+        indexListTreeItem.resetCache();
+        return this._explorerController.refresh();
+      }
+    );
+    this.registerCommand(
+      'mdb.createIndexFromTreeView',
+      (indexListTreeItem: IndexListTreeItem): Promise<boolean> => {
+        return this._playgroundController.createPlaygroundForNewIndex(
+          indexListTreeItem.databaseName,
+          indexListTreeItem.collectionName
+        );
       }
     );
   }

--- a/src/templates/playgroundCreateIndexTemplate.ts
+++ b/src/templates/playgroundCreateIndexTemplate.ts
@@ -1,0 +1,28 @@
+const template = `// MongoDB Playground
+// Use Ctrl+Space inside a snippet or a string literal to trigger completions.
+
+// The current database to use.
+use('CURRENT_DATABASE');
+
+// Create a new index in the collection.
+// 'ensureIndex' checks to see if the index already exists
+// before creating it, to avoid duplicates.
+db.getCollection('CURRENT_COLLECTION')
+  .ensureIndex(
+    {
+      /**
+       * Define the index.
+       * key: string | object
+       * fieldName: 1 // Create an ascending index on field 'fieldName'.
+       */
+    }, {
+      /**
+       * Optional index options.
+       * unique: false // Creates an unique index.
+       * background: false // Creates the index in the background, yielding whenever possible.
+       */
+    }
+  );
+`;
+
+export default template;

--- a/src/templates/playgroundCreateIndexTemplate.ts
+++ b/src/templates/playgroundCreateIndexTemplate.ts
@@ -10,16 +10,38 @@ use('CURRENT_DATABASE');
 db.getCollection('CURRENT_COLLECTION')
   .ensureIndex(
     {
-      /**
-       * Define the index.
-       * key: string | object
-       * fieldName: 1 // Create an ascending index on field 'fieldName'.
+      /*
+       * Keys
+       *
+       * Normal index
+       * fieldA:  1, //ascending
+       * fieldB: -1  //descending
+       *
+       * Wildcard index
+       * '$**': 1, //wildcard index on all fields and subfields in a document
+       * 'path.to.field.$**': 1 //wildcard index on a specific field and its subpaths
+       *
+       * Text index
+       * fieldA: 'text',
+       * fieldB: 'text'
+       *
+       * Geospatial Index
+       * locationField: '2dsphere'
+       *
+       * Hashed Index
+       * fieldA: 'hashed'
        */
     }, {
-      /**
-       * Optional index options.
-       * unique: false // Creates an unique index.
-       * background: false // Creates the index in the background, yielding whenever possible.
+      /*
+       * Options (https://docs.mongodb.com/manual/reference/method/db.collection.createIndex/#options-for-all-index-types)
+       *
+       * background: true, //ignored in 4.2+
+       * unique: false,
+       * name: 'some name',
+       * partialFilterExpression: {},
+       * sparse: false,
+       * expireAfterSeconds: TTL,
+       * collation: {}
        */
     }
   );

--- a/src/templates/playgroundSearchTemplate.ts
+++ b/src/templates/playgroundSearchTemplate.ts
@@ -1,4 +1,4 @@
-const template: string = `// MongoDB Playground
+const template = `// MongoDB Playground
 // Use Ctrl+Space inside a snippet or a string literal to trigger completions.
 
 // The current database to use.

--- a/src/templates/playgroundTemplate.ts
+++ b/src/templates/playgroundTemplate.ts
@@ -1,4 +1,4 @@
-const template: string = `// MongoDB Playground
+const template = `// MongoDB Playground
 // To disable this template go to Settings | MongoDB | Use Default Template For Playground.
 // Make sure you are connected to enable completions and to be able to run a playground.
 // Use Ctrl+Space inside a snippet or a string literal to trigger completions.

--- a/src/test/suite/explorer/indexTreeItem.test.ts
+++ b/src/test/suite/explorer/indexTreeItem.test.ts
@@ -17,7 +17,8 @@ suite('IndexTreeItem Test Suite', () => {
         name: '_id_1_gnocchi_1',
         ns: 'tasty_fruits.pineapple'
       },
-      'tasty_fruits.pineapple'
+      'tasty_fruits.pineapple',
+      false
     );
 
     const indexKeyTreeItems = await testIndexTreeItem.getChildren();

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -59,6 +59,8 @@ suite('Extension Test Suite', () => {
       'mdb.refreshCollection',
       'mdb.refreshSchema',
       'mdb.copySchemaFieldName',
+      'mdb.refreshIndexes',
+      'mdb.createIndexFromTreeView',
 
       // Editor commands.
       'mdb.codeLens.showMoreDocumentsClicked'


### PR DESCRIPTION
VSCODE-138

This PR adds a button and right click action to create a playground with a template to create an index quickly. The PR also adds a refresh indexes right click action. It also adds caching to the expanded state of indexes which should be nice (previously they'd collapse if a parent folder was expanded/collapsed).

How does the ensureIndex/createIndex playground template look? Went with `ensureIndex` instead of `createIndex`

![lower res low fps quick create](https://user-images.githubusercontent.com/1791149/90123065-8702e680-dd5e-11ea-8308-68c5a3b47e93.gif)
*Using older template in gif*
