### PR TITLE
VSCODE-174: Run only mongodb files when using shortcuts or command palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -519,6 +519,14 @@
       ],
       "commandPalette": [
         {
+          "command": "mdb.runSelectedPlaygroundBlocks",
+          "when": "editorLangId == mongodb"
+        },
+        {
+          "command": "mdb.runAllPlaygroundBlocks",
+          "when": "editorLangId == mongodb"
+        },
+        {
           "command": "mdb.refreshPlaygroundsFromTreeView",
           "when": "false"
         },
@@ -709,7 +717,7 @@
           },
           "description": "Files and folders to exclude while searching for playground in the the current workspace.",
           "default": [
-            "**/.!(todo|todos|task|tasks)/**",
+            "**/.*",
             "**/_output/**",
             "**/bower_components/**",
             "**/build/**",

--- a/package.json
+++ b/package.json
@@ -520,11 +520,11 @@
       "commandPalette": [
         {
           "command": "mdb.runSelectedPlaygroundBlocks",
-          "when": "editorLangId == mongodb"
+          "when": "editorTextFocus && editorLangId == mongodb"
         },
         {
           "command": "mdb.runAllPlaygroundBlocks",
-          "when": "editorLangId == mongodb"
+          "when": "editorTextFocus && editorLangId == mongodb"
         },
         {
           "command": "mdb.refreshPlaygroundsFromTreeView",
@@ -648,6 +648,20 @@
         }
       ]
     },
+    "keybindings": [
+      {
+        "command": "mdb.runSelectedPlaygroundBlocks",
+        "key": "ctrl+alt+s",
+        "mac": "cmd+alt+s",
+        "when": "editorTextFocus && editorLangId == mongodb"
+      },
+      {
+        "command": "mdb.runAllPlaygroundBlocks",
+        "key": "ctrl+alt+r",
+        "mac": "cmd+alt+r",
+        "when": "editorTextFocus && editorLangId == mongodb"
+      }
+    ],
     "capabilities": {
       "codeLensProvider": {
         "resolveProvider": "true"

--- a/src/editors/playgroundController.ts
+++ b/src/editors/playgroundController.ts
@@ -321,7 +321,7 @@ export default class PlaygroundController {
       this._activeTextEditor.document.languageId !== 'mongodb'
     ) {
       vscode.window.showErrorMessage(
-        'Please connect to a database before running a playground.'
+        `Please open a '.mongodb' playground file before running it.`
       );
 
       return Promise.resolve(false);
@@ -353,7 +353,7 @@ export default class PlaygroundController {
       this._activeTextEditor.document.languageId !== 'mongodb'
     ) {
       vscode.window.showErrorMessage(
-        'Please connect to a database before running a playground.'
+        `Please open a '.mongodb' playground file before running it.`
       );
 
       return Promise.resolve(false);
@@ -371,7 +371,7 @@ export default class PlaygroundController {
       this._activeTextEditor.document.languageId !== 'mongodb'
     ) {
       vscode.window.showErrorMessage(
-        'Please connect to a database before running a playground.'
+        `Please open a '.mongodb' playground file before running it.`
       );
 
       return Promise.resolve(false);

--- a/src/test/suite/editors/playgroundController.test.ts
+++ b/src/test/suite/editors/playgroundController.test.ts
@@ -69,12 +69,36 @@ suite('Playground Controller Test Suite', function () {
     });
 
     test('run all playground blocks should throw the playground not found error', async () => {
-      const errorMessage = 'Please open a playground before running it.';
+      const errorMessage = `Please open a '.mongodb' playground file before running it.`;
 
       fakeShowErrorMessage.resolves(errorMessage);
 
       try {
         await testPlaygroundController.runAllPlaygroundBlocks();
+      } catch (error) {
+        sinon.assert.calledWith(fakeShowErrorMessage, errorMessage);
+      }
+    });
+
+    test('run selected playground blocks should throw the playground not found error', async () => {
+      const errorMessage = `Please open a '.mongodb' playground file before running it.`;
+
+      fakeShowErrorMessage.resolves(errorMessage);
+
+      try {
+        await testPlaygroundController.runSelectedPlaygroundBlocks();
+      } catch (error) {
+        sinon.assert.calledWith(fakeShowErrorMessage, errorMessage);
+      }
+    });
+
+    test('run all or selected playground blocks should throw the playground not found error', async () => {
+      const errorMessage = `Please open a '.mongodb' playground file before running it.`;
+
+      fakeShowErrorMessage.resolves(errorMessage);
+
+      try {
+        await testPlaygroundController.runAllOrSelectedPlaygroundBlocks();
       } catch (error) {
         sinon.assert.calledWith(fakeShowErrorMessage, errorMessage);
       }


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
We display the play icon to run a playground only for .mongodb files. But we also have a possibility to trigger playground running events by using a command palette or shortcuts. In this case, a user can try to run a non-mongodb file or even start running a playground when no playgrounds open. It will try to run the last open playground. We should display playground running commands in the command palette only when mongodb file is open and show the running error for other file extensions or when the playground not found.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
