### PR TITLE
VSCODE-175: show code lenses before a playground block

### DIFF
--- a/src/editors/playgroundController.ts
+++ b/src/editors/playgroundController.ts
@@ -111,13 +111,15 @@ export default class PlaygroundController {
     const selectedText = this.getSelectedText(item).trim();
     const lastSelectedLine =
       this._activeTextEditor?.document.lineAt(item.end.line).text.trim() || '';
+    const selections = this._activeTextEditor?.selections.sort((a, b) => (a.start.line > b.start.line ? 1 : -1));
+    const firstLine = selections ? selections[0].start.line : 0;
 
     if (
       selectedText.length > 0 &&
       selectedText.length >= lastSelectedLine.length
     ) {
       this._partialExecutionCodeLensProvider?.refresh(
-        new vscode.Range(item.start.line, 0, item.start.line, 0)
+        new vscode.Range(firstLine, 0, firstLine, 0)
       );
     } else {
       this._partialExecutionCodeLensProvider?.refresh();

--- a/src/editors/playgroundController.ts
+++ b/src/editors/playgroundController.ts
@@ -117,7 +117,7 @@ export default class PlaygroundController {
       selectedText.length >= lastSelectedLine.length
     ) {
       this._partialExecutionCodeLensProvider?.refresh(
-        new vscode.Range(item.end.line + 1, 0, item.end.line + 1, 0)
+        new vscode.Range(item.start.line, 0, item.start.line, 0)
       );
     } else {
       this._partialExecutionCodeLensProvider?.refresh();


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
Change the logic to show code lenses above the selected block of text instead of showing them below the selection. According to VSCode API code lenses always appear above the specified line, therefore if there is no empty line below the selected block of text, there is no entry point for code lenses to appear above and code lenses are missing.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
