### PR TITLE
0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to the "mongodb" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [0.2.0] - 2020-10-1
+
+### Added
+
+- Added a Playgrounds panel that displays `.mongodb` playground files in the open workspace
+- Added a setting to configure which folders and files are exluded from the playgrounds panel file searching
+- Added a Help and Resources panel to the explorer with useful links
+- Added a button to the indexes folder in the tree view which, when clicked, creates a playground prefilled with an index creation script
+
+### Changed
+
+- Updated our mongosh dependency to 0.4.2 which brings more functionality to playgrounds
+
+### Fixed
+
+- Fixed index expanded state caching in the explorer tree view
+
 ## [0.1.1] - 2020-08-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,18 +8,18 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ### Added
 
-- Added a Playgrounds panel that displays `.mongodb` playground files in the open workspace
-- Added a setting to configure which folders and files are exluded from the playgrounds panel file searching
-- Added a Help and Resources panel to the explorer with useful links
-- Added a button to the indexes folder in the tree view which, when clicked, creates a playground prefilled with an index creation script
+- Added a Playgrounds panel that displays `.mongodb` playground files in the current VSCode workspace
+- Added a setting to configure which folders and files are excluded from the playgrounds panel file searching
+- Added a help and resources panel to the explorer with links to documentation and feedback portals
+- Added a button to the indexes folder in the tree view which creates a playground prefilled with an index creation script
 
 ### Changed
 
-- Updated our mongosh dependency to 0.4.2 which brings more functionality to playgrounds
+- Updated our mongosh dependency to 0.4.2 to bring more functionality to playgrounds
 
 ### Fixed
 
-- Fixed index expanded state caching in the explorer tree view
+- Fixed indexes expanded state caching in the connection explorer panel tree view
 
 ## [0.1.1] - 2020-08-10
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mongodb-vscode",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "mongodb-vscode",
   "displayName": "MongoDB for VS Code",
   "description": "Connect to MongoDB and Atlas directly from your VS Code environment, navigate your databases and collections, inspect your schema and use playgrounds to prototype queries and aggregations.",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "homepage": "https://github.com/mongodb-js/vscode",
   "qna": "https://developer.mongodb.com/community/forums/",
   "repository": {


### PR DESCRIPTION
VSCODE-171

This PR bumps the version and has the CHANGELOG updates:
```markdown
## [0.2.0] - 2020-10-1

### Added

- Added a Playgrounds panel that displays `.mongodb` playground files in the current VSCode workspace
- Added a setting to configure which folders and files are excluded from the playgrounds panel file searching
- Added a help and resources panel to the explorer with links to documentation and feedback portals
- Added a button to the indexes folder in the tree view which creates a playground prefilled with an index creation script

### Changed

- Updated our mongosh dependency to 0.4.2 to bring more functionality to playgrounds

### Fixed

- Fixed indexes expanded state caching in the connection explorer panel tree view
```