### PR TITLE
VSCODE-180 - Account for playground files from previous session

### DIFF
--- a/src/editors/playgroundController.ts
+++ b/src/editors/playgroundController.ts
@@ -80,12 +80,14 @@ export default class PlaygroundController {
       }
     );
 
-    vscode.window.onDidChangeActiveTextEditor((editor) => {
+    const onEditorChange = (editor) => {
       if (editor?.document.languageId !== 'Log') {
         this._activeTextEditor = editor;
         log.info('Active editor path', editor?.document.uri?.path);
       }
-    });
+    };
+    vscode.window.onDidChangeActiveTextEditor(onEditorChange);
+    onEditorChange(vscode.window.activeTextEditor);
 
     vscode.window.onDidChangeTextEditorSelection((editor) => {
       if (

--- a/src/test/suite/editors/playgroundController.test.ts
+++ b/src/test/suite/editors/playgroundController.test.ts
@@ -287,5 +287,31 @@ suite('Playground Controller Test Suite', function () {
         expect(codeLens?.length).to.be.equal(1);
       });
     });
+
+    test('playground controller loads the active editor on start', () => {
+      const activeTestEditorMock = {
+        document: {
+          languageId: '',
+          uri: {
+            path: 'test'
+          }
+        }
+      };
+
+      sandbox.replaceGetter(
+        vscode.window,
+        'activeTextEditor',
+        () => activeTestEditorMock
+      );
+
+      const playgroundControllerTest = new PlaygroundController(
+        mockExtensionContext,
+        testConnectionController,
+        mockLanguageServerController as LanguageServerController,
+        testTelemetryController
+      );
+
+      expect(playgroundControllerTest._activeTextEditor).to.deep.equal(activeTestEditorMock);
+    });
   });
 });


### PR DESCRIPTION
A playground file might already be open at the time the
`PlaygroundController` is created.

---

Not sure how to add tests for this, the existing ones for `playgroundController` don’t really seem to account for this type of scenario?

<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
