### PR TITLE
VSCODE-189: Add rename connection button to overview page

### DIFF
--- a/src/test/suite/views/webview-app/components/connection-status/connection-status.test.tsx
+++ b/src/test/suite/views/webview-app/components/connection-status/connection-status.test.tsx
@@ -1,52 +1,117 @@
 import assert from 'assert';
 import * as React from 'react';
-import { shallow } from 'enzyme';
-import {
-  ConnectionStatus
+import * as sinon from 'sinon';
+import { mount, shallow } from 'enzyme';
+import { createStore } from 'redux';
+import { faPencilAlt } from '@fortawesome/free-solid-svg-icons';
+import { Provider } from 'react-redux';
+
+import ConnectionStatus, {
+  ConnectionStatus as PlainConnectionStatus
 } from '../../../../../../views/webview-app/components/connection-status/connection-status';
 import { CONNECTION_STATUS } from '../../../../../../views/webview-app/extension-app-message-constants';
+import {
+  AppState,
+  initialState,
+  rootReducer
+} from '../../../../../../views/webview-app/store/store';
 
 describe('Connection Status Component Test Suite', () => {
   describe('connected connection status', () => {
     test('it shows that it is connected to the connection name', () => {
-      const wrapper = shallow(<ConnectionStatus
+      const wrapper = shallow(<PlainConnectionStatus
         activeConnectionName="Active connection name"
         connectionStatus={CONNECTION_STATUS.CONNECTED}
         onClickCreatePlayground={(): void => {}}
         requestConnectionStatus={(): void => {}}
+        onClickRenameConnection={(): void => {}}
       />);
       assert(wrapper.text().includes('Connected to:'));
       assert(wrapper.text().includes('Active connection name'));
     });
 
     test('it shows a create playground button', () => {
-      const wrapper = shallow(<ConnectionStatus
+      const wrapper = shallow(<PlainConnectionStatus
         activeConnectionName="Active connection name"
         connectionStatus={CONNECTION_STATUS.CONNECTED}
         onClickCreatePlayground={(): void => {}}
         requestConnectionStatus={(): void => {}}
+        onClickRenameConnection={(): void => {}}
       />);
       assert(wrapper.find('button').exists());
+    });
+
+    test('it shows an edit connection name button', () => {
+      const wrapper = shallow(<PlainConnectionStatus
+        activeConnectionName="Active connection name"
+        connectionStatus={CONNECTION_STATUS.CONNECTED}
+        onClickCreatePlayground={(): void => {}}
+        requestConnectionStatus={(): void => {}}
+        onClickRenameConnection={(): void => {}}
+      />);
+      assert(wrapper.find(faPencilAlt).exists());
+    });
+
+    describe('with store actions', () => {
+      let fakeVscodeWindowPostMessage;
+      let wrapper;
+      let store;
+
+      beforeEach(() => {
+        fakeVscodeWindowPostMessage = sinon.fake.returns(null);
+
+        sinon.replace(
+          (global as any).vscodeFake,
+          'postMessage',
+          fakeVscodeWindowPostMessage
+        );
+
+        store = createStore(rootReducer, {
+          ...initialState,
+          connectionStatus: CONNECTION_STATUS.CONNECTED
+        } as AppState);
+
+        wrapper = mount(
+          <Provider
+            store={store}
+          >
+            <ConnectionStatus />
+          </Provider>
+        );
+      });
+
+      afterEach(() => {
+        sinon.restore();
+      });
+
+      test('when the edit connection name button is clicked it posts a message to the extension to rename the connection', () => {
+        assert(!fakeVscodeWindowPostMessage.called);
+        wrapper.find('button').at(0).simulate('click');
+        assert(fakeVscodeWindowPostMessage.called);
+        assert(fakeVscodeWindowPostMessage.firstCall.args[0].command === 'RENAME_ACTIVE_CONNECTION');
+      });
     });
   });
 
   describe('disconnected', () => {
     test('it shows a disconnect message', () => {
-      const wrapper = shallow(<ConnectionStatus
+      const wrapper = shallow(<PlainConnectionStatus
         activeConnectionName=""
         connectionStatus={CONNECTION_STATUS.DISCONNECTED}
         onClickCreatePlayground={(): void => {}}
         requestConnectionStatus={(): void => {}}
+        onClickRenameConnection={(): void => {}}
       />);
       assert(wrapper.text().includes('Not connected'));
     });
 
     test('it does not show a create playground button', () => {
-      const wrapper = shallow(<ConnectionStatus
+      const wrapper = shallow(<PlainConnectionStatus
         activeConnectionName=""
         connectionStatus={CONNECTION_STATUS.DISCONNECTED}
         onClickCreatePlayground={(): void => {}}
         requestConnectionStatus={(): void => {}}
+        onClickRenameConnection={(): void => {}}
       />);
       assert(wrapper.find('button').exists() === false);
     });
@@ -54,11 +119,12 @@ describe('Connection Status Component Test Suite', () => {
 
   describe('connecting', () => {
     test('it shows a connecting message', () => {
-      const wrapper = shallow(<ConnectionStatus
+      const wrapper = shallow(<PlainConnectionStatus
         activeConnectionName=""
         connectionStatus={CONNECTION_STATUS.CONNECTING}
         onClickCreatePlayground={(): void => {}}
         requestConnectionStatus={(): void => {}}
+        onClickRenameConnection={(): void => {}}
       />);
       assert(wrapper.text().includes('Connecting...'));
     });
@@ -66,11 +132,12 @@ describe('Connection Status Component Test Suite', () => {
 
   describe('disconnecting', () => {
     test('it shows a connecting message', () => {
-      const wrapper = shallow(<ConnectionStatus
+      const wrapper = shallow(<PlainConnectionStatus
         activeConnectionName=""
         connectionStatus={CONNECTION_STATUS.DISCONNECTING}
         onClickCreatePlayground={(): void => {}}
         requestConnectionStatus={(): void => {}}
+        onClickRenameConnection={(): void => {}}
       />);
       assert(wrapper.text().includes('Disconnecting...'));
     });
@@ -78,11 +145,12 @@ describe('Connection Status Component Test Suite', () => {
 
   describe('loading', () => {
     test('it shows a loading message', () => {
-      const wrapper = shallow(<ConnectionStatus
+      const wrapper = shallow(<PlainConnectionStatus
         activeConnectionName=""
         connectionStatus={CONNECTION_STATUS.LOADING}
         onClickCreatePlayground={(): void => {}}
         requestConnectionStatus={(): void => {}}
+        onClickRenameConnection={(): void => {}}
       />);
       assert(wrapper.text().includes('Loading...'));
     });

--- a/src/test/suite/views/webview-app/components/connection-status/connection-status.test.tsx
+++ b/src/test/suite/views/webview-app/components/connection-status/connection-status.test.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import * as sinon from 'sinon';
 import { mount, shallow } from 'enzyme';
 import { createStore } from 'redux';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPencilAlt } from '@fortawesome/free-solid-svg-icons';
 import { Provider } from 'react-redux';
 
@@ -49,7 +50,7 @@ describe('Connection Status Component Test Suite', () => {
         requestConnectionStatus={(): void => {}}
         onClickRenameConnection={(): void => {}}
       />);
-      assert(wrapper.find(faPencilAlt).exists());
+      assert(wrapper.find(FontAwesomeIcon).prop('icon') === faPencilAlt);
     });
 
     describe('with store actions', () => {
@@ -75,7 +76,9 @@ describe('Connection Status Component Test Suite', () => {
           <Provider
             store={store}
           >
-            <ConnectionStatus />
+            <ConnectionStatus
+              requestConnectionStatus={(): void => {}}
+            />
           </Provider>
         );
       });
@@ -85,10 +88,9 @@ describe('Connection Status Component Test Suite', () => {
       });
 
       test('when the edit connection name button is clicked it posts a message to the extension to rename the connection', () => {
-        assert(!fakeVscodeWindowPostMessage.called);
         wrapper.find('button').at(0).simulate('click');
         assert(fakeVscodeWindowPostMessage.called);
-        assert(fakeVscodeWindowPostMessage.firstCall.args[0].command === 'RENAME_ACTIVE_CONNECTION');
+        assert(fakeVscodeWindowPostMessage.secondCall.args[0].command === 'RENAME_ACTIVE_CONNECTION');
       });
     });
   });

--- a/src/views/webview-app/components/connection-status/connection-status.less
+++ b/src/views/webview-app/components/connection-status/connection-status.less
@@ -38,8 +38,8 @@
   margin: 0 20px;
 
   display: inline-block;
-  font-size: 20px;
-  line-height: 24px;
+  font-size: 18px;
+  line-height: 23px;
   vertical-align: middle;
 }
 

--- a/src/views/webview-app/components/connection-status/connection-status.less
+++ b/src/views/webview-app/components/connection-status/connection-status.less
@@ -60,3 +60,19 @@
     background-color: #3F864B;
   }
 }
+
+.connection-status-rename {
+  color: var(--vscode-editor-foreground);
+  padding: 2px 4px;
+  margin-left: 4px;
+  vertical-align: top;
+  transition: 250ms all;
+  background: none;
+  border: none;
+  font-size: 12px;
+
+  &:hover {
+    cursor: pointer;
+    color: #fbb129;
+  }
+}

--- a/src/views/webview-app/components/connection-status/connection-status.tsx
+++ b/src/views/webview-app/components/connection-status/connection-status.tsx
@@ -30,8 +30,6 @@ type DispatchProps = {
 };
 
 export class ConnectionStatus extends React.Component<StateProps & DispatchProps> {
-  connectionStatusPollingInterval: null | number = null;
-
   componentDidMount(): void {
     this.startConnectionStatusPolling();
   }
@@ -40,7 +38,9 @@ export class ConnectionStatus extends React.Component<StateProps & DispatchProps
     this.stopConnectionStatusPolling();
   }
 
-  startConnectionStatusPolling(): void {
+  connectionStatusPollingInterval: null | number = null;
+
+  startConnectionStatusPolling = (): void => {
     if (this.connectionStatusPollingInterval !== null) {
       return;
     }
@@ -51,7 +51,7 @@ export class ConnectionStatus extends React.Component<StateProps & DispatchProps
     }, CONNECTION_STATUS_POLLING_FREQ_MS) as any;
   };
 
-  stopConnectionStatusPolling(): void {
+  stopConnectionStatusPolling = (): void => {
     if (this.connectionStatusPollingInterval === null) {
       return;
     }

--- a/src/views/webview-app/components/connection-status/connection-status.tsx
+++ b/src/views/webview-app/components/connection-status/connection-status.tsx
@@ -6,10 +6,13 @@ import { AppState } from '../../store/store';
 import {
   ActionTypes,
   CreateNewPlaygroundAction,
+  RenameConnectionAction,
   RequestConnectionStatusAction
 } from '../../store/actions';
 import InfoSprinkle from '../info-sprinkle/info-sprinkle';
 import { CONNECTION_STATUS } from '../../extension-app-message-constants';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faPencilAlt } from '@fortawesome/free-solid-svg-icons';
 
 const styles = require('./connection-status.less');
 
@@ -22,6 +25,7 @@ type StateProps = {
 
 type DispatchProps = {
   onClickCreatePlayground: () => void;
+  onClickRenameConnection: () => void;
   requestConnectionStatus: () => void;
 };
 
@@ -60,7 +64,8 @@ export class ConnectionStatus extends React.Component<StateProps & DispatchProps
   renderConnectedStatus(): React.ReactNode {
     const {
       activeConnectionName,
-      onClickCreatePlayground
+      onClickCreatePlayground,
+      onClickRenameConnection
     } = this.props;
 
     return (
@@ -70,6 +75,14 @@ export class ConnectionStatus extends React.Component<StateProps & DispatchProps
             styles['connection-status-dot'],
             styles['connection-status-dot-connected']
           )}/>Connected to: <strong>{activeConnectionName}</strong>
+          <button
+            className={styles['connection-status-rename']}
+            onClick={(): void => onClickRenameConnection()}
+          >
+            <FontAwesomeIcon
+              icon={faPencilAlt}
+            />
+          </button>
         </div>
         <div className={styles['connection-status-playground-area']}>
           <div className={styles['connection-status-playground-message']}>
@@ -155,6 +168,9 @@ const mapStateToProps = (state: AppState): StateProps => {
 const mapDispatchToProps: DispatchProps = {
   onClickCreatePlayground: (): CreateNewPlaygroundAction => ({
     type: ActionTypes.CREATE_NEW_PLAYGROUND
+  }),
+  onClickRenameConnection: (): RenameConnectionAction => ({
+    type: ActionTypes.RENAME_CONNECTION
   }),
   requestConnectionStatus: (): RequestConnectionStatusAction => ({
     type: ActionTypes.REQUEST_CONNECTION_STATUS

--- a/src/views/webview-app/components/info-sprinkle/info-sprinkle.less
+++ b/src/views/webview-app/components/info-sprinkle/info-sprinkle.less
@@ -14,6 +14,6 @@
   transition: 250ms all;
 
   &:hover {
-    color: #C3E7CA;
+    color: #fbb129;
   }
 }

--- a/src/views/webview-app/extension-app-message-constants.ts
+++ b/src/views/webview-app/extension-app-message-constants.ts
@@ -19,12 +19,13 @@ export enum MESSAGE_TYPES {
   CONNECT = 'CONNECT',
   CONNECT_RESULT = 'CONNECT_RESULT',
   CONNECTION_STATUS_MESSAGE = 'CONNECTION_STATUS_MESSAGE',
+  EXTENSION_LINK_CLICKED = 'EXTENSION_LINK_CLICKED',
   CREATE_NEW_PLAYGROUND = 'CREATE_NEW_PLAYGROUND',
+  FILE_PICKER_RESULTS = 'FILE_PICKER_RESULTS',
   GET_CONNECTION_STATUS = 'GET_CONNECTION_STATUS',
   OPEN_CONNECTION_STRING_INPUT = 'OPEN_CONNECTION_STRING_INPUT',
   OPEN_FILE_PICKER = 'OPEN_FILE_PICKER',
-  FILE_PICKER_RESULTS = 'FILE_PICKER_RESULTS',
-  EXTENSION_LINK_CLICKED = 'EXTENSION_LINK_CLICKED'
+  RENAME_ACTIVE_CONNECTION = 'RENAME_ACTIVE_CONNECTION'
 }
 
 interface BasicWebviewMessage {
@@ -79,13 +80,18 @@ export interface LinkClickedMessage extends BasicWebviewMessage {
   linkId: string;
 }
 
+export interface RenameConnectionMessage extends BasicWebviewMessage {
+  command: MESSAGE_TYPES.RENAME_ACTIVE_CONNECTION;
+}
+
 export type MESSAGE_FROM_WEBVIEW_TO_EXTENSION =
   | ConnectMessage
   | CreateNewPlaygroundMessage
   | GetConnectionStatusMessage
   | LinkClickedMessage
   | OpenConnectionStringInputMessage
-  | OpenFilePickerMessage;
+  | OpenFilePickerMessage
+  | RenameConnectionMessage;
 
 export type MESSAGE_FROM_EXTENSION_TO_WEBVIEW =
   | ConnectResultsMessage

--- a/src/views/webview-app/store/actions.ts
+++ b/src/views/webview-app/store/actions.ts
@@ -24,6 +24,7 @@ export enum ActionTypes {
   PASSWORD_CHANGED = 'PASSWORD_CHANGED',
   PORT_CHANGED = 'PORT_CHANGED',
   READ_PREFERENCE_CHANGED = 'READ_PREFERENCE_CHANGED',
+  RENAME_CONNECTION = 'RENAME_CONNECTION',
   REPLICA_SET_CHANGED = 'REPLICA_SET_CHANGED',
   REQUEST_CONNECTION_STATUS = 'REQUEST_CONNECTION_STATUS',
   SET_CONNECTION_STATUS = 'SET_CONNECTION_STATUS',
@@ -154,6 +155,10 @@ export interface ReadPreferenceChangedAction extends BaseAction {
   readPreference: READ_PREFERENCES;
 }
 
+export interface RenameConnectionAction extends BaseAction {
+  type: ActionTypes.RENAME_CONNECTION;
+}
+
 export interface ReplicaSetChangedAction extends BaseAction {
   type: ActionTypes.REPLICA_SET_CHANGED;
   replicaSet: string;
@@ -263,6 +268,7 @@ export type Actions =
   | PasswordChangedAction
   | PortChangedAction
   | ReadPreferenceChangedAction
+  | RenameConnectionAction
   | ReplicaSetChangedAction
   | RequestConnectionStatusAction
   | SetConnectionStatusAction

--- a/src/views/webview-app/store/store.ts
+++ b/src/views/webview-app/store/store.ts
@@ -274,6 +274,13 @@ export const rootReducer = (
         }
       };
 
+    case ActionTypes.RENAME_CONNECTION:
+      vscode.postMessage({
+        command: MESSAGE_TYPES.RENAME_ACTIVE_CONNECTION
+      });
+
+      return { ...state };
+
     case ActionTypes.REPLICA_SET_CHANGED:
       return {
         ...state,

--- a/src/views/webviewController.ts
+++ b/src/views/webviewController.ts
@@ -195,7 +195,9 @@ export default class WebviewController {
 
       case MESSAGE_TYPES.RENAME_ACTIVE_CONNECTION:
         if (this._connectionController.isCurrentlyConnected()) {
-          this._connectionController.renameConnection(this._connectionController.getActiveConnectionId() as string);
+          this._connectionController.renameConnection(
+            this._connectionController.getActiveConnectionId() as string
+          );
         }
 
         return;

--- a/src/views/webviewController.ts
+++ b/src/views/webviewController.ts
@@ -192,6 +192,13 @@ export default class WebviewController {
         );
 
         return;
+
+      case MESSAGE_TYPES.RENAME_ACTIVE_CONNECTION:
+        if (this._connectionController.isCurrentlyConnected()) {
+          this._connectionController.renameConnection(this._connectionController.getActiveConnectionId() as string);
+        }
+
+        return;
       default:
         // no-op.
         return;


### PR DESCRIPTION
VSCODE-189

This PR adds a rename connection button to the overview page next to your active connection name (pencil icon).
Also two smaller styling updates after chatting with Alena & Claudia: updated playground message font size 20->18px and hover color on the info icon.

![renaming a connection](https://user-images.githubusercontent.com/1791149/96697572-5c4f9280-138c-11eb-8f76-4af8ead61be7.gif)
_Light mode_
<img width="825" alt="Screen Shot 2020-10-21 at 11 38 34 AM" src="https://user-images.githubusercontent.com/1791149/96702397-fe25ae00-1391-11eb-93fb-71f28b02b9ee.png">
