### PR TITLE
Atlas sign-in/up uses a localhost redirect

### DIFF
--- a/src/explorer/helpTree.ts
+++ b/src/explorer/helpTree.ts
@@ -30,7 +30,7 @@ export class HelpLinkTreeItem extends vscode.TreeItem {
   url: string;
   useRedirect: boolean;
 
-  constructor(title: string, url: string, linkId: string, iconName?: string, useRedirect = false,) {
+  constructor(title: string, url: string, linkId: string, iconName?: string, useRedirect = false) {
     super(title, vscode.TreeItemCollapsibleState.None);
 
     this.linkId = linkId;

--- a/src/explorer/helpTree.ts
+++ b/src/explorer/helpTree.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { openLink } from '../utils/linkHelper';
 const path = require('path');
 
 import { getImagesPath } from '../extensionConstants';
@@ -27,19 +28,21 @@ export class HelpLinkTreeItem extends vscode.TreeItem {
   contextValue = HELP_LINK_CONTEXT_VALUE;
   linkId: string;
   url: string;
+  useRedirect: boolean;
 
-  constructor(title: string, url: string, linkId: string, iconName?: string) {
+  constructor(title: string, url: string, linkId: string, iconName?: string, useRedirect = false,) {
     super(title, vscode.TreeItemCollapsibleState.None);
 
     this.linkId = linkId;
     this.iconName = iconName;
     this.url = url;
+    this.useRedirect = useRedirect;
     this.iconPath = getIconPath(iconName);
   }
 }
 
 export default class HelpTree
-implements vscode.TreeDataProvider<vscode.TreeItem> {
+  implements vscode.TreeDataProvider<vscode.TreeItem> {
   contextValue = 'helpTree';
 
   getTreeItem(element: vscode.TreeItem): vscode.TreeItem {
@@ -101,7 +104,8 @@ implements vscode.TreeDataProvider<vscode.TreeItem> {
         'Create Free Atlas Cluster',
         'https://www.mongodb.com/cloud/atlas/register?utm_source=vscode&utm_medium=product&utm_campaign=VS%20code%20extension',
         'freeClusterCTA',
-        'atlas'
+        'atlas',
+        true
       );
 
       return Promise.resolve([
@@ -124,10 +128,14 @@ implements vscode.TreeDataProvider<vscode.TreeItem> {
         helpItem.linkId
       );
 
-      await vscode.commands.executeCommand(
-        'vscode.open',
-        vscode.Uri.parse(helpItem.url)
-      );
+      if (helpItem.useRedirect) {
+        await openLink(helpItem.url);
+      } else {
+        await vscode.commands.executeCommand(
+          'vscode.open',
+          vscode.Uri.parse(helpItem.url)
+        );
+      }
     }
   }
 }

--- a/src/explorer/helpTree.ts
+++ b/src/explorer/helpTree.ts
@@ -129,7 +129,15 @@ export default class HelpTree
       );
 
       if (helpItem.useRedirect) {
-        await openLink(helpItem.url);
+        try {
+          await openLink(helpItem.url);
+        } catch (err) {
+          // If opening the link fails we default to regular link opening.
+          await vscode.commands.executeCommand(
+            'vscode.open',
+            vscode.Uri.parse(helpItem.url)
+          );
+        }
       } else {
         await vscode.commands.executeCommand(
           'vscode.open',

--- a/src/test/suite/utils/linkHelper.test.ts
+++ b/src/test/suite/utils/linkHelper.test.ts
@@ -1,0 +1,26 @@
+import { openLink } from '../../../utils/linkHelper';
+import { expect } from 'chai';
+import vscode from 'vscode';
+import http from 'http';
+const sinon = require('sinon');
+
+suite('Open Link Test Suite', () => {
+  test('the helper server is instantiated correctly', () => {
+    const stubServer = { on: sinon.spy(), listen: sinon.spy() };
+    const stubCreateServer = sinon.fake.returns(stubServer);
+    sinon.replace(http, 'createServer', stubCreateServer);
+    openLink('https://mongodb.com', 4321);
+    expect(stubServer.on.calledWith('connection')).to.be.true;
+    expect(stubServer.listen.calledWith(4321)).to.be.true;
+  });
+
+  // test('the browser opens correctly', async () => {
+  //   const stubExecuteCommand = sinon.fake.resolves();
+  //   sinon.replace(vscode.commands, 'executeCommand', stubExecuteCommand);
+  //   await openLink('https://mongodb.com', 4321);
+  //   expect(stubExecuteCommand.called).to.be.true;
+  //   expect(stubExecuteCommand.firstCall.args[0]).to.equal('vscode.open');
+  //   expect(stubExecuteCommand.firstCall.args[1].path).to.equal(vscode.Uri.parse('https://mongodb.com:4322').path);
+  // });
+});
+

--- a/src/test/suite/utils/linkHelper.test.ts
+++ b/src/test/suite/utils/linkHelper.test.ts
@@ -7,20 +7,25 @@ const sinon = require('sinon');
 suite('Open Link Test Suite', () => {
   test('the helper server is instantiated correctly', () => {
     const stubServer = { on: sinon.spy(), listen: sinon.spy() };
-    const stubCreateServer = sinon.fake.returns(stubServer);
-    sinon.replace(http, 'createServer', stubCreateServer);
+    const stubCreateServer = sinon.stub(http, 'createServer').returns(stubServer);
     openLink('https://mongodb.com', 4321);
     expect(stubServer.on.calledWith('connection')).to.be.true;
     expect(stubServer.listen.calledWith(4321)).to.be.true;
+    stubCreateServer.restore();
   });
 
-  // test('the browser opens correctly', async () => {
-  //   const stubExecuteCommand = sinon.fake.resolves();
-  //   sinon.replace(vscode.commands, 'executeCommand', stubExecuteCommand);
-  //   await openLink('https://mongodb.com', 4321);
-  //   expect(stubExecuteCommand.called).to.be.true;
-  //   expect(stubExecuteCommand.firstCall.args[0]).to.equal('vscode.open');
-  //   expect(stubExecuteCommand.firstCall.args[1].path).to.equal(vscode.Uri.parse('https://mongodb.com:4322').path);
-  // });
+  test('the browser opens correctly', () => {
+    const stubServer = sinon.createStubInstance(http.Server, {
+      on: sinon.stub(),
+      listen: sinon.stub().callsArg(1)
+    });
+    const stubCreateServer = sinon.stub(http, 'createServer').returns(stubServer);
+    const stubExecuteCommand = sinon.stub(vscode.commands, 'executeCommand').resolves();
+    openLink('https://mongodb.com', 4321);
+    expect(stubExecuteCommand.firstCall.args[0]).to.equal('vscode.open');
+    expect(stubExecuteCommand.firstCall.args[1].path).to.equal(vscode.Uri.parse('https://mongodb.com:4322').path);
+    stubExecuteCommand.restore();
+    stubCreateServer.restore();
+  });
 });
 

--- a/src/utils/linkHelper.ts
+++ b/src/utils/linkHelper.ts
@@ -1,0 +1,45 @@
+import * as vscode from 'vscode';
+import { createServer, Server } from 'http';
+
+/**
+ * Opens a link through an in-browser redirect from localhost
+ * via a short-lived helper server.
+ *
+ * Inspired from the Azure sign-in experience in MS'
+ * extesion: https://github.com/microsoft/vscode-azure-account/blob/1d948273b4233fc101251d588e677ceb158951ea/src/codeFlowLogin.ts
+ *
+ * @param {string} url the url to open
+ * @param {number} [serverPort=3211] the port where the helper server should listen.
+ *
+ * @returns {Server} the helper Server instance
+ */
+export const openLink = (url: string, serverPort = 3211): Promise<Server> => new Promise((resolve) => {
+  const server = createServer((request, response) => {
+    response.writeHead(200);
+    response.end(`
+      <html>
+        <head>
+          <meta http-equiv="refresh" content="0;url=${url}" />
+        </head>
+      </html>
+      `)
+  });
+
+  // This works well for the time being but it should be changed
+  // once we introduce a login with Atlas functionality. When that
+  // will happen, then the server needs to stay alive until we get
+  // the callback from Atlas.
+  server.on('connection', () => {
+    setTimeout(() => {
+      server.close();
+    }, 2000);
+  });
+
+  server.listen(serverPort, async () => {
+    await vscode.commands.executeCommand(
+      'vscode.open',
+      vscode.Uri.parse(`http://localhost:${serverPort}`)
+    );
+    resolve(server);
+  });
+});

--- a/src/utils/linkHelper.ts
+++ b/src/utils/linkHelper.ts
@@ -13,7 +13,7 @@ import { createServer, Server } from 'http';
  *
  * @returns {Server} the helper Server instance
  */
-export const openLink = (url: string, serverPort = 3211): Promise<Server> => new Promise((resolve) => {
+export const openLink = (url: string, serverPort = 3211): Promise<Server> => new Promise((resolve, reject) => {
   const server = createServer((request, response) => {
     response.writeHead(302, { location: url });
     response.end();
@@ -27,6 +27,10 @@ export const openLink = (url: string, serverPort = 3211): Promise<Server> => new
     setTimeout(() => {
       server.close();
     }, 2000);
+  });
+
+  server.on('error', (err) => {
+    reject(err);
   });
 
   server.listen(serverPort, async () => {

--- a/src/utils/linkHelper.ts
+++ b/src/utils/linkHelper.ts
@@ -15,14 +15,8 @@ import { createServer, Server } from 'http';
  */
 export const openLink = (url: string, serverPort = 3211): Promise<Server> => new Promise((resolve) => {
   const server = createServer((request, response) => {
-    response.writeHead(200);
-    response.end(`
-      <html>
-        <head>
-          <meta http-equiv="refresh" content="0;url=${url}" />
-        </head>
-      </html>
-      `)
+    response.writeHead(302, { location: url });
+    response.end();
   });
 
   // This works well for the time being but it should be changed


### PR DESCRIPTION
This constitutes the prep work to eventually introduce a sign-in/sign-up functionality for Atlas.
By using a short-lived local server, we can redirect the user to the right Atlas sign-in/up page and wait for an auth redirect in VS Code.

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions
~I have a test that is currently commented out that I don't know how to make pass.~

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
