### PR TITLE
Only allow redirects for mongodb.com domains

### DIFF
--- a/src/utils/linkHelper.ts
+++ b/src/utils/linkHelper.ts
@@ -1,6 +1,10 @@
 import * as vscode from 'vscode';
 import { createServer, Server } from 'http';
 
+const TRUSTED_DOMAINS: Array<RegExp> = [
+  /^.*mongodb\.com$/i
+];
+
 /**
  * Opens a link through an in-browser redirect from localhost
  * via a short-lived helper server.
@@ -14,6 +18,11 @@ import { createServer, Server } from 'http';
  * @returns {Server} the helper Server instance
  */
 export const openLink = (url: string, serverPort = 3211): Promise<Server> => new Promise((resolve, reject) => {
+  const { scheme, authority } = vscode.Uri.parse(url);
+  if (scheme !== 'https' || !TRUSTED_DOMAINS.find(regex => regex.test(authority))) {
+    return reject(new Error('untrusted url'));
+  }
+
   const server = createServer((request, response) => {
     response.writeHead(302, { location: url });
     response.end();


### PR DESCRIPTION
## Description

Restricts the redirects done by the short-lived helper server to a list of trusted domains.

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
