### PR TITLE
VSCODE-177: display playground output in editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -535,11 +535,11 @@
       "commandPalette": [
         {
           "command": "mdb.runSelectedPlaygroundBlocks",
-          "when": "editorTextFocus && editorLangId == mongodb"
+          "when": "editorLangId == mongodb"
         },
         {
           "command": "mdb.runAllPlaygroundBlocks",
-          "when": "editorTextFocus && editorLangId == mongodb"
+          "when": "editorLangId == mongodb"
         },
         {
           "command": "mdb.refreshPlaygroundsFromTreeView",
@@ -672,13 +672,13 @@
         "command": "mdb.runSelectedPlaygroundBlocks",
         "key": "ctrl+alt+s",
         "mac": "cmd+alt+s",
-        "when": "editorTextFocus && editorLangId == mongodb"
+        "when": "editorLangId == mongodb"
       },
       {
         "command": "mdb.runAllPlaygroundBlocks",
         "key": "ctrl+alt+r",
         "mac": "cmd+alt+r",
-        "when": "editorTextFocus && editorLangId == mongodb"
+        "when": "editorLangId == mongodb"
       }
     ],
     "capabilities": {

--- a/src/editors/editorsController.ts
+++ b/src/editors/editorsController.ts
@@ -126,10 +126,6 @@ export default class EditorsController {
       )} - ${Date.now()}.json${uriQuery}`
     );
 
-    console.log('textDocumentUri----------------------');
-    console.log(textDocumentUri);
-    console.log('----------------------');
-
     return new Promise((resolve, reject) => {
       vscode.workspace.openTextDocument(textDocumentUri).then((doc) => {
         vscode.window

--- a/src/editors/editorsController.ts
+++ b/src/editors/editorsController.ts
@@ -13,9 +13,13 @@ import DocumentProvider, {
   DOCUMENT_ID_URI_IDENTIFIER,
   VIEW_DOCUMENT_SCHEME
 } from './documentProvider';
+import PlaygroundResultProvider, {
+  PLAYGROUND_RESULT_SCHEME
+} from './playgroundResultProvider';
 import ConnectionController from '../connectionController';
 import { createLogger } from '../logging';
 import { StatusView } from '../views';
+import PlaygroundController from './playgroundController';
 
 const log = createLogger('editors controller');
 
@@ -25,16 +29,20 @@ const log = createLogger('editors controller');
  */
 export default class EditorsController {
   _connectionController: ConnectionController;
+  _playgroundController: PlaygroundController;
   _collectionDocumentsOperationsStore = new CollectionDocumentsOperationsStore();
   _collectionViewProvider: CollectionDocumentsProvider;
   _documentViewProvider: DocumentProvider;
+  _playgroundResultViewProvider: PlaygroundResultProvider;
 
   constructor(
     context: vscode.ExtensionContext,
-    connectionController: ConnectionController
+    connectionController: ConnectionController,
+    playgroundController: PlaygroundController
   ) {
     log.info('activating...');
     this._connectionController = connectionController;
+    this._playgroundController = playgroundController;
 
     const collectionViewProvider = new CollectionDocumentsProvider(
       connectionController,
@@ -75,6 +83,19 @@ export default class EditorsController {
     );
     this._documentViewProvider = documentViewProvider;
 
+    const playgroundResultViewProvider = new PlaygroundResultProvider(
+      playgroundController,
+      new StatusView(context)
+    );
+
+    context.subscriptions.push(
+      vscode.workspace.registerTextDocumentContentProvider(
+        PLAYGROUND_RESULT_SCHEME,
+        playgroundResultViewProvider
+      )
+    );
+    this._playgroundResultViewProvider = playgroundResultViewProvider;
+
     log.info('activated.');
   }
 
@@ -104,6 +125,11 @@ export default class EditorsController {
         documentId
       )} - ${Date.now()}.json${uriQuery}`
     );
+
+    console.log('textDocumentUri----------------------');
+    console.log(textDocumentUri);
+    console.log('----------------------');
+
     return new Promise((resolve, reject) => {
       vscode.workspace.openTextDocument(textDocumentUri).then((doc) => {
         vscode.window

--- a/src/editors/playgroundController.ts
+++ b/src/editors/playgroundController.ts
@@ -344,7 +344,6 @@ export default class PlaygroundController {
       vscode.workspace.openTextDocument(playgroundResultURI).then((doc) => {
         vscode.window.showTextDocument(doc, { preview: true, viewColumn })
         .then(editor => {
-          this._playgroundResultTextEditor = editor;
           editor.edit(editBuilder => {
             let fullRange = new vscode.Range(new vscode.Position(0, 0), editor.document.positionAt(editor.document.getText().length));
 

--- a/src/editors/playgroundController.ts
+++ b/src/editors/playgroundController.ts
@@ -84,7 +84,7 @@ export default class PlaygroundController {
       }
     );
 
-    vscode.window.onDidChangeActiveTextEditor((editor) => {
+    const onEditorChange = (editor) => {
       if (editor?.document.uri.scheme === PLAYGROUND_RESULT_SCHEME) {
         this._playgroundResultViewColumn = editor.viewColumn;
         this._playgroundResultTextDocument = editor?.document;
@@ -94,7 +94,10 @@ export default class PlaygroundController {
         this.activeTextEditor = editor;
         log.info('Active editor path', editor?.document.uri?.path);
       }
-    });
+    };
+
+    vscode.window.onDidChangeActiveTextEditor(onEditorChange);
+    onEditorChange(vscode.window.activeTextEditor);
 
     vscode.window.onDidChangeTextEditorSelection((editor) => {
       if (

--- a/src/editors/playgroundResultProvider.ts
+++ b/src/editors/playgroundResultProvider.ts
@@ -1,0 +1,29 @@
+import * as vscode from 'vscode';
+import { StatusView } from '../views';
+import PlaygroundController from './playgroundController';
+
+export const PLAYGROUND_RESULT_SCHEME = 'PLAYGROUND_RESULT_SCHEME';
+
+export default class PlaygroundResultProvider implements vscode.TextDocumentContentProvider {
+  _playgroundController: PlaygroundController;
+  _statusView: StatusView;
+
+  constructor(
+    playgroundController: PlaygroundController,
+    statusView: StatusView
+  ) {
+    this._playgroundController = playgroundController;
+    this._statusView = statusView;
+  }
+
+  onDidChangeEmitter = new vscode.EventEmitter<vscode.Uri>();
+  onDidChange = this.onDidChangeEmitter.event;
+
+  provideTextDocumentContent(uri: vscode.Uri): Promise<string> {
+    return new Promise((resolve, reject) => {
+      this._statusView.showMessage('Getting results...');
+
+      return resolve(JSON.stringify(this._playgroundController.playgroundResult, null, 2));
+    });
+  }
+}

--- a/src/editors/playgroundResultProvider.ts
+++ b/src/editors/playgroundResultProvider.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { StatusView } from '../views';
-import PlaygroundController from './playgroundController';
+import PlaygroundController, { PlaygroundEventTypes } from './playgroundController';
 
 export const PLAYGROUND_RESULT_SCHEME = 'PLAYGROUND_RESULT_SCHEME';
 
@@ -14,12 +14,21 @@ export default class PlaygroundResultProvider implements vscode.TextDocumentCont
   ) {
     this._playgroundController = playgroundController;
     this._statusView = statusView;
+
+    this._playgroundController.addEventListener(
+      PlaygroundEventTypes.PLAYGROUND_RESULT_CHANGED,
+      () => this.provideTextDocumentContent()
+    );
   }
 
   onDidChangeEmitter = new vscode.EventEmitter<vscode.Uri>();
   onDidChange = this.onDidChangeEmitter.event;
 
-  provideTextDocumentContent(uri: vscode.Uri): Promise<string> {
+  provideTextDocumentContent(): Promise<string> {
+    console.log('----------------------');
+    console.log(777);
+    console.log('----------------------');
+
     return new Promise((resolve, reject) => {
       this._statusView.showMessage('Getting results...');
 

--- a/src/editors/playgroundResultProvider.ts
+++ b/src/editors/playgroundResultProvider.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { StatusView } from '../views';
-import PlaygroundController, { PlaygroundEventTypes } from './playgroundController';
+import PlaygroundController from './playgroundController';
 
 export const PLAYGROUND_RESULT_SCHEME = 'PLAYGROUND_RESULT_SCHEME';
 
@@ -14,22 +14,13 @@ export default class PlaygroundResultProvider implements vscode.TextDocumentCont
   ) {
     this._playgroundController = playgroundController;
     this._statusView = statusView;
-
-    this._playgroundController.addEventListener(
-      PlaygroundEventTypes.PLAYGROUND_RESULT_CHANGED,
-      () => this.provideTextDocumentContent()
-    );
   }
 
   onDidChangeEmitter = new vscode.EventEmitter<vscode.Uri>();
   onDidChange = this.onDidChangeEmitter.event;
 
   provideTextDocumentContent(): Promise<string> {
-    console.log('----------------------');
-    console.log(777);
-    console.log('----------------------');
-
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       this._statusView.showMessage('Getting results...');
 
       return resolve(JSON.stringify(this._playgroundController.playgroundResult, null, 2));

--- a/src/language/mongoDBService.ts
+++ b/src/language/mongoDBService.ts
@@ -3,8 +3,6 @@ import { Worker as WorkerThreads } from 'worker_threads';
 import { signatures } from '@mongosh/shell-api';
 import * as util from 'util';
 import { Visitor } from './visitor';
-import { ExecuteAllResult } from '../utils/types';
-
 import { ServerCommands, PlaygroundRunParameters } from './serverCommands';
 
 const path = require('path');

--- a/src/language/mongoDBService.ts
+++ b/src/language/mongoDBService.ts
@@ -181,6 +181,10 @@ export default class MongoDBService {
 
         await worker.terminate();
 
+        this._connection.console.log('result----------------------');
+        this._connection.console.log(`${util.inspect(result)}`);
+        this._connection.console.log('----------------------');
+
         return resolve(result);
       });
 

--- a/src/language/mongoDBService.ts
+++ b/src/language/mongoDBService.ts
@@ -181,10 +181,6 @@ export default class MongoDBService {
 
         await worker.terminate();
 
-        this._connection.console.log('result----------------------');
-        this._connection.console.log(`${util.inspect(result)}`);
-        this._connection.console.log('----------------------');
-
         return resolve(result);
       });
 

--- a/src/language/worker.ts
+++ b/src/language/worker.ts
@@ -40,7 +40,7 @@ const executeAll = async (
         for (const { type, printable } of values) {
           outputLines.push({
             type,
-            content: formatOutput({ value: printable, type })
+            content: printable
           });
         }
       }
@@ -48,12 +48,12 @@ const executeAll = async (
     const { type, printable } = await runtime.evaluate(
       codeToEvaluate
     );
-    outputLines.push({
+    const result = {
       type,
-      content: formatOutput({ value: printable, type })
-    });
+      content: printable
+    };
 
-    return [null, outputLines];
+    return [null, { outputLines, result }];
   } catch (error) {
     return [error];
   }

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -71,10 +71,6 @@ export default class MDBExtensionController implements vscode.Disposable {
     }
 
     this._languageServerController = new LanguageServerController(context);
-    this._editorsController = new EditorsController(
-      context,
-      this._connectionController
-    );
     this._explorerController = new ExplorerController(
       this._connectionController
     );
@@ -85,6 +81,11 @@ export default class MDBExtensionController implements vscode.Disposable {
       this._connectionController,
       this._languageServerController,
       this._telemetryController
+    );
+    this._editorsController = new EditorsController(
+      context,
+      this._connectionController,
+      this._playgroundController
     );
     this._webviewController = new WebviewController(
       this._connectionController,

--- a/src/telemetry/telemetryController.ts
+++ b/src/telemetry/telemetryController.ts
@@ -267,12 +267,11 @@ export default class TelemetryController {
   }
 
   public getPlaygroundResultType(res: ExecuteAllResult): string {
-    const lastResult = res && res[res.length - 1];
-    if (!lastResult || !lastResult.type) {
+    if (!res || !res.result || !res.result.type) {
       return 'other';
     }
 
-    const shellApiType = lastResult.type.toLocaleLowerCase();
+    const shellApiType = res.result.type.toLocaleLowerCase();
 
     // See: https://github.com/mongodb-js/mongosh/blob/master/packages/shell-api/src/shell-api.js
     if (shellApiType.includes('insert')) {

--- a/src/test/suite/editors/playgroundController.test.ts
+++ b/src/test/suite/editors/playgroundController.test.ts
@@ -286,6 +286,15 @@ suite('Playground Controller Test Suite', function () {
 
         expect(codeLens?.length).to.be.equal(1);
       });
+
+      test('evaluatePlayground should open editor to print results', async () => {
+        await vscode.workspace
+          .getConfiguration('mdb')
+          .update('confirmRunAll', false);
+        const isEditprOpened = await testPlaygroundController.evaluatePlayground();
+
+        expect(isEditprOpened).to.be.equal(true);
+      });
     });
 
     test('playground controller loads the active editor on start', () => {

--- a/src/test/suite/editors/playgroundController.test.ts
+++ b/src/test/suite/editors/playgroundController.test.ts
@@ -287,6 +287,34 @@ suite('Playground Controller Test Suite', function () {
         expect(codeLens?.length).to.be.equal(1);
       });
 
+      test('playground controller loads the active editor on start', () => {
+        const activeTestEditorMock = {
+          document: {
+            languageId: '',
+            uri: {
+              path: 'test'
+            }
+          }
+        };
+
+        sandbox.replaceGetter(
+          vscode.window,
+          'activeTextEditor',
+          () => activeTestEditorMock
+        );
+
+        const playgroundControllerTest = new PlaygroundController(
+          mockExtensionContext,
+          testConnectionController,
+          mockLanguageServerController as LanguageServerController,
+          testTelemetryController
+        );
+
+        expect(playgroundControllerTest.activeTextEditor).to.deep.equal(
+          activeTestEditorMock
+        );
+      });
+
       test('evaluatePlayground should open editor to print results', async () => {
         await vscode.workspace
           .getConfiguration('mdb')

--- a/src/test/suite/editors/playgroundController.test.ts
+++ b/src/test/suite/editors/playgroundController.test.ts
@@ -65,7 +65,7 @@ suite('Playground Controller Test Suite', function () {
 
   suite('playground is not open', () => {
     before(() => {
-      testPlaygroundController._activeTextEditor = undefined;
+      testPlaygroundController.activeTextEditor = undefined;
     });
 
     test('run all playground blocks should throw the playground not found error', async () => {
@@ -107,7 +107,7 @@ suite('Playground Controller Test Suite', function () {
 
   suite('playground is open', () => {
     before(async () => {
-      testPlaygroundController._activeTextEditor = await loadPlayground(
+      testPlaygroundController.activeTextEditor = await loadPlayground(
         getDocUri('testCodeLens.mongodb')
       );
     });
@@ -118,12 +118,12 @@ suite('Playground Controller Test Suite', function () {
         const mockGetActiveConnectionModel = sinon.fake.returns(null);
 
         sinon.replace(
-          testPlaygroundController._connectionController,
+          testPlaygroundController.connectionController,
           'getActiveConnectionName',
           mockGetActiveConnectionName
         );
         sinon.replace(
-          testPlaygroundController._connectionController,
+          testPlaygroundController.connectionController,
           'getActiveConnectionModel',
           mockGetActiveConnectionModel
         );
@@ -184,12 +184,12 @@ suite('Playground Controller Test Suite', function () {
         });
 
         sinon.replace(
-          testPlaygroundController._connectionController,
+          testPlaygroundController.connectionController,
           'getActiveConnectionName',
           mockGetActiveConnectionName
         );
         sinon.replace(
-          testPlaygroundController._connectionController,
+          testPlaygroundController.connectionController,
           'getActiveConnectionModel',
           mockGetActiveConnectionModel
         );
@@ -272,7 +272,7 @@ suite('Playground Controller Test Suite', function () {
           new vscode.Range(0, 5, 0, 11)
         );
 
-        const codeLens = testPlaygroundController._partialExecutionCodeLensProvider?.provideCodeLenses();
+        const codeLens = testPlaygroundController.partialExecutionCodeLensProvider?.provideCodeLenses();
 
         expect(codeLens?.length).to.be.equal(0);
       });
@@ -282,7 +282,7 @@ suite('Playground Controller Test Suite', function () {
           new vscode.Range(0, 0, 0, 14)
         );
 
-        const codeLens = testPlaygroundController._partialExecutionCodeLensProvider?.provideCodeLenses();
+        const codeLens = testPlaygroundController.partialExecutionCodeLensProvider?.provideCodeLenses();
 
         expect(codeLens?.length).to.be.equal(1);
       });

--- a/src/test/suite/editors/playgroundController.test.ts
+++ b/src/test/suite/editors/playgroundController.test.ts
@@ -296,31 +296,5 @@ suite('Playground Controller Test Suite', function () {
         expect(isEditprOpened).to.be.equal(true);
       });
     });
-
-    test('playground controller loads the active editor on start', () => {
-      const activeTestEditorMock = {
-        document: {
-          languageId: '',
-          uri: {
-            path: 'test'
-          }
-        }
-      };
-
-      sandbox.replaceGetter(
-        vscode.window,
-        'activeTextEditor',
-        () => activeTestEditorMock
-      );
-
-      const playgroundControllerTest = new PlaygroundController(
-        mockExtensionContext,
-        testConnectionController,
-        mockLanguageServerController as LanguageServerController,
-        testTelemetryController
-      );
-
-      expect(playgroundControllerTest._activeTextEditor).to.deep.equal(activeTestEditorMock);
-    });
   });
 });

--- a/src/test/suite/language/mongoDBService.test.ts
+++ b/src/test/suite/language/mongoDBService.test.ts
@@ -992,8 +992,12 @@ suite('MongoDBService Test Suite', () => {
         },
         source.token
       );
+      const res = {
+        outputLines: [],
+        result: { type: null, content: 2 }
+      };
 
-      expect(result).to.deep.equal([{ type: null, content: '2' }]);
+      expect(result).to.deep.equal(res);
     });
 
     test('evaluate multiple commands at once', async function () {
@@ -1006,8 +1010,12 @@ suite('MongoDBService Test Suite', () => {
         },
         source.token
       );
+      const res = {
+        outputLines: [],
+        result: { type: null, content: 3 }
+      };
 
-      expect(result).to.deep.equal([{ type: null, content: '3' }]);
+      expect(result).to.deep.equal(res);
     });
 
     test('create each time a new runtime', async function () {
@@ -1020,8 +1028,12 @@ suite('MongoDBService Test Suite', () => {
         },
         source.token
       );
+      const firstRes = {
+        outputLines: [],
+        result: { type: null, content: 2 }
+      };
 
-      expect(firstEvalResult).to.deep.equal([{ type: null, content: '2' }]);
+      expect(firstEvalResult).to.deep.equal(firstRes);
 
       const secondEvalResult = await testMongoDBService.executeAll(
         {
@@ -1029,8 +1041,12 @@ suite('MongoDBService Test Suite', () => {
         },
         source.token
       );
+      const secondRes = {
+        outputLines: [],
+        result: { type: null, content: 3 }
+      };
 
-      expect(secondEvalResult).to.deep.equal([{ type: null, content: '3' }]);
+      expect(secondEvalResult).to.deep.equal(secondRes);
     });
 
     test('includes results from print() and console.log()', async function () {
@@ -1043,14 +1059,17 @@ suite('MongoDBService Test Suite', () => {
         },
         source.token
       );
+      const res = {
+        outputLines: [
+          { type: null, content: 'Hello' },
+          { type: null, content: 1 },
+          { type: null, content: 2 },
+          { type: null, content: 3 }
+        ],
+        result: { type: null, content: 42 }
+      };
 
-      expect(result).to.deep.equal([
-        { type: null, content: 'Hello' },
-        { type: null, content: '1' },
-        { type: null, content: '2' },
-        { type: null, content: '3' },
-        { type: null, content: '42' },
-      ]);
+      expect(result).to.deep.equal(res);
     });
   });
 });

--- a/src/test/suite/stubs.ts
+++ b/src/test/suite/stubs.ts
@@ -193,7 +193,10 @@ class MockLanguageServerController {
   }
 
   executeAll(codeToEvaluate: string): Promise<ExecuteAllResult> {
-    return Promise.resolve([{ type: null, content: 'Result' }]);
+    return Promise.resolve({
+      outputLines: [],
+      result: { type: null, content: 'Result' }
+    });
   }
 
   connectToServiceProvider(params: {

--- a/src/test/suite/telemetry/telemetryController.test.ts
+++ b/src/test/suite/telemetry/telemetryController.test.ts
@@ -175,98 +175,130 @@ suite('Telemetry Controller Test Suite', () => {
 
   suite('prepare playground result types', () => {
     test('convert AggregationCursor shellApiType to aggregation telemetry type', () => {
-      const res = [{ type: 'AggregationCursor', content: '' }];
+      const res = {
+        outputLines: [],
+        result: { type: 'AggregationCursor', content: '' }
+      };
       const type = testTelemetryController.getPlaygroundResultType(res);
 
       expect(type).to.deep.equal('aggregation');
     });
 
     test('convert BulkWriteResult shellApiType to other telemetry type', () => {
-      const res = [{ type: 'BulkWriteResult', content: '' }];
+      const res = {
+        outputLines: [],
+        result: { type: 'BulkWriteResult', content: '' }
+      };
       const type = testTelemetryController.getPlaygroundResultType(res);
 
       expect(type).to.deep.equal('other');
     });
 
     test('convert Collection shellApiType to other telemetry type', () => {
-      const res = [{ type: 'Collection', content: '' }];
+      const res = {
+        outputLines: [],
+        result: { type: 'Collection', content: '' }
+      };
       const type = testTelemetryController.getPlaygroundResultType(res);
 
       expect(type).to.deep.equal('other');
     });
 
     test('convert Cursor shellApiType to other telemetry type', () => {
-      const res = [{ type: 'Cursor', content: '' }];
+      const res = {
+        outputLines: [],
+        result: { type: 'Cursor', content: '' }
+      };
       const type = testTelemetryController.getPlaygroundResultType(res);
 
       expect(type).to.deep.equal('query');
     });
 
     test('convert Database shellApiType to other telemetry type', () => {
-      const res = [{ type: 'Database', content: '' }];
+      const res = {
+        outputLines: [],
+        result: { type: 'Database', content: '' }
+      };
       const type = testTelemetryController.getPlaygroundResultType(res);
 
       expect(type).to.deep.equal('other');
     });
 
     test('convert DeleteResult shellApiType to other telemetry type', () => {
-      const res = [{ type: 'DeleteResult', content: '' }];
+      const res = {
+        outputLines: [],
+        result: { type: 'DeleteResult', content: '' }
+      };
       const type = testTelemetryController.getPlaygroundResultType(res);
 
       expect(type).to.deep.equal('delete');
     });
 
     test('convert InsertManyResult shellApiType to other telemetry type', () => {
-      const res = [{ type: 'InsertManyResult', content: '' }];
+      const res = {
+        outputLines: [],
+        result: { type: 'InsertManyResult', content: '' }
+      };
       const type = testTelemetryController.getPlaygroundResultType(res);
 
       expect(type).to.deep.equal('insert');
     });
 
     test('convert InsertOneResult shellApiType to other telemetry type', () => {
-      const res = [{ type: 'InsertOneResult', content: '' }];
+      const res = {
+        outputLines: [],
+        result: { type: 'InsertOneResult', content: '' }
+      };
       const type = testTelemetryController.getPlaygroundResultType(res);
 
       expect(type).to.deep.equal('insert');
     });
 
     test('convert ReplicaSet shellApiType to other telemetry type', () => {
-      const res = [{ type: 'ReplicaSet', content: '' }];
+      const res = {
+        outputLines: [],
+        result: { type: 'ReplicaSet', content: '' }
+      };
       const type = testTelemetryController.getPlaygroundResultType(res);
 
       expect(type).to.deep.equal('other');
     });
 
     test('convert Shard shellApiType to other telemetry type', () => {
-      const res = [{ type: 'Shard', content: '' }];
+      const res = {
+        outputLines: [],
+        result: { type: 'Shard', content: '' }
+      };
       const type = testTelemetryController.getPlaygroundResultType(res);
 
       expect(type).to.deep.equal('other');
     });
 
     test('convert ShellApi shellApiType to other telemetry type', () => {
-      const res = [{ type: 'ShellApi', content: '' }];
+      const res = {
+        outputLines: [],
+        result: { type: 'ShellApi', content: '' }
+      };
       const type = testTelemetryController.getPlaygroundResultType(res);
 
       expect(type).to.deep.equal('other');
     });
 
     test('convert UpdateResult shellApiType to other telemetry type', () => {
-      const res = [{ type: 'UpdateResult', content: '' }];
-      const type = testTelemetryController.getPlaygroundResultType(res);
-
-      expect(type).to.deep.equal('update');
-    });
-
-    test('convert UpdateResult shellApiType to other telemetry type', () => {
-      const res = [{ type: 'UpdateResult', content: '' }];
+      const res = {
+        outputLines: [],
+        result: { type: 'UpdateResult', content: '' }
+      };
       const type = testTelemetryController.getPlaygroundResultType(res);
 
       expect(type).to.deep.equal('update');
     });
 
     test('return other telemetry type if evaluation returns a string', () => {
-      const res = [{ type: null, content: '2' }];
+      const res = {
+        outputLines: [],
+        result: { type: null, content: '2' }
+      };
       const type = testTelemetryController.getPlaygroundResultType(res);
 
       expect(type).to.deep.equal('other');

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -3,4 +3,7 @@ export type OutputItem = {
   content: string;
 };
 
-export type ExecuteAllResult = OutputItem[] | undefined;
+export type ExecuteAllResult = {
+  outputLines: OutputItem[] | undefined,
+  result: any
+};


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
- Move playground results from the output channel to the virtual document opened in a split-view mode.
- The results of a playground should have syntax highlighting if they represent a JSON document.
- The results that are not Ja SON document should be printed as plain text with a single color.
- Users can open as many playgrounds they want, but results should be always printed to the same Results editor.
- The Results editor can be drag and dropped to any side of a split-view mode and should keep receiving results from any opened playground. 
- The Results file can be saved on a disc and in this case the current Results file stops acting as a Results editor and the new Results editor will be open with the next successful playground execution. It will allow users to freeze some results and compare them with each other.
- Keep printing debug information (eg console.log) in the output channel.

Also, this PR includes a small package.json fix to address the following issue: https://github.com/mongodb-js/vscode/issues/196

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
