### PR TITLE
VSCODE-200: Open mongodb shell with git bash

### DIFF
--- a/src/test/suite/commands/launchMongoShell.test.ts
+++ b/src/test/suite/commands/launchMongoShell.test.ts
@@ -163,16 +163,16 @@ suite('Commands Test Suite', () => {
       );
 
       assert(
-        shellArgs[1] === '--ssl',
-        `Expected open terminal to set ssl arg "--ssl" found "${shellArgs[1]}"`
+        shellArgs[1] === '--tls',
+        `Expected open terminal to set tls arg "--tls" found "${shellArgs[1]}"`
       );
       assert(
-        shellArgs[2] === '--sslAllowInvalidHostnames',
-        `Expected open terminal to set ssl arg "--sslAllowInvalidHostnames" found "${shellArgs[2]}"`
+        shellArgs[2] === '--tlsAllowInvalidHostnames',
+        `Expected open terminal to set tls arg "--tlsAllowInvalidHostnames" found "${shellArgs[2]}"`
       );
       assert(
-        shellArgs[3] === '--sslCAFile=./path_to_some_file',
-        `Expected open terminal to set sslCAFile arg "--sslCAFile=./path_to_some_file" found "${shellArgs[3]}"`
+        shellArgs[3] === '--tlsCAFile="./path_to_some_file"',
+        `Expected open terminal to set tlsCAFile arg "--tlsCAFile="./path_to_some_file"" found "${shellArgs[3]}"`
       );
     });
   });
@@ -271,16 +271,16 @@ suite('Commands Test Suite', () => {
 
       const shellCommandText = fakeSendTerminalText.firstCall.args[0];
       assert(
-        shellCommandText.includes('--ssl'),
-        `Expected open terminal to have ssl arg "--ssl" found "${shellCommandText}"`
+        shellCommandText.includes('--tls'),
+        `Expected open terminal to have tls arg "--tls" found "${shellCommandText}"`
       );
       assert(
-        shellCommandText.includes('--sslAllowInvalidHostnames'),
-        `Expected open terminal to have ssl arg "--sslAllowInvalidHostnames" found "${shellCommandText}"`
+        shellCommandText.includes('--tlsAllowInvalidHostnames'),
+        `Expected open terminal to have tls arg "--tlsAllowInvalidHostnames" found "${shellCommandText}"`
       );
       assert(
-        shellCommandText.includes('--sslCAFile=./path_to_some_file'),
-        `Expected open terminal to have sslCAFile arg "--sslCAFile=./path_to_some_file" found "${shellCommandText}"`
+        shellCommandText.includes('--tlsCAFile="./path_to_some_file"'),
+        `Expected open terminal to have tlsCAFile arg "--tlsCAFile="./path_to_some_file"" found "${shellCommandText}"`
       );
     });
   });
@@ -373,16 +373,16 @@ suite('Commands Test Suite', () => {
 
       const shellCommandText = fakeSendTerminalText.firstCall.args[0];
       assert(
-        shellCommandText.includes('--ssl'),
-        `Expected open terminal to have ssl arg "--ssl" found "${shellCommandText}"`
+        shellCommandText.includes('--tls'),
+        `Expected open terminal to have tls arg "--tls" found "${shellCommandText}"`
       );
       assert(
-        shellCommandText.includes('--sslAllowInvalidHostnames'),
-        `Expected open terminal to have ssl arg "--sslAllowInvalidHostnames" found "${shellCommandText}"`
+        shellCommandText.includes('--tlsAllowInvalidHostnames'),
+        `Expected open terminal to have tls arg "--tlsAllowInvalidHostnames" found "${shellCommandText}"`
       );
       assert(
-        shellCommandText.includes('--sslCAFile=./path_to_some_file'),
-        `Expected open terminal to have sslCAFile arg "--sslCAFile=./path_to_some_file" found "${shellCommandText}"`
+        shellCommandText.includes('--tlsCAFile="./path_to_some_file"'),
+        `Expected open terminal to have tlsCAFile arg "--tlsCAFile="./path_to_some_file"" found "${shellCommandText}"`
       );
     });
   });


### PR DESCRIPTION
VSCODE-200

Fixes https://github.com/mongodb-js/vscode/issues/186

This PR adds support for launching MongoDB shell when the user has their default shell set to git bash.
It also fixes an issue with loading files with spaces in them.

The way we do the environment passing for these different shell environments is a bit manual and hacky. I've looked around for a bit for a node package which provides support for building the shell command for various shells/environments but haven't found one. Do ya'll know of one? I think this works for now but it would be nice to have a quick catch all to prevent any lack of support for other environments.

Manually tested with SSL certs on windows (with a cert file with a space in it which is how I came across that other bug xD).