### PR TITLE
fix(VSCODE-202): Allow x509 username to be optional in connection string parsing and building

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13670,9 +13670,9 @@
       }
     },
     "mongodb-connection-model": {
-      "version": "16.1.8",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-model/-/mongodb-connection-model-16.1.8.tgz",
-      "integrity": "sha512-PhlfLYZhicERFhFC767SdN52VpTv0ZN+GU31lRqlCfljnaKuDuocytX4XhNupCSy0c6dKrNCoP+K3fDucevJYg==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-model/-/mongodb-connection-model-17.0.2.tgz",
+      "integrity": "sha512-JTLUh11BB0PmkWYiV5hLxGRabthuc64vZ/fdfPsewMTeQoU5GLzh74DHg0HPso2iIcCgSVhZiYjBjO3+0DPNhQ==",
       "requires": {
         "ampersand-model": "^8.0.0",
         "ampersand-rest-collection": "^6.0.0",
@@ -13735,6 +13735,22 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
           "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
+        },
+        "mongodb-connection-model": {
+          "version": "16.1.8",
+          "resolved": "https://registry.npmjs.org/mongodb-connection-model/-/mongodb-connection-model-16.1.8.tgz",
+          "integrity": "sha512-PhlfLYZhicERFhFC767SdN52VpTv0ZN+GU31lRqlCfljnaKuDuocytX4XhNupCSy0c6dKrNCoP+K3fDucevJYg==",
+          "requires": {
+            "ampersand-model": "^8.0.0",
+            "ampersand-rest-collection": "^6.0.0",
+            "async": "^3.1.0",
+            "debug": "^4.1.1",
+            "lodash": "^4.17.15",
+            "mongodb": "^3.6.1",
+            "raf": "^3.4.1",
+            "ssh2": "^0.8.7",
+            "storage-mixin": "^3.3.4"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -832,7 +832,7 @@
     "encoding": "^0.1.12",
     "micromatch": "^4.0.2",
     "mongodb-cloud-info": "^1.1.2",
-    "mongodb-connection-model": "^16.1.4",
+    "mongodb-connection-model": "^17.0.2",
     "mongodb-data-service": "^16.8.1",
     "mongodb-ns": "^2.2.0",
     "mongodb-schema": "^8.2.5",


### PR DESCRIPTION
VSCODE-202

Pulls in https://github.com/mongodb-js/connection-model/pull/327/files