### PR TITLE
fix: use `createIndex` instead of deprecated `ensureIndex`

### DIFF
--- a/src/templates/playgroundCreateIndexTemplate.ts
+++ b/src/templates/playgroundCreateIndexTemplate.ts
@@ -5,10 +5,8 @@ const template = `// MongoDB Playground
 use('CURRENT_DATABASE');
 
 // Create a new index in the collection.
-// 'ensureIndex' checks to see if the index already exists
-// before creating it, to avoid duplicates.
 db.getCollection('CURRENT_COLLECTION')
-  .ensureIndex(
+  .createIndex(
     {
       /*
        * Keys


### PR DESCRIPTION
TIL `ensureIndex` is deprecated 😅 

https://docs.mongodb.com/manual/reference/method/db.collection.ensureIndex/

![create index](https://user-images.githubusercontent.com/1791149/98961849-4e61dd00-2506-11eb-9e27-051464e6a135.gif)
