### PR TITLE
feat(connect-form): Update ssl tab to use box group select instead of select dropdown

### DIFF
--- a/src/views/webview-app/components/connect-form/ssl-tab/ssl-tab.tsx
+++ b/src/views/webview-app/components/connect-form/ssl-tab/ssl-tab.tsx
@@ -10,7 +10,7 @@ import SSL_METHODS, {
   SSLMethodOptions
 } from '../../../connection-model/constants/ssl-methods';
 import FormGroup from '../../form/form-group';
-import FormItemSelect from '../../form/form-item-select';
+import RadioBoxGroup from '../../form/radio-box-group/radio-box-group';
 import SSLServerValidation from './ssl-server-validation';
 import SSLServerClientValidation from './ssl-server-client-validation';
 
@@ -53,13 +53,14 @@ class SSLTab extends React.Component<StateProps & DispatchProps> {
 
     return (
       <FormGroup id="sslMethod" separator>
-        <FormItemSelect
+        <RadioBoxGroup
           label="SSL"
           name="sslMethod"
-          options={SSLMethodOptions.map((methodOption) => ({
-            [`${methodOption.id}`]: methodOption.title
+          options={SSLMethodOptions.map((sslMethodOption) => ({
+            label: sslMethodOption.title,
+            value: sslMethodOption.id
           }))}
-          changeHandler={this.onSSLMethodChanged}
+          onChange={this.onSSLMethodChanged}
           value={sslMethod}
         />
         {this.renderSSLMethod()}


### PR DESCRIPTION
This PR changes our SSL Tab to use the box group select component instead of the select dropdown.

This PR does remove our last reference to the select component, so it isn't used in the form anymore. I didn't remove it from the codebase because it is included in the mocks so we'll be using it later. If preferred I can remove it for now and add it back in later.

![ssl box select](https://user-images.githubusercontent.com/1791149/99412648-f8ed4d80-28c2-11eb-8fc7-b85d361eb5b8.gif)
