### PR TITLE
fix(VSCODE-118): Fix opening documents with binary _id from tree view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3621,12 +3621,11 @@
       }
     },
     "bson": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.1.0.tgz",
-      "integrity": "sha512-xwNzRRsK2xmHvHuPESi0zVfgsm4edO47WdulNaShTriunNUMRDOAlKwpJc8zpkOXczIzbxUD7kFzhUGVYoZLDw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.2.0.tgz",
+      "integrity": "sha512-c3MlJqdROnCRvDr/+MLfaDvQ7CvGI4p1hKX45/fvgzSwKRdOjsfRug1NJJ8ty5mXCNtUdjJEWzoZWcBQxV4TyA==",
       "requires": {
-        "buffer": "^5.1.0",
-        "long": "^4.0.0"
+        "buffer": "^5.6.0"
       }
     },
     "buffer": {
@@ -12568,11 +12567,6 @@
           }
         }
       }
-    },
-    "long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "loose-envify": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -827,7 +827,7 @@
     "@mongosh/service-provider-server": "^0.5.2",
     "@mongosh/shell-api": "^0.5.2",
     "analytics-node": "^3.4.0-beta.1",
-    "bson": "^4.0.3",
+    "bson": "^4.2.0",
     "classnames": "^2.2.6",
     "debug": "^4.1.1",
     "dotenv": "^8.2.0",

--- a/src/editors/documentProvider.ts
+++ b/src/editors/documentProvider.ts
@@ -36,7 +36,9 @@ export default class DocumentViewProvider implements vscode.TextDocumentContentP
       const documentIdEJSONString = decodeURIComponent(
         uriParams.get(DOCUMENT_ID_URI_IDENTIFIER) || ''
       );
-      const documentId = EJSON.parse(documentIdEJSONString).value;
+
+      const jsonObjectId = JSON.parse(documentIdEJSONString).value;
+      const documentId = EJSON.deserialize(jsonObjectId);
 
       // Ensure we're still connected to the correct connection.
       if (connectionId !== this._connectionController.getActiveConnectionId()) {
@@ -77,7 +79,7 @@ export default class DocumentViewProvider implements vscode.TextDocumentContentP
           }
 
           if (!documents || documents.length === 0) {
-            const errorMessage = `Unable to find document: ${documentId}`;
+            const errorMessage = `Unable to find document: ${JSON.stringify(jsonObjectId)}`;
             vscode.window.showErrorMessage(errorMessage);
             return reject(new Error(errorMessage));
           }

--- a/src/editors/editorsController.ts
+++ b/src/editors/editorsController.ts
@@ -99,15 +99,15 @@ export default class EditorsController {
     log.info('activated.');
   }
 
-  onViewDocument(namespace: string, documentId: any): Promise<boolean> {
+  onViewDocument(namespace: string, documentId: EJSON.SerializableTypes): Promise<boolean> {
     log.info('view document in editor', namespace);
 
     const connectionId = this._connectionController.getActiveConnectionId();
     const connectionIdUriQuery = `${CONNECTION_ID_URI_IDENTIFIER}=${connectionId}`;
     // Encode the _id field incase the document id is a custom string with
     // special characters.
-    const documentIdString = EJSON.stringify({
-      value: documentId
+    const documentIdString = JSON.stringify({
+      value: EJSON.serialize(documentId)
     });
 
     const documentIdUriQuery = `${DOCUMENT_ID_URI_IDENTIFIER}=${encodeURIComponent(

--- a/src/explorer/documentTreeItem.ts
+++ b/src/explorer/documentTreeItem.ts
@@ -1,3 +1,4 @@
+import { EJSON } from 'bson';
 import * as vscode from 'vscode';
 
 export const DOCUMENT_ITEM = 'documentTreeItem';
@@ -6,11 +7,9 @@ export default class DocumentTreeItem extends vscode.TreeItem
   implements vscode.TreeDataProvider<DocumentTreeItem> {
   contextValue = DOCUMENT_ITEM;
 
-  private _documentLabel: string;
-
   namespace: string;
   document: any;
-  documentId: string;
+  documentId: EJSON.SerializableTypes;
 
   constructor(document: any, namespace: string, documentIndexInTree: number) {
     // A document can not have a `_id` when it is in a view. In this instance
@@ -25,7 +24,6 @@ export default class DocumentTreeItem extends vscode.TreeItem
     const documentLabel = document._id
       ? JSON.stringify(document._id)
       : `Document ${documentIndexInTree + 1}`;
-    this._documentLabel = documentLabel;
 
     this.document = document;
     this.documentId = document._id;

--- a/src/test/suite/editors/documentStringFixtures.ts
+++ b/src/test/suite/editors/documentStringFixtures.ts
@@ -1,4 +1,4 @@
-import { EJSON } from 'bson';
+import { Binary, EJSON } from 'bson';
 
 const docString =
   '{"_id":{"$oid":"57e193d7a9cc81b4027498b5"},"Symbol":"symbol","String":"string","Int32":{"$numberInt":"42"},"Int64":{"$numberLong":"42"},"Double":{"$numberDouble":"-1"},"Binary":{"$binary":{"base64":"o0w498Or7cijeBSpkquNtg==","subType":"03"}},"BinaryUserDefined":{"$binary":{"base64":"AQIDBAU=","subType":"80"}},"Code":{"$code":"function() {}"},"CodeWithScope":{"$code":"function() {}","$scope":{}},"Subdocument":{"foo":"bar"},"Array":[{"$numberInt":"1"},{"$numberInt":"2"},{"$numberInt":"3"},{"$numberInt":"4"},{"$numberInt":"5"}],"Timestamp":{"$timestamp":{"t":42,"i":1}},"Regex":{"$regularExpression":{"pattern":"pattern","options":""}},"DatetimeEpoch":{"$date":{"$numberLong":"0"}},"DatetimePositive":{"$date":{"$numberLong":"2147483647"}},"DatetimeNegative":{"$date":{"$numberLong":"-2147483648"}},"True":true,"False":false,"DBPointer":{"$ref":"collection","$id":{"$oid":"57e193d7a9cc81b4027498b1"}},"DBRef":{"$ref":"collection","$id":{"$oid":"57fd71e96e32ab4225b723fb"},"$db":"database"},"Minkey":{"$minKey":1},"Maxkey":{"$maxKey":1},"Null":null,"Undefined":null}';
@@ -56,3 +56,12 @@ export const documentWithAllBsonTypesJsonified = `{
   "Null": null,
   "Undefined": null
 }`;
+
+export const documentWithBinaryId = {
+  _id: new Binary('aaa')
+};
+export const documentWithBinaryIdString = JSON.stringify(
+  documentWithBinaryId,
+  null,
+  2
+);


### PR DESCRIPTION
VSCODE-118

Previously only object ids and primitives were able to be open.
This fixes part of https://github.com/mongodb-js/vscode/issues/131 however it looks like we can't hand numberLong types over a certain amount, which is a separate issue.

*The first document opened in gif*
<img width="290" alt="Screen Shot 2020-11-20 at 4 42 34 PM" src="https://user-images.githubusercontent.com/1791149/99852642-64e3e600-2b4f-11eb-879e-bcbbbef5c176.png">

Also found out that Compass doesn't allow editing binary - or numberLong - values except in the json view, however when it's edited in the json view it silently fails. Need to see if a ticket already exists.
![opening docs with binary, object id, and number ids](https://user-images.githubusercontent.com/1791149/99852531-2ea66680-2b4f-11eb-9f12-69833f0e0c9b.gif)
