### PR TITLE
chore(test): make tests more resilient VSCODE-209

### DIFF
--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -904,7 +904,7 @@ suite('Connection Controller Test Suite', function () {
   test('a successfully connecting connection can be removed while it is being connected to', async () => {
     const connectionModel = await getConnection(TEST_DATABASE_URI);
 
-    const connectionId = 'skateboard';
+    const connectionId = 'skateboard2';
     testConnectionController._connections[connectionId] = {
       id: connectionId,
       name: 'asdfasdg',

--- a/src/test/suite/explorer/fieldTreeItem.test.ts
+++ b/src/test/suite/explorer/fieldTreeItem.test.ts
@@ -17,7 +17,8 @@ import {
 } from '../dbTestHelper';
 import { TestExtensionContext } from '../stubs';
 
-suite('FieldTreeItem Test Suite', () => {
+suite('FieldTreeItem Test Suite', function () {
+  this.timeout(10000);
   test('its context value should be in the package json', function () {
     let registeredCommandInPackageJson = false;
 

--- a/src/test/suite/explorer/playgroundsExplorer.test.ts
+++ b/src/test/suite/explorer/playgroundsExplorer.test.ts
@@ -4,7 +4,8 @@ import { before, afterEach } from 'mocha';
 import { mdbTestExtension } from '../stubbableMdbExtension';
 import PlaygroundsTree from './../../../explorer/playgroundsTree';
 
-suite('Playgrounds Controller Test Suite', () => {
+suite('Playgrounds Controller Test Suite', function () {
+  this.timeout(10000);
   const testPlaygroundsExplorer =
     mdbTestExtension.testExtensionController._playgroundsExplorer;
   let excludeFromPlaygroundsSearchDefault: string[];

--- a/src/test/suite/explorer/schemaTreeItem.test.ts
+++ b/src/test/suite/explorer/schemaTreeItem.test.ts
@@ -2,6 +2,7 @@ import assert from 'assert';
 import * as vscode from 'vscode';
 import { afterEach } from 'mocha';
 import * as sinon from 'sinon';
+import { inspect } from 'util';
 
 const { contributes } = require('../../../../package.json');
 
@@ -18,7 +19,8 @@ import {
 } from '../dbTestHelper';
 import { TestExtensionContext } from '../stubs';
 
-suite('SchemaTreeItem Test Suite', () => {
+suite('SchemaTreeItem Test Suite', function () {
+  this.timeout(10000);
   afterEach(() => {
     sinon.restore();
   });
@@ -339,7 +341,7 @@ suite('SchemaTreeItem Test Suite', () => {
             dataService.disconnect();
             assert(
               schemaFields.length === 3,
-              `Expected 3 schema tree items to be returned, recieved ${schemaFields.length}`
+              `Expected 3 schema tree items to be returned, recieved ${schemaFields.length}: ${inspect(schemaFields)}`
             );
             assert(
               fieldIsExpandable(schemaFields[1].field),

--- a/src/test/suite/mdbExtensionController.test.ts
+++ b/src/test/suite/mdbExtensionController.test.ts
@@ -20,7 +20,9 @@ import IndexListTreeItem from '../../explorer/indexListTreeItem';
 const sinon = require('sinon');
 const testDatabaseURI = 'mongodb://localhost:27018';
 
-suite('MDBExtensionController Test Suite', () => {
+suite('MDBExtensionController Test Suite', function () {
+  this.timeout(10000);
+
   beforeEach(() => {
     // Here we stub the showInformationMessage process because it is too much
     // for the render process and leads to crashes while testing.

--- a/src/test/suite/telemetry/telemetryController.test.ts
+++ b/src/test/suite/telemetry/telemetryController.test.ts
@@ -166,7 +166,7 @@ suite('Telemetry Controller Test Suite', () => {
   });
 
   test('track playground loaded and saved events', async function () {
-    this.timeout(3000);
+    this.timeout(10000);
     await loadAndSavePlayground(getDocUri('testSaving.mongodb'));
 
     sinon.assert.called(mockTrackPlaygroundLoadedMethod);


### PR DESCRIPTION
I ran tests for this a few dozen times in a loop and they did not fail
this way.

Changes include:
- A few timeout increases that otherwise were triggered locally for me
- Using a different `connectionId` for a specific test in the
  connection controller tests to avoid possible conflicts with other
  tests
- Printing more details in case of failure for one test that failed
  once but that I could not reproduce again.

<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
