### PR TITLE
feat(VSCODE-196): Show connection form error in connection form

### DIFF
--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -364,7 +364,7 @@ export default class ConnectionController {
 
           return resolve({
             successfullyConnected: false,
-            connectionErrorMessage: 'connection overriden'
+            connectionErrorMessage: 'connection attempt overriden'
           });
         }
 

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -208,7 +208,7 @@ export default class ConnectionController {
       }
 
       this.addNewConnectionStringAndConnect(connectionString).then(
-        (result) => resolve(!!result),
+        resolve,
         (err) => {
           vscode.window.showErrorMessage(err.message);
           resolve(false);

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -41,6 +41,11 @@ export enum NewConnectionType {
   SAVED_CONNECTION = 'SAVED_CONNECTION'
 }
 
+type ConnectionAttemptResult = {
+  successfullyConnected: boolean;
+  connectionErrorMessage: string;
+};
+
 export default class ConnectionController {
   // This is a map of connection ids to their configurations.
   // These connections can be saved on the session (runtime),
@@ -58,7 +63,7 @@ export default class ConnectionController {
   // the request. That way if a new connection attempt is made while
   // the connection is being established, we know we can ignore the
   // request when it is completed so we don't have two live connections at once.
-  private _connectingVersion = 0;
+  private _connectingVersion: null | string = null;
 
   private _connecting = false;
   private _connectingConnectionId: null | string = null;
@@ -174,7 +179,7 @@ export default class ConnectionController {
   };
 
   public async connectWithURI(): Promise<boolean> {
-    let connectionString: any;
+    let connectionString: string | undefined;
 
     log.info('connectWithURI command called');
 
@@ -197,13 +202,13 @@ export default class ConnectionController {
       return Promise.resolve(false);
     }
 
-    if (!connectionString) {
-      return Promise.resolve(false);
-    }
-
     return new Promise((resolve) => {
+      if (!connectionString) {
+        return resolve(false);
+      }
+
       this.addNewConnectionStringAndConnect(connectionString).then(
-        resolve,
+        (result) => resolve(!!result),
         (err) => {
           vscode.window.showErrorMessage(err.message);
           resolve(false);
@@ -212,14 +217,15 @@ export default class ConnectionController {
     });
   }
 
-  // Resolves true when the connection is successfully added.
+  // Resolves the new connection id when the connection is successfully added.
+  // Resolves false when it is added and not connected.
   // The connection can fail to connect but be successfully added.
   public addNewConnectionStringAndConnect = (
     connectionString: string
   ): Promise<boolean> => {
     log.info('Trying to connect to a new connection configuration');
 
-    return new Promise<boolean>((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       Connection.from(
         connectionString,
         (error: Error | undefined, newConnectionModel: ConnectionModelType) => {
@@ -230,7 +236,10 @@ export default class ConnectionController {
           return this.saveNewConnectionAndConnect(
             newConnectionModel,
             ConnectionTypes.CONNECTION_STRING
-          ).then(resolve, reject);
+          ).then(
+            (connectResult) => resolve(connectResult.successfullyConnected),
+            reject
+          );
         }
       );
     });
@@ -262,9 +271,8 @@ export default class ConnectionController {
   public saveNewConnectionAndConnect = async (
     connectionModel: ConnectionModelType,
     connectionType: ConnectionTypes
-  ): Promise<boolean> => {
+  ): Promise<ConnectionAttemptResult> => {
     const {
-      driverUrl,
       instanceId,
       sshTunnelOptions
     } = connectionModel.getAttributes({
@@ -303,25 +311,14 @@ export default class ConnectionController {
       this._storageController.storeNewConnection(newLoadedConnection);
     }
 
-    return new Promise((resolve, reject) => {
-      this.connect(connectionId, connectionModel, connectionType).then(
-        (connectSuccess) => {
-          if (!connectSuccess) {
-            return resolve(false);
-          }
-
-          return resolve(true);
-        },
-        reject
-      );
-    });
+    return this.connect(connectionId, connectionModel, connectionType);
   };
 
   public connect = async (
     connectionId: string,
     connectionModel: ConnectionModelType,
     connectionType: ConnectionTypes
-  ): Promise<boolean> => {
+  ): Promise<ConnectionAttemptResult> => {
     log.info(
       'Connect called to connect to instance:',
       connectionModel.getAttributes({
@@ -331,7 +328,7 @@ export default class ConnectionController {
 
     // Store a version of this connection, so we can see when the conection
     // is successful if it is still the most recent connection attempt.
-    this._connectingVersion++;
+    this._connectingVersion = connectionId;
     const connectingAttemptVersion = this._connectingVersion;
 
     this._connecting = true;
@@ -345,7 +342,7 @@ export default class ConnectionController {
 
     this._statusView.showMessage('Connecting to MongoDB...');
 
-    return new Promise<boolean>((resolve, reject) => {
+    return new Promise<ConnectionAttemptResult>((resolve, reject) => {
       // Override the default connection `appname`.
       connectionModel.appname = `${name} ${version}`;
 
@@ -365,7 +362,10 @@ export default class ConnectionController {
             /* */
           }
 
-          return resolve(false);
+          return resolve({
+            successfullyConnected: false,
+            connectionErrorMessage: 'connection overriden'
+          });
         }
 
         this._statusView.hideMessage();
@@ -392,7 +392,10 @@ export default class ConnectionController {
         // Send metrics to Segment
         this.sendTelemetry(newDataService, connectionType);
 
-        return resolve(true);
+        return resolve({
+          successfullyConnected: true,
+          connectionErrorMessage: ''
+        });
       });
     });
   };
@@ -423,11 +426,14 @@ export default class ConnectionController {
           connectionId,
           connectionModel,
           ConnectionTypes.CONNECTION_ID
-        ).then(resolve, (err: Error) => {
-          vscode.window.showErrorMessage(err.message);
+        ).then(
+          (connectResult) => resolve(connectResult.successfullyConnected),
+          (err: Error) => {
+            vscode.window.showErrorMessage(err.message);
 
-          return resolve(false);
-        });
+            return resolve(false);
+          }
+        );
       });
     }
 
@@ -551,13 +557,13 @@ export default class ConnectionController {
     const connectionNameToRemove:
       | string
       | undefined = await vscode.window.showQuickPick(
-      connectionIds.map(
-        (id, index) => `${index + 1}: ${this._connections[id].name}`
-      ),
-      {
-        placeHolder: 'Choose a connection to remove...'
-      }
-    );
+        connectionIds.map(
+          (id, index) => `${index + 1}: ${this._connections[id].name}`
+        ),
+        {
+          placeHolder: 'Choose a connection to remove...'
+        }
+      );
 
     if (!connectionNameToRemove) {
       return Promise.resolve(false);
@@ -572,14 +578,14 @@ export default class ConnectionController {
   }
 
   public async renameConnection(connectionId: string): Promise<boolean> {
-    let inputtedConnectionName: any;
+    let inputtedConnectionName: string | undefined;
 
     try {
       inputtedConnectionName = await vscode.window.showInputBox({
         value: this._connections[connectionId].name,
         placeHolder: 'e.g. My Connection Name',
         prompt: 'Enter new connection name.',
-        validateInput: (inputConnectionName: any) => {
+        validateInput: (inputConnectionName: string) => {
           if (
             inputConnectionName &&
             inputConnectionName.length > MAX_CONNECTION_NAME_LENGTH
@@ -754,10 +760,10 @@ export default class ConnectionController {
     this._connecting = false;
     this._disconnecting = false;
     this._connectingConnectionId = '';
-    this._connectingVersion = 0;
+    this._connectingVersion = null;
   }
 
-  public getConnectingVersion(): number {
+  public getConnectingVersion(): string | null {
     return this._connectingVersion;
   }
 

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -818,11 +818,12 @@ suite('Connection Controller Test Suite', function () {
 
     test('updates the connecting version on each new connection attempt', async () => {
       assert(testConnectionController.getConnectingVersion() === null);
-      testConnectionController.addNewConnectionStringAndConnect(
+      await testConnectionController.addNewConnectionStringAndConnect(
         TEST_DATABASE_URI
       );
 
       const currentConnectingVersion = testConnectionController.getConnectingVersion();
+
       assert(currentConnectingVersion !== null);
       assert(currentConnectingVersion === testConnectionController._connections[
         Object.keys(testConnectionController._connections)[0]

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -816,15 +816,22 @@ suite('Connection Controller Test Suite', function () {
       );
     });
 
-    test('increments the connecting version on each new connection attempt', async () => {
+    test('updates the connecting version on each new connection attempt', async () => {
+      assert(testConnectionController.getConnectingVersion() === null);
       testConnectionController.addNewConnectionStringAndConnect(
         TEST_DATABASE_URI
       );
 
+      const currentConnectingVersion = testConnectionController.getConnectingVersion();
+      assert(currentConnectingVersion !== null);
+      assert(currentConnectingVersion === testConnectionController._connections[
+        Object.keys(testConnectionController._connections)[0]
+      ].id);
+
       await testConnectionController.addNewConnectionStringAndConnect(
         TEST_DATABASE_URI
       );
-      assert(testConnectionController.getConnectingVersion() === 2);
+      assert(testConnectionController.getConnectingVersion() !== currentConnectingVersion);
     });
 
     test('it only connects to the most recent connection attempt', async () => {

--- a/src/test/suite/views/webview-app/store/store.test.ts
+++ b/src/test/suite/views/webview-app/store/store.test.ts
@@ -8,8 +8,18 @@ describe('Webview Store Test Suite', () => {
   test('ensure the state updates on an action call', () => {
     const resultingState = rootReducer(undefined, {
       type: 'CONNECTION_EVENT_OCCURED',
+      connectionAttemptId: null,
       successfullyConnected: true
     } as any);
     assert(resultingState.isConnected);
+  });
+
+  test('ensure we don\'t update connection status when the connectionAttemptId doesnt match the current one', () => {
+    const resultingState = rootReducer(undefined, {
+      type: 'CONNECTION_EVENT_OCCURED',
+      connectionAttemptId: 'aaa',
+      successfullyConnected: true
+    } as any);
+    assert(!resultingState.isConnected);
   });
 });

--- a/src/test/suite/views/webviewController.test.ts
+++ b/src/test/suite/views/webviewController.test.ts
@@ -299,7 +299,7 @@ suite('Webview Test Suite', () => {
     });
   });
 
-  test('web view sends an successful connect result on an attempt that is overridden', (done) => {
+  test('web view sends an unsuccessful connect result on an attempt that is overridden', (done) => {
     const testExtensionContext = new TestExtensionContext();
     const testStorageController = new StorageController(testExtensionContext);
     const testTelemetryController = new TelemetryController(
@@ -315,8 +315,8 @@ suite('Webview Test Suite', () => {
     const fakeWebview = {
       html: '',
       postMessage: (message: any): void => {
-        assert(message.connectionSuccess);
-        const expectedMessage = 'Successfully connected to localhost:27018.';
+        assert(!message.connectionSuccess);
+        const expectedMessage = 'connection attempt overriden';
         assert(
           message.connectionMessage === expectedMessage,
           `Expected connection message "${message.connectionMessage}" to equal ${expectedMessage}`

--- a/src/views/webview-app/components/app.tsx
+++ b/src/views/webview-app/components/app.tsx
@@ -19,6 +19,7 @@ const styles = require('../connect.module.less');
 
 type DispatchProps = {
   onConnectedEvent: (
+    connectionAttemptId: string,
     successfullyConnected: boolean,
     connectionMessage: string
   ) => void;
@@ -40,6 +41,7 @@ export class App extends React.Component<DispatchProps> {
       switch (message.command) {
         case MESSAGE_TYPES.CONNECT_RESULT:
           this.props.onConnectedEvent(
+            message.connectionAttemptId,
             message.connectionSuccess,
             message.connectionMessage
           );
@@ -73,10 +75,12 @@ export class App extends React.Component<DispatchProps> {
 
 const mapDispatchToProps: DispatchProps = {
   onConnectedEvent: (
+    connectionAttemptId: string,
     successfullyConnected: boolean,
     connectionMessage: string
   ): ConnectionEventOccuredAction => ({
     type: ActionTypes.CONNECTION_EVENT_OCCURED,
+    connectionAttemptId,
     successfullyConnected,
     connectionMessage
   }),

--- a/src/views/webview-app/extension-app-message-constants.ts
+++ b/src/views/webview-app/extension-app-message-constants.ts
@@ -1,3 +1,4 @@
+import ConnectionModel from './connection-model/connection-model';
 import { FilePickerActionTypes } from './store/actions';
 
 export enum CONNECTION_STATUS {
@@ -37,13 +38,15 @@ export interface ConnectionStatusMessage extends BasicWebviewMessage {
 
 export interface ConnectMessage extends BasicWebviewMessage {
   command: MESSAGE_TYPES.CONNECT;
-  connectionModel: any;
+  connectionModel: ConnectionModel;
+  connectionAttemptId: string;
 }
 
 export interface ConnectResultsMessage extends BasicWebviewMessage {
   command: MESSAGE_TYPES.CONNECT_RESULT;
   connectionSuccess: boolean;
   connectionMessage: string;
+  connectionAttemptId: string;
 }
 
 export interface GetConnectionStatusMessage extends BasicWebviewMessage {

--- a/src/views/webview-app/store/actions.ts
+++ b/src/views/webview-app/store/actions.ts
@@ -80,6 +80,7 @@ export interface ConnectionEventOccuredAction extends BaseAction {
   type: ActionTypes.CONNECTION_EVENT_OCCURED;
   successfullyConnected: boolean;
   connectionMessage: string;
+  connectionAttemptId: string;
 }
 
 export interface ConnectionFormChangedAction extends BaseAction {

--- a/src/views/webview-app/store/store.ts
+++ b/src/views/webview-app/store/store.ts
@@ -109,9 +109,12 @@ export const rootReducer = (
         };
       }
 
+      const connectionAttemptId = uuidv4();
+
       vscode.postMessage({
         command: MESSAGE_TYPES.CONNECT,
-        connectionModel: state.currentConnection
+        connectionModel: state.currentConnection,
+        connectionAttemptId: connectionAttemptId
       });
 
       return {
@@ -119,7 +122,8 @@ export const rootReducer = (
         // The form may be displaying a previous error message from a failed connect.
         isValid: true,
         isConnecting: true,
-        isConnected: false
+        isConnected: false,
+        connectionAttemptId
       };
 
     case ActionTypes.CREATE_NEW_PLAYGROUND:

--- a/src/views/webview-app/store/store.ts
+++ b/src/views/webview-app/store/store.ts
@@ -1,4 +1,5 @@
 import { Actions, ActionTypes, FilePickerActionTypes } from './actions';
+import { v4 as uuidv4 } from 'uuid';
 
 import ConnectionModel, {
   validateConnectionModel
@@ -20,6 +21,7 @@ const vscode = acquireVsCodeApi();
 
 export interface AppState {
   activeConnectionName: string;
+  connectionAttemptId: null | string;
   connectionFormTab: CONNECTION_FORM_TABS;
   connectionMessage: string;
   connectionStatus: CONNECTION_STATUS;
@@ -36,6 +38,7 @@ export interface AppState {
 
 export const initialState: AppState = {
   activeConnectionName: '',
+  connectionAttemptId: null,
   connectionFormTab: CONNECTION_FORM_TABS.GENERAL,
   connectionMessage: '',
   connectionStatus: CONNECTION_STATUS.LOADING,
@@ -59,6 +62,18 @@ const showFilePicker = (
     action,
     multi
   });
+};
+
+const sendConnectToExtension = (connectionModel: ConnectionModel): string => {
+  const connectionAttemptId = uuidv4();
+
+  vscode.postMessage({
+    command: MESSAGE_TYPES.CONNECT,
+    connectionModel,
+    connectionAttemptId
+  });
+
+  return connectionAttemptId;
 };
 
 // eslint-disable-next-line complexity
@@ -109,21 +124,13 @@ export const rootReducer = (
         };
       }
 
-      const connectionAttemptId = uuidv4();
-
-      vscode.postMessage({
-        command: MESSAGE_TYPES.CONNECT,
-        connectionModel: state.currentConnection,
-        connectionAttemptId: connectionAttemptId
-      });
-
       return {
         ...state,
         // The form may be displaying a previous error message from a failed connect.
         isValid: true,
         isConnecting: true,
         isConnected: false,
-        connectionAttemptId
+        connectionAttemptId: sendConnectToExtension(state.currentConnection)
       };
 
     case ActionTypes.CREATE_NEW_PLAYGROUND:
@@ -153,14 +160,19 @@ export const rootReducer = (
       };
 
     case ActionTypes.CONNECTION_EVENT_OCCURED:
-      return {
-        ...state,
-        isConnecting: false,
-        isConnected: action.successfullyConnected,
-        isValid: action.successfullyConnected ? state.isValid : false,
-        errorMessage: action.successfullyConnected ? '' : action.connectionMessage,
-        connectionMessage: action.connectionMessage
-      };
+      if (state.connectionAttemptId === action.connectionAttemptId) {
+        // Only update to show the connection attempt result
+        // when we it is the most recent connection attempt.
+        return {
+          ...state,
+          isConnecting: false,
+          isConnected: action.successfullyConnected,
+          isValid: action.successfullyConnected ? state.isValid : false,
+          errorMessage: action.successfullyConnected ? '' : action.connectionMessage,
+          connectionMessage: action.connectionMessage
+        };
+      }
+      return { ...state };
 
     case ActionTypes.HOSTNAME_CHANGED:
       return {

--- a/src/views/webviewController.ts
+++ b/src/views/webviewController.ts
@@ -85,14 +85,19 @@ export default class WebviewController {
         ConnectionTypes.CONNECTION_FORM
       );
 
-      panel.webview.postMessage({
-        command: MESSAGE_TYPES.CONNECT_RESULT,
-        connectionAttemptId,
-        connectionSuccess: successfullyConnected,
-        connectionMessage: successfullyConnected
-          ? `Successfully connected to ${this._connectionController.getActiveConnectionName()}.`
-          : connectionErrorMessage
-      });
+      try {
+        // The webview may have been closed in which case this will throw.
+        panel.webview.postMessage({
+          command: MESSAGE_TYPES.CONNECT_RESULT,
+          connectionAttemptId,
+          connectionSuccess: successfullyConnected,
+          connectionMessage: successfullyConnected
+            ? `Successfully connected to ${this._connectionController.getActiveConnectionName()}.`
+            : connectionErrorMessage
+        });
+      } catch (err) {
+        log.error('Unable to send connection result to webview:', err);
+      }
     } catch (error) {
       vscode.window.showErrorMessage(`Unable to load connection: ${error}`);
 

--- a/src/views/webviewController.ts
+++ b/src/views/webviewController.ts
@@ -1,15 +1,16 @@
 import * as vscode from 'vscode';
 import ConnectionController, {
-  DataServiceEventTypes,
   ConnectionTypes
 } from '../connectionController';
 import TelemetryController from '../telemetry/telemetryController';
 import {
   MESSAGE_FROM_WEBVIEW_TO_EXTENSION,
-  MESSAGE_TYPES
+  MESSAGE_TYPES,
+  OpenFilePickerMessage
 } from './webview-app/extension-app-message-constants';
 import { createLogger } from '../logging';
 import EXTENSION_COMMANDS from '../commands';
+import ConnectionModel from './webview-app/connection-model/connection-model';
 
 const path = require('path');
 const log = createLogger('webviewController');
@@ -67,62 +68,71 @@ export default class WebviewController {
     this._telemetryController = telemetryController;
   }
 
-  listenForConnectionResultsAndUpdatePanel = (
-    panel: vscode.WebviewPanel
-  ): () => void => {
-    const connectionDidChange = (): void => {
-      if (
-        !this._connectionController.isConnecting()
-      ) {
-        this._connectionController.removeEventListener(
-          DataServiceEventTypes.CONNECTIONS_DID_CHANGE,
-          connectionDidChange
-        );
+  handleWebviewConnectAttempt = async (
+    panel: vscode.WebviewPanel,
+    rawConnectionModel: ConnectionModel,
+    connectionAttemptId: string
+  ): Promise<void> => {
+    try {
+      const connectionModel = this._connectionController
+        .parseNewConnection(rawConnectionModel as any);
 
-        panel.webview.postMessage({
-          command: MESSAGE_TYPES.CONNECT_RESULT,
-          connectionSuccess: this._connectionController.isCurrentlyConnected(),
-          connectionMessage: this._connectionController.isCurrentlyConnected()
-            ? `Successfully connected to ${this._connectionController.getActiveConnectionName()}.`
-            : 'Unable to connect.'
-        });
-      }
-    };
+      const {
+        successfullyConnected,
+        connectionErrorMessage
+      } = await this._connectionController.saveNewConnectionAndConnect(
+        connectionModel,
+        ConnectionTypes.CONNECTION_FORM
+      );
 
-    this._connectionController.addEventListener(
-      DataServiceEventTypes.CONNECTIONS_DID_CHANGE,
-      connectionDidChange
-    );
+      panel.webview.postMessage({
+        command: MESSAGE_TYPES.CONNECT_RESULT,
+        connectionAttemptId,
+        connectionSuccess: successfullyConnected,
+        connectionMessage: successfullyConnected
+          ? `Successfully connected to ${this._connectionController.getActiveConnectionName()}.`
+          : connectionErrorMessage
+      });
+    } catch (error) {
+      vscode.window.showErrorMessage(`Unable to load connection: ${error}`);
 
-    // We return the listening function so we can remove the listener elsewhere.
-    return connectionDidChange;
+      panel.webview.postMessage({
+        command: MESSAGE_TYPES.CONNECT_RESULT,
+        connectionAttemptId,
+        connectionSuccess: false,
+        connectionMessage: `Unable to load connection: ${error}`
+      });
+    }
   };
 
-  handleWebviewMessage = (
+  handleWebviewOpenFilePickerRequest = async (
+    message: OpenFilePickerMessage,
+    panel: vscode.WebviewPanel
+  ): Promise<void> => {
+    const files = await vscode.window.showOpenDialog({
+      ...openFileOptions,
+      canSelectMany: message.multi
+    });
+    panel.webview.postMessage({
+      command: MESSAGE_TYPES.FILE_PICKER_RESULTS,
+      action: message.action,
+      files: (files && files.length > 0)
+        ? files.map((file) => path.resolve(file.path.substr(1)))
+        : undefined
+    });
+  };
+
+  handleWebviewMessage = async (
     message: MESSAGE_FROM_WEBVIEW_TO_EXTENSION,
     panel: vscode.WebviewPanel
-  ): void => {
+  ): Promise<void> => {
     switch (message.command) {
       case MESSAGE_TYPES.CONNECT:
-        try {
-          const connectionModel = this._connectionController
-            .parseNewConnection(message.connectionModel);
-
-          this.listenForConnectionResultsAndUpdatePanel(panel);
-
-          this._connectionController.saveNewConnectionAndConnect(
-            connectionModel,
-            ConnectionTypes.CONNECTION_FORM
-          );
-        } catch (error) {
-          vscode.window.showErrorMessage(`Unable to load connection: ${error}`);
-
-          panel.webview.postMessage({
-            command: MESSAGE_TYPES.CONNECT_RESULT,
-            connectionSuccess: false,
-            connectionMessage: `Unable to load connection: ${error}`
-          });
-        }
+        await this.handleWebviewConnectAttempt(
+          panel,
+          message.connectionModel,
+          message.connectionAttemptId
+        );
         return;
       case MESSAGE_TYPES.CREATE_NEW_PLAYGROUND:
         vscode.commands.executeCommand(
@@ -137,21 +147,7 @@ export default class WebviewController {
         });
         return;
       case MESSAGE_TYPES.OPEN_FILE_PICKER:
-        vscode.window
-          .showOpenDialog({
-            ...openFileOptions,
-            canSelectMany: message.multi
-          })
-          .then((files) => {
-            panel.webview.postMessage({
-              command: MESSAGE_TYPES.FILE_PICKER_RESULTS,
-              action: message.action,
-              files:
-                files && files.length > 0
-                  ? files.map((file) => path.resolve(file.path.substr(1)))
-                  : undefined
-            });
-          });
+        await this.handleWebviewOpenFilePickerRequest(message, panel);
         return;
       case MESSAGE_TYPES.OPEN_CONNECTION_STRING_INPUT:
         vscode.commands.executeCommand(EXTENSION_COMMANDS.MDB_CONNECT_WITH_URI);
@@ -179,13 +175,13 @@ export default class WebviewController {
     }
   };
 
-  onRecievedWebviewMessage = (
+  onRecievedWebviewMessage = async (
     message: MESSAGE_FROM_WEBVIEW_TO_EXTENSION,
     panel: vscode.WebviewPanel
-  ): void => {
+  ): Promise<void> => {
     // Ensure handling message from the webview can't crash the extension.
     try {
-      this.handleWebviewMessage(message, panel);
+      await this.handleWebviewMessage(message, panel);
     } catch (err) {
       log.info('Error occured when parsing message from webview:');
       log.info(err);


### PR DESCRIPTION
VSCODE-196

This PR updates how we show errors in our connection form. Previously we would show descriptive errors in vscode alerts. This updates the behavior to make the error in the connection form the verbose one, and move away from showing verbose vscode notifications, to show the error in the form ui. 

Wrapped a bit of cleanup in too, previously we were storing the connecting connection identifier as a number, now we use a uuid or the connection's id. The connection form now also stores the connecting connection identifier, so it can ignore overridden connection attempt results.

This PR should also handle the case where the user has closed the form window where they are attempting to connect. Previously this would cause a silent background error.

![showing error in connection form](https://user-images.githubusercontent.com/1791149/100629659-8c794200-32f7-11eb-9c10-8b9f760a050c.gif)
