### PR TITLE
[DNM] chore(467) rename NodeOptions to MongoClientOptions

### DIFF
--- a/src/language/worker.ts
+++ b/src/language/worker.ts
@@ -2,7 +2,7 @@ import { parentPort, workerData } from 'worker_threads';
 import { ElectronRuntime } from '@mongosh/browser-runtime-electron';
 import {
   CliServiceProvider,
-  NodeOptions
+  MongoClientOptions
 } from '@mongosh/service-provider-server';
 import parseSchema = require('mongodb-schema');
 import { ServerCommands } from './serverCommands';
@@ -21,7 +21,7 @@ type WorkerError = any | null;
 const executeAll = async (
   codeToEvaluate: string,
   connectionString: string,
-  connectionOptions: NodeOptions
+  connectionOptions: MongoClientOptions
 ): Promise<[WorkerError, WorkerResult?]> => {
   try {
     // Instantiate a data service provider.


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
MONGOSH-467 Upgrade the Node driver to 4.0

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
Previously we were making our own options interface `NodeOptions` but now that the driver is in typescript we can use their `MongoClientOptions` interface directly. This will need to be merged after the shell is released with the change
