### PR TITLE
fix(VSCODE-118): Fix opening binary _id

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13771,6 +13771,15 @@
           "version": "1.1.5",
           "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
           "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg=="
+        },
+        "saslprep": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+          "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+          "optional": true,
+          "requires": {
+            "sparse-bitfield": "^3.0.3"
+          }
         }
       }
     },
@@ -14009,6 +14018,16 @@
           "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
           "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg==",
           "dev": true
+        },
+        "saslprep": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+          "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "sparse-bitfield": "^3.0.3"
+          }
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,18 +13,18 @@
       }
     },
     "@babel/core": {
-      "version": "7.11.6",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.6.tgz",
-      "integrity": "sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==",
+      "version": "7.12.9",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.9.tgz",
+      "integrity": "sha512-gTXYh3M5wb7FRXQy+FErKFAv90BnlOuNn1QkCK2lREoPAjrQCO49+HVSrFoe5uakFAF5eenS75KbO2vQiLrTMQ==",
       "requires": {
         "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.11.6",
-        "@babel/helper-module-transforms": "^7.11.0",
-        "@babel/helpers": "^7.10.4",
-        "@babel/parser": "^7.11.5",
-        "@babel/template": "^7.10.4",
-        "@babel/traverse": "^7.11.5",
-        "@babel/types": "^7.11.5",
+        "@babel/generator": "^7.12.5",
+        "@babel/helper-module-transforms": "^7.12.1",
+        "@babel/helpers": "^7.12.5",
+        "@babel/parser": "^7.12.7",
+        "@babel/template": "^7.12.7",
+        "@babel/traverse": "^7.12.9",
+        "@babel/types": "^7.12.7",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
@@ -43,11 +43,11 @@
       }
     },
     "@babel/generator": {
-      "version": "7.11.6",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
-      "integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.5.tgz",
+      "integrity": "sha512-m16TQQJ8hPt7E+OS/XVQg/7U184MLXtvuGbCdA7na61vha+ImkyyNM/9DDA0unYCVZn3ZOhng+qz48/KBOT96A==",
       "requires": {
-        "@babel/types": "^7.11.5",
+        "@babel/types": "^7.12.5",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       }
@@ -62,68 +62,6 @@
         "@babel/helper-optimise-call-expression": "^7.10.4",
         "@babel/helper-replace-supers": "^7.12.1",
         "@babel/helper-split-export-declaration": "^7.10.4"
-      },
-      "dependencies": {
-        "@babel/generator": {
-          "version": "7.12.5",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.5.tgz",
-          "integrity": "sha512-m16TQQJ8hPt7E+OS/XVQg/7U184MLXtvuGbCdA7na61vha+ImkyyNM/9DDA0unYCVZn3ZOhng+qz48/KBOT96A==",
-          "requires": {
-            "@babel/types": "^7.12.5",
-            "jsesc": "^2.5.1",
-            "source-map": "^0.5.0"
-          }
-        },
-        "@babel/helper-member-expression-to-functions": {
-          "version": "7.12.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz",
-          "integrity": "sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==",
-          "requires": {
-            "@babel/types": "^7.12.1"
-          }
-        },
-        "@babel/helper-replace-supers": {
-          "version": "7.12.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.5.tgz",
-          "integrity": "sha512-5YILoed0ZyIpF4gKcpZitEnXEJ9UoDRki1Ey6xz46rxOzfNMAhVIJMoune1hmPVxh40LRv1+oafz7UsWX+vyWA==",
-          "requires": {
-            "@babel/helper-member-expression-to-functions": "^7.12.1",
-            "@babel/helper-optimise-call-expression": "^7.10.4",
-            "@babel/traverse": "^7.12.5",
-            "@babel/types": "^7.12.5"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.12.5",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.5.tgz",
-          "integrity": "sha512-FVM6RZQ0mn2KCf1VUED7KepYeUWoVShczewOCfm3nzoBybaih51h+sYVVGthW9M6lPByEPTQf+xm27PBdlpwmQ=="
-        },
-        "@babel/traverse": {
-          "version": "7.12.5",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.5.tgz",
-          "integrity": "sha512-xa15FbQnias7z9a62LwYAA5SZZPkHIXpd42C6uW68o8uTuua96FHZy1y61Va5P/i83FAAcMpW8+A/QayntzuqA==",
-          "requires": {
-            "@babel/code-frame": "^7.10.4",
-            "@babel/generator": "^7.12.5",
-            "@babel/helper-function-name": "^7.10.4",
-            "@babel/helper-split-export-declaration": "^7.11.0",
-            "@babel/parser": "^7.12.5",
-            "@babel/types": "^7.12.5",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.19"
-          }
-        },
-        "@babel/types": {
-          "version": "7.12.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-          "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-function-name": {
@@ -145,41 +83,43 @@
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
-      "integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
+      "version": "7.12.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.7.tgz",
+      "integrity": "sha512-DCsuPyeWxeHgh1Dus7APn7iza42i/qXqiFPWyBDdOFtvS581JQePsc1F/nD+fHrcswhLlRc2UpYS1NwERxZhHw==",
       "requires": {
-        "@babel/types": "^7.11.0"
+        "@babel/types": "^7.12.7"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
-      "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
+      "integrity": "sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==",
       "requires": {
-        "@babel/types": "^7.10.4"
+        "@babel/types": "^7.12.5"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
-      "integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
+      "integrity": "sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==",
       "requires": {
-        "@babel/helper-module-imports": "^7.10.4",
-        "@babel/helper-replace-supers": "^7.10.4",
-        "@babel/helper-simple-access": "^7.10.4",
+        "@babel/helper-module-imports": "^7.12.1",
+        "@babel/helper-replace-supers": "^7.12.1",
+        "@babel/helper-simple-access": "^7.12.1",
         "@babel/helper-split-export-declaration": "^7.11.0",
+        "@babel/helper-validator-identifier": "^7.10.4",
         "@babel/template": "^7.10.4",
-        "@babel/types": "^7.11.0",
+        "@babel/traverse": "^7.12.1",
+        "@babel/types": "^7.12.1",
         "lodash": "^4.17.19"
       }
     },
     "@babel/helper-optimise-call-expression": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
-      "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
+      "version": "7.12.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.7.tgz",
+      "integrity": "sha512-I5xc9oSJ2h59OwyUqjv95HRyzxj53DAubUERgQMrpcCEYQyToeHA+NEcUEsVWB4j53RDeskeBJ0SgRAYHDBckw==",
       "requires": {
-        "@babel/types": "^7.10.4"
+        "@babel/types": "^7.12.7"
       }
     },
     "@babel/helper-plugin-utils": {
@@ -188,23 +128,22 @@
       "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
     },
     "@babel/helper-replace-supers": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
-      "integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.5.tgz",
+      "integrity": "sha512-5YILoed0ZyIpF4gKcpZitEnXEJ9UoDRki1Ey6xz46rxOzfNMAhVIJMoune1hmPVxh40LRv1+oafz7UsWX+vyWA==",
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.10.4",
+        "@babel/helper-member-expression-to-functions": "^7.12.1",
         "@babel/helper-optimise-call-expression": "^7.10.4",
-        "@babel/traverse": "^7.10.4",
-        "@babel/types": "^7.10.4"
+        "@babel/traverse": "^7.12.5",
+        "@babel/types": "^7.12.5"
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
-      "integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
+      "integrity": "sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==",
       "requires": {
-        "@babel/template": "^7.10.4",
-        "@babel/types": "^7.10.4"
+        "@babel/types": "^7.12.1"
       }
     },
     "@babel/helper-split-export-declaration": {
@@ -220,14 +159,19 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
       "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
     },
+    "@babel/helper-validator-option": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.1.tgz",
+      "integrity": "sha512-YpJabsXlJVWP0USHjnC/AQDTLlZERbON577YUVO/wLpqyj6HAtVYnWaQaN0iUN+1/tWn3c+uKKXjRut5115Y2A=="
+    },
     "@babel/helpers": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
-      "integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.5.tgz",
+      "integrity": "sha512-lgKGMQlKqA8meJqKsW6rUnc4MdUk35Ln0ATDqdM1a/UpARODdI4j5Y5lVfUScnSNkJcdCRAaWkspykNoFg9sJA==",
       "requires": {
         "@babel/template": "^7.10.4",
-        "@babel/traverse": "^7.10.4",
-        "@babel/types": "^7.10.4"
+        "@babel/traverse": "^7.12.5",
+        "@babel/types": "^7.12.5"
       }
     },
     "@babel/highlight": {
@@ -241,9 +185,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.11.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
-      "integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q=="
+      "version": "7.12.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.7.tgz",
+      "integrity": "sha512-oWR02Ubp4xTLCAqPRiNIuMVgNO5Aif/xpXtabhzW2HWUD47XJsAB4Zd/Rg30+XeQA3juXigV7hlquOTmwqLiwg=="
     },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
@@ -264,9 +208,9 @@
       }
     },
     "@babel/plugin-syntax-class-properties": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.10.4.tgz",
-      "integrity": "sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.1.tgz",
+      "integrity": "sha512-U40A76x5gTwmESz+qiqssqmeEsKvcSyvtgktrm0uzcARAmM9I1jR221f6Oq+GmHrcD+LvZDag1UTOTe2fL3TeA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -344,6 +288,15 @@
         "@babel/helper-plugin-utils": "^7.8.0"
       }
     },
+    "@babel/plugin-syntax-top-level-await": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.12.1.tgz",
+      "integrity": "sha512-i7ooMZFS+a/Om0crxZodrTzNEPJHZrlMVGMTEpFAj6rYY/bKCddB0Dk/YxfPuYXOopuhKk/e1jV6h+WUU9XN3A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
     "@babel/plugin-syntax-typescript": {
       "version": "7.12.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.12.1.tgz",
@@ -363,52 +316,53 @@
       }
     },
     "@babel/preset-typescript": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.12.1.tgz",
-      "integrity": "sha512-hNK/DhmoJPsksdHuI/RVrcEws7GN5eamhi28JkO52MqIxU8Z0QpmiSOQxZHWOHV7I3P4UjHV97ay4TcamMA6Kw==",
+      "version": "7.12.7",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.12.7.tgz",
+      "integrity": "sha512-nOoIqIqBmHBSEgBXWR4Dv/XBehtIFcw9PqZw6rFYuKrzsZmOQm3PR5siLBnKZFEsDb03IegG8nSjU/iXXXYRmw==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-validator-option": "^7.12.1",
         "@babel/plugin-transform-typescript": "^7.12.1"
       }
     },
     "@babel/runtime": {
-      "version": "7.11.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-      "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+      "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
     },
     "@babel/template": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
-      "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+      "version": "7.12.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
+      "integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
       "requires": {
         "@babel/code-frame": "^7.10.4",
-        "@babel/parser": "^7.10.4",
-        "@babel/types": "^7.10.4"
+        "@babel/parser": "^7.12.7",
+        "@babel/types": "^7.12.7"
       }
     },
     "@babel/traverse": {
-      "version": "7.11.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
-      "integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
+      "version": "7.12.9",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.9.tgz",
+      "integrity": "sha512-iX9ajqnLdoU1s1nHt36JDI9KG4k+vmI8WgjK5d+aDTwQbL2fUnzedNedssA645Ede3PM2ma1n8Q4h2ohwXgMXw==",
       "requires": {
         "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.11.5",
+        "@babel/generator": "^7.12.5",
         "@babel/helper-function-name": "^7.10.4",
         "@babel/helper-split-export-declaration": "^7.11.0",
-        "@babel/parser": "^7.11.5",
-        "@babel/types": "^7.11.5",
+        "@babel/parser": "^7.12.7",
+        "@babel/types": "^7.12.7",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.19"
       }
     },
     "@babel/types": {
-      "version": "7.11.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-      "integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+      "version": "7.12.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.7.tgz",
+      "integrity": "sha512-MNyI92qZq6jrQkXvtIiykvl4WtoRrVV9MPn+ZfsoEENjiWcBQ3ZSHrkxnJWgWtLX3XXqX5hrSQ+X69wkmesXuQ==",
       "requires": {
         "@babel/helper-validator-identifier": "^7.10.4",
         "lodash": "^4.17.19",
@@ -511,9 +465,9 @@
       }
     },
     "@fortawesome/react-fontawesome": {
-      "version": "0.1.11",
-      "resolved": "https://npm.fontawesome.com/@fortawesome/react-fontawesome/-/0.1.11/react-fontawesome-0.1.11.tgz",
-      "integrity": "sha512-sClfojasRifQKI0OPqTy8Ln8iIhnxR/Pv/hukBhWnBz9kQRmqi6JSH3nghlhAY7SUeIIM7B5/D2G8WjX0iepVg==",
+      "version": "0.1.13",
+      "resolved": "https://npm.fontawesome.com/@fortawesome/react-fontawesome/-/0.1.13/react-fontawesome-0.1.13.tgz",
+      "integrity": "sha512-/HrLnIft5Ks2511Pz6TxHBIctC9QalVscAC64sufQ4sJH/sXaQlG3uR9LCu6VpEwkBemgcBLrz/QPNP/ddbjDg==",
       "requires": {
         "prop-types": "^15.7.2"
       }
@@ -524,9 +478,9 @@
       "integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg=="
     },
     "@iconify-icons/codicon": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@iconify-icons/codicon/-/codicon-1.0.6.tgz",
-      "integrity": "sha512-DIBcHqeVSG1qL3M+lVKkn9qRENh7KOtHXQhHLskHEhJRlXAQ2vCQ9IgmsOn8C8ZF18IXTzI8Qh7+lkc9O0wmPw=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@iconify-icons/codicon/-/codicon-1.1.1.tgz",
+      "integrity": "sha512-5tfn3RFY4VvLAwB0ha3cHfSKOboNjMV8e82dkpzSHURPyMO3qVWZxFjL4p3h8QHHvxFd4t0pwb9OvzfzTz6+pw=="
     },
     "@iconify/react": {
       "version": "1.1.3",
@@ -583,23 +537,23 @@
       "dev": true
     },
     "@jest/console": {
-      "version": "26.5.2",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-26.5.2.tgz",
-      "integrity": "sha512-lJELzKINpF1v74DXHbCRIkQ/+nUV1M+ntj+X1J8LxCgpmJZjfLmhFejiMSbjjD66fayxl5Z06tbs3HMyuik6rw==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-26.6.2.tgz",
+      "integrity": "sha512-IY1R2i2aLsLr7Id3S6p2BA82GNWryt4oSvEXLAKc+L2zdi89dSkE8xC1C+0kpATG4JhBJREnQOH7/zmccM2B0g==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.5.2",
+        "@jest/types": "^26.6.2",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "jest-message-util": "^26.5.2",
-        "jest-util": "^26.5.2",
+        "jest-message-util": "^26.6.2",
+        "jest-util": "^26.6.2",
         "slash": "^3.0.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -616,6 +570,15 @@
           "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.11",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
+          "integrity": "sha512-jfcNBxHFYJ4nPIacsi3woz1+kvUO6s1CyeEhtnDHBjHUMNj5UlW2GynmnSgiJJEdNg9yW5C8lfoNRZrHGv5EqA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
           }
         },
         "ansi-styles": {
@@ -670,34 +633,34 @@
       }
     },
     "@jest/core": {
-      "version": "26.5.2",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-26.5.2.tgz",
-      "integrity": "sha512-LLTo1LQMg7eJjG/+P1NYqFof2B25EV1EqzD5FonklihG4UJKiK2JBIvWonunws6W7e+DhNLoFD+g05tCY03eyA==",
+      "version": "26.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-26.6.3.tgz",
+      "integrity": "sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==",
       "dev": true,
       "requires": {
-        "@jest/console": "^26.5.2",
-        "@jest/reporters": "^26.5.2",
-        "@jest/test-result": "^26.5.2",
-        "@jest/transform": "^26.5.2",
-        "@jest/types": "^26.5.2",
+        "@jest/console": "^26.6.2",
+        "@jest/reporters": "^26.6.2",
+        "@jest/test-result": "^26.6.2",
+        "@jest/transform": "^26.6.2",
+        "@jest/types": "^26.6.2",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
-        "jest-changed-files": "^26.5.2",
-        "jest-config": "^26.5.2",
-        "jest-haste-map": "^26.5.2",
-        "jest-message-util": "^26.5.2",
+        "jest-changed-files": "^26.6.2",
+        "jest-config": "^26.6.3",
+        "jest-haste-map": "^26.6.2",
+        "jest-message-util": "^26.6.2",
         "jest-regex-util": "^26.0.0",
-        "jest-resolve": "^26.5.2",
-        "jest-resolve-dependencies": "^26.5.2",
-        "jest-runner": "^26.5.2",
-        "jest-runtime": "^26.5.2",
-        "jest-snapshot": "^26.5.2",
-        "jest-util": "^26.5.2",
-        "jest-validate": "^26.5.2",
-        "jest-watcher": "^26.5.2",
+        "jest-resolve": "^26.6.2",
+        "jest-resolve-dependencies": "^26.6.3",
+        "jest-runner": "^26.6.3",
+        "jest-runtime": "^26.6.3",
+        "jest-snapshot": "^26.6.2",
+        "jest-util": "^26.6.2",
+        "jest-validate": "^26.6.2",
+        "jest-watcher": "^26.6.2",
         "micromatch": "^4.0.2",
         "p-each-series": "^2.1.0",
         "rimraf": "^3.0.0",
@@ -706,9 +669,9 @@
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -725,6 +688,15 @@
           "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.11",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
+          "integrity": "sha512-jfcNBxHFYJ4nPIacsi3woz1+kvUO6s1CyeEhtnDHBjHUMNj5UlW2GynmnSgiJJEdNg9yW5C8lfoNRZrHGv5EqA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
           }
         },
         "ansi-regex": {
@@ -794,21 +766,21 @@
       }
     },
     "@jest/environment": {
-      "version": "26.5.2",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.5.2.tgz",
-      "integrity": "sha512-YjhCD/Zhkz0/1vdlS/QN6QmuUdDkpgBdK4SdiVg4Y19e29g4VQYN5Xg8+YuHjdoWGY7wJHMxc79uDTeTOy9Ngw==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.6.2.tgz",
+      "integrity": "sha512-nFy+fHl28zUrRsCeMB61VDThV1pVTtlEokBRgqPrcT1JNq4yRNIyTHfyht6PqtUvY9IsuLGTrbG8kPXjSZIZwA==",
       "dev": true,
       "requires": {
-        "@jest/fake-timers": "^26.5.2",
-        "@jest/types": "^26.5.2",
+        "@jest/fake-timers": "^26.6.2",
+        "@jest/types": "^26.6.2",
         "@types/node": "*",
-        "jest-mock": "^26.5.2"
+        "jest-mock": "^26.6.2"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -825,6 +797,15 @@
           "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.11",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
+          "integrity": "sha512-jfcNBxHFYJ4nPIacsi3woz1+kvUO6s1CyeEhtnDHBjHUMNj5UlW2GynmnSgiJJEdNg9yW5C8lfoNRZrHGv5EqA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
           }
         },
         "ansi-styles": {
@@ -879,23 +860,23 @@
       }
     },
     "@jest/fake-timers": {
-      "version": "26.5.2",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.5.2.tgz",
-      "integrity": "sha512-09Hn5Oraqt36V1akxQeWMVL0fR9c6PnEhpgLaYvREXZJAh2H2Y+QLCsl0g7uMoJeoWJAuz4tozk1prbR1Fc1sw==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.6.2.tgz",
+      "integrity": "sha512-14Uleatt7jdzefLPYM3KLcnUl1ZNikaKq34enpb5XG9i81JpppDb5muZvonvKyrl7ftEHkKS5L5/eB/kxJ+bvA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.5.2",
+        "@jest/types": "^26.6.2",
         "@sinonjs/fake-timers": "^6.0.1",
         "@types/node": "*",
-        "jest-message-util": "^26.5.2",
-        "jest-mock": "^26.5.2",
-        "jest-util": "^26.5.2"
+        "jest-message-util": "^26.6.2",
+        "jest-mock": "^26.6.2",
+        "jest-util": "^26.6.2"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -912,6 +893,15 @@
           "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.11",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
+          "integrity": "sha512-jfcNBxHFYJ4nPIacsi3woz1+kvUO6s1CyeEhtnDHBjHUMNj5UlW2GynmnSgiJJEdNg9yW5C8lfoNRZrHGv5EqA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
           }
         },
         "ansi-styles": {
@@ -966,20 +956,20 @@
       }
     },
     "@jest/globals": {
-      "version": "26.5.2",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.5.2.tgz",
-      "integrity": "sha512-9PmnFsAUJxpPt1s/stq02acS1YHliVBDNfAWMe1bwdRr1iTCfhbNt3ERQXrO/ZfZSweftoA26Q/2yhSVSWQ3sw==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.6.2.tgz",
+      "integrity": "sha512-85Ltnm7HlB/KesBUuALwQ68YTU72w9H2xW9FjZ1eL1U3lhtefjjl5c2MiUbpXt/i6LaPRvoOFJ22yCBSfQ0JIA==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^26.5.2",
-        "@jest/types": "^26.5.2",
-        "expect": "^26.5.2"
+        "@jest/environment": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "expect": "^26.6.2"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -996,6 +986,15 @@
           "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.11",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
+          "integrity": "sha512-jfcNBxHFYJ4nPIacsi3woz1+kvUO6s1CyeEhtnDHBjHUMNj5UlW2GynmnSgiJJEdNg9yW5C8lfoNRZrHGv5EqA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
           }
         },
         "ansi-styles": {
@@ -1050,16 +1049,16 @@
       }
     },
     "@jest/reporters": {
-      "version": "26.5.2",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.5.2.tgz",
-      "integrity": "sha512-zvq6Wvy6MmJq/0QY0YfOPb49CXKSf42wkJbrBPkeypVa8I+XDxijvFuywo6TJBX/ILPrdrlE/FW9vJZh6Rf9vA==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.6.2.tgz",
+      "integrity": "sha512-h2bW53APG4HvkOnVMo8q3QXa6pcaNt1HkwVsOPMBV6LD/q9oSpxNSYZQYkAnjdMjrJ86UuYeLo+aEZClV6opnw==",
       "dev": true,
       "requires": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^26.5.2",
-        "@jest/test-result": "^26.5.2",
-        "@jest/transform": "^26.5.2",
-        "@jest/types": "^26.5.2",
+        "@jest/console": "^26.6.2",
+        "@jest/test-result": "^26.6.2",
+        "@jest/transform": "^26.6.2",
+        "@jest/types": "^26.6.2",
         "chalk": "^4.0.0",
         "collect-v8-coverage": "^1.0.0",
         "exit": "^0.1.2",
@@ -1070,22 +1069,22 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.0.2",
-        "jest-haste-map": "^26.5.2",
-        "jest-resolve": "^26.5.2",
-        "jest-util": "^26.5.2",
-        "jest-worker": "^26.5.0",
+        "jest-haste-map": "^26.6.2",
+        "jest-resolve": "^26.6.2",
+        "jest-util": "^26.6.2",
+        "jest-worker": "^26.6.2",
         "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
         "terminal-link": "^2.0.0",
-        "v8-to-istanbul": "^5.0.1"
+        "v8-to-istanbul": "^7.0.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -1102,6 +1101,15 @@
           "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.11",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
+          "integrity": "sha512-jfcNBxHFYJ4nPIacsi3woz1+kvUO6s1CyeEhtnDHBjHUMNj5UlW2GynmnSgiJJEdNg9yW5C8lfoNRZrHGv5EqA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
           }
         },
         "ansi-styles": {
@@ -1162,9 +1170,9 @@
       }
     },
     "@jest/source-map": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.5.0.tgz",
-      "integrity": "sha512-jWAw9ZwYHJMe9eZq/WrsHlwF8E3hM9gynlcDpOyCb9bR8wEd9ZNBZCi7/jZyzHxC7t3thZ10gO2IDhu0bPKS5g==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.6.2.tgz",
+      "integrity": "sha512-YwYcCwAnNmOVsZ8mr3GfnzdXDAl4LaenZP5z+G0c8bzC9/dugL8zRmxZzdoTl4IaS3CryS1uWnROLPFmb6lVvA==",
       "dev": true,
       "requires": {
         "callsites": "^3.0.0",
@@ -1181,21 +1189,21 @@
       }
     },
     "@jest/test-result": {
-      "version": "26.5.2",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.5.2.tgz",
-      "integrity": "sha512-E/Zp6LURJEGSCWpoMGmCFuuEI1OWuI3hmZwmULV0GsgJBh7u0rwqioxhRU95euUuviqBDN8ruX/vP/4bwYolXw==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.6.2.tgz",
+      "integrity": "sha512-5O7H5c/7YlojphYNrK02LlDIV2GNPYisKwHm2QTKjNZeEzezCbwYs9swJySv2UfPMyZ0VdsmMv7jIlD/IKYQpQ==",
       "dev": true,
       "requires": {
-        "@jest/console": "^26.5.2",
-        "@jest/types": "^26.5.2",
+        "@jest/console": "^26.6.2",
+        "@jest/types": "^26.6.2",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -1212,6 +1220,15 @@
           "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.11",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
+          "integrity": "sha512-jfcNBxHFYJ4nPIacsi3woz1+kvUO6s1CyeEhtnDHBjHUMNj5UlW2GynmnSgiJJEdNg9yW5C8lfoNRZrHGv5EqA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
           }
         },
         "ansi-styles": {
@@ -1266,34 +1283,34 @@
       }
     },
     "@jest/test-sequencer": {
-      "version": "26.5.2",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.5.2.tgz",
-      "integrity": "sha512-XmGEh7hh07H2B8mHLFCIgr7gA5Y6Hw1ZATIsbz2fOhpnQ5AnQtZk0gmP0Q5/+mVB2xygO64tVFQxOajzoptkNA==",
+      "version": "26.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.6.3.tgz",
+      "integrity": "sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^26.5.2",
+        "@jest/test-result": "^26.6.2",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^26.5.2",
-        "jest-runner": "^26.5.2",
-        "jest-runtime": "^26.5.2"
+        "jest-haste-map": "^26.6.2",
+        "jest-runner": "^26.6.3",
+        "jest-runtime": "^26.6.3"
       }
     },
     "@jest/transform": {
-      "version": "26.5.2",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.5.2.tgz",
-      "integrity": "sha512-AUNjvexh+APhhmS8S+KboPz+D3pCxPvEAGduffaAJYxIFxGi/ytZQkrqcKDUU0ERBAo5R7087fyOYr2oms1seg==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.6.2.tgz",
+      "integrity": "sha512-E9JjhUgNzvuQ+vVAL21vlyfy12gP0GhazGgJC4h6qUt1jSdUXGWJ1wfu/X7Sd8etSgxV4ovT1pb9v5D6QW4XgA==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/types": "^26.5.2",
+        "@jest/types": "^26.6.2",
         "babel-plugin-istanbul": "^6.0.0",
         "chalk": "^4.0.0",
         "convert-source-map": "^1.4.0",
         "fast-json-stable-stringify": "^2.0.0",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^26.5.2",
+        "jest-haste-map": "^26.6.2",
         "jest-regex-util": "^26.0.0",
-        "jest-util": "^26.5.2",
+        "jest-util": "^26.6.2",
         "micromatch": "^4.0.2",
         "pirates": "^4.0.1",
         "slash": "^3.0.0",
@@ -1302,9 +1319,9 @@
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -1321,6 +1338,15 @@
           "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.11",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
+          "integrity": "sha512-jfcNBxHFYJ4nPIacsi3woz1+kvUO6s1CyeEhtnDHBjHUMNj5UlW2GynmnSgiJJEdNg9yW5C8lfoNRZrHGv5EqA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
           }
         },
         "ansi-styles": {
@@ -1381,66 +1407,13 @@
       }
     },
     "@jest/types": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
-      "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
-      "dev": true,
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
+      "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^1.1.1",
-        "@types/yargs": "^15.0.0",
-        "chalk": "^3.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
+        "@types/yargs": "^13.0.0"
       }
     },
     "@leafygreen-ui/emotion": {
@@ -1611,21 +1584,6 @@
         "@mongosh/i18n": "^0.5.2",
         "bson": "^4.2.0",
         "mongodb-build-info": "^1.1.1"
-      },
-      "dependencies": {
-        "bson": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-4.2.0.tgz",
-          "integrity": "sha512-c3MlJqdROnCRvDr/+MLfaDvQ7CvGI4p1hKX45/fvgzSwKRdOjsfRug1NJJ8ty5mXCNtUdjJEWzoZWcBQxV4TyA==",
-          "requires": {
-            "buffer": "^5.6.0"
-          }
-        },
-        "mongodb-build-info": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/mongodb-build-info/-/mongodb-build-info-1.1.1.tgz",
-          "integrity": "sha512-HC4ZG98ObbWGM3ikL3VfSvuug3iQVpA2kBob/MxK+mn2PNdVTvR5lShio+Ev1rDqODfq3ePcfO6prfi0agQp8g=="
-        }
       }
     },
     "@mongosh/service-provider-server": {
@@ -1645,13 +1603,6 @@
           "version": "7.5.2",
           "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.5.2.tgz",
           "integrity": "sha512-T+m89VdXj/eidZyejvmoP9jivXgBDdkOSBVQjU9kF349NEx10QdPNGxHeZUaj1IlJ32/ewdyXJjnJxyxJroYwg=="
-        },
-        "saslprep": {
-          "version": "github:mongodb-js/saslprep#9813a626d0685f54e4f2fac6160470d6e01d8c96",
-          "from": "github:mongodb-js/saslprep#v1.0.4",
-          "requires": {
-            "sparse-bitfield": "^3.0.3"
-          }
         }
       }
     },
@@ -1748,9 +1699,9 @@
       }
     },
     "@sinonjs/samsam": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.2.0.tgz",
-      "integrity": "sha512-CaIcyX5cDsjcW/ab7HposFWzV1kC++4HNsfnEdFJa7cP1QIuILAKV+BgfeqRXhcnSAc76r/Rh/O5C+300BwUIw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.3.0.tgz",
+      "integrity": "sha512-hXpcfx3aq+ETVBwPlRFICld5EnrkexXuXDwqUNhDdr5L8VjvMeSRwyOa0qL7XFmR+jVWR4rUZtnxlG7RX72sBg==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.6.0",
@@ -1774,42 +1725,6 @@
         "aria-query": "3.0.0",
         "pretty-format": "^24.8.0",
         "wait-for-expect": "^1.2.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "24.9.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
-          "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^1.1.1",
-            "@types/yargs": "^13.0.0"
-          }
-        },
-        "@types/yargs": {
-          "version": "13.0.11",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
-          "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
-          "requires": {
-            "@types/yargs-parser": "*"
-          }
-        },
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-        },
-        "pretty-format": {
-          "version": "24.9.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
-          "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
-          "requires": {
-            "@jest/types": "^24.9.0",
-            "ansi-regex": "^4.0.0",
-            "ansi-styles": "^3.2.0",
-            "react-is": "^16.8.4"
-          }
-        }
       }
     },
     "@testing-library/react": {
@@ -1822,9 +1737,9 @@
       }
     },
     "@types/babel__core": {
-      "version": "7.1.10",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.10.tgz",
-      "integrity": "sha512-x8OM8XzITIMyiwl5Vmo2B1cR1S1Ipkyv4mdlbJjMa1lmuKvKY9FrBbEANIaMlnWn5Rf7uO+rC/VgYabNkE17Hw==",
+      "version": "7.1.12",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.12.tgz",
+      "integrity": "sha512-wMTHiiTiBAAPebqaPiPDLFA4LYPKr6Ph0Xq/6rq1Ur3v66HXyG+clfR9CNETkD7MQS8ZHvpQOtA53DLws5WAEQ==",
       "requires": {
         "@babel/parser": "^7.1.0",
         "@babel/types": "^7.0.0",
@@ -1842,26 +1757,26 @@
       }
     },
     "@types/babel__template": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.3.tgz",
-      "integrity": "sha512-uCoznIPDmnickEi6D0v11SBpW0OuVqHJCa7syXqQHy5uktSCreIlt0iglsCnmvz8yCb38hGcWeseA8cWJSwv5Q==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.0.tgz",
+      "integrity": "sha512-NTPErx4/FiPCGScH7foPyr+/1Dkzkni+rHiYHHoTjvwou7AQzJkNeD60A9CXRy+ZEN2B1bggmkTMCDb+Mv5k+A==",
       "requires": {
         "@babel/parser": "^7.1.0",
         "@babel/types": "^7.0.0"
       }
     },
     "@types/babel__traverse": {
-      "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.15.tgz",
-      "integrity": "sha512-Pzh9O3sTK8V6I1olsXpCfj2k/ygO2q1X0vhhnDrEQyYLHZesWz+zMZMVcwXLCYf0U36EtmyYaFGPfXlTtDHe3A==",
+      "version": "7.0.16",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.16.tgz",
+      "integrity": "sha512-S63Dt4CZOkuTmpLGGWtT/mQdVORJOpx6SZWGVaP56dda/0Nx5nEe82K7/LAm8zYr6SfMq+1N2OreIOrHAx656w==",
       "requires": {
         "@babel/types": "^7.3.0"
       }
     },
     "@types/chai": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.13.tgz",
-      "integrity": "sha512-o3SGYRlOpvLFpwJA6Sl1UPOwKFEvE4FxTEB/c9XHI2whdnd4kmPVkNLL8gY4vWGBxWWDumzLbKsAhEH5SKn37Q=="
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.14.tgz",
+      "integrity": "sha512-G+ITQPXkwTrslfG5L/BksmbLUA0M1iybEsmCWPqzSxsRRhJZimBKJkoMi8fr/CPygPTj4zO5pJH7I2/cm9M7SQ=="
     },
     "@types/chai-fs": {
       "version": "2.0.2",
@@ -1892,9 +1807,9 @@
       }
     },
     "@types/classnames": {
-      "version": "2.2.10",
-      "resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.2.10.tgz",
-      "integrity": "sha512-1UzDldn9GfYYEsWWnn/P4wkTlkZDH7lDb0wBMGbtIQc9zXEQq7FlKBdZUn6OBqD8sKZZ2RQO2mAjGpXiDGoRmQ==",
+      "version": "2.2.11",
+      "resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.2.11.tgz",
+      "integrity": "sha512-2koNhpWm3DgWRp5tpkiJ8JGc1xTn2q0l+jUNUE7oMKXUf5NpI9AIdC4kbjGNFBdHtcxBD18LAksoudAVhFKCjw==",
       "dev": true
     },
     "@types/debug": {
@@ -1904,9 +1819,9 @@
       "dev": true
     },
     "@types/enzyme": {
-      "version": "3.10.7",
-      "resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-3.10.7.tgz",
-      "integrity": "sha512-J+0wduPGAkzOvW7sr6hshGv1gBI3WXLRTczkRKzVPxLP3xAkYxZmvvagSBPw8Z452fZ8TGUxCmAXcb44yLQksw==",
+      "version": "3.10.8",
+      "resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-3.10.8.tgz",
+      "integrity": "sha512-vlOuzqsTHxog6PV79+tvOHFb6hq4QZKMq1lLD9MaWD1oec2lHTKndn76XOpSwCA0oFTaIbKVPrgM3k78Jjd16g==",
       "dev": true,
       "requires": {
         "@types/cheerio": "*",
@@ -1930,9 +1845,9 @@
       }
     },
     "@types/graceful-fs": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.3.tgz",
-      "integrity": "sha512-AiHRaEB50LQg0pZmm659vNBb9f4SJ0qrAnteuzhSeAUcJKxoYgEnprg/83kppCnc2zvtCKbdZry1a5pVY3lOTQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.4.tgz",
+      "integrity": "sha512-mWA/4zFQhfvOA8zWkXobwJvBD7vzcxgrOQ0J5CH1votGqdq9m7+FwtGaqyCZqC3NyyBkc9z4m+iry4LlqcMWJg==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -1961,13 +1876,119 @@
       }
     },
     "@types/jest": {
-      "version": "26.0.14",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.14.tgz",
-      "integrity": "sha512-Hz5q8Vu0D288x3iWXePSn53W7hAjP0H7EQ6QvDO9c7t46mR0lNOLlfuwQ+JkVxuhygHzlzPX+0jKdA3ZgSh+Vg==",
+      "version": "26.0.16",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.16.tgz",
+      "integrity": "sha512-Gp12+7tmKCgv9JjtltxUXokohCAEZfpJaEW5tn871SGRp8I+bRWBonQO7vW5NHwnAHe5dd50+Q4zyKuN35i09g==",
       "dev": true,
       "requires": {
-        "jest-diff": "^25.2.1",
-        "pretty-format": "^25.2.1"
+        "jest-diff": "^26.0.0",
+        "pretty-format": "^26.0.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/istanbul-reports": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.11",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
+          "integrity": "sha512-jfcNBxHFYJ4nPIacsi3woz1+kvUO6s1CyeEhtnDHBjHUMNj5UlW2GynmnSgiJJEdNg9yW5C8lfoNRZrHGv5EqA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+          "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.6.2",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^17.0.1"
+          }
+        },
+        "react-is": {
+          "version": "17.0.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+          "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "@types/json-schema": {
@@ -1992,21 +2013,21 @@
       "dev": true
     },
     "@types/minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.1.tgz",
+      "integrity": "sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==",
       "dev": true
     },
     "@types/mocha": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.0.3.tgz",
-      "integrity": "sha512-vyxR57nv8NfcU0GZu8EUXZLTbCMupIUwy95LJ6lllN+JRPG25CwMHoB1q5xKh8YKhQnHYRAn4yW2yuHbf/5xgg==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.0.4.tgz",
+      "integrity": "sha512-M4BwiTJjHmLq6kjON7ZoI2JMlBvpY3BYSdiP6s/qCT3jb1s9/DeJF0JELpAxiVSIxXDzfNKe+r7yedMIoLbknQ==",
       "dev": true
     },
     "@types/node": {
-      "version": "14.11.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.8.tgz",
-      "integrity": "sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw==",
+      "version": "14.14.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.10.tgz",
+      "integrity": "sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -2021,9 +2042,9 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
     "@types/prettier": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.1.tgz",
-      "integrity": "sha512-2zs+O+UkDsJ1Vcp667pd3f8xearMdopz/z54i99wtRDI5KLmngk7vlrYZD0ZjKHaROR03EznlBbVY9PfAEyJIQ==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.5.tgz",
+      "integrity": "sha512-UEyp8LwZ4Dg30kVU2Q3amHHyTn1jEdhCIE59ANed76GaT1Vp76DD3ZWSAxgCrw6wJ0TqeoBpqmfUHiUDPs//HQ==",
       "dev": true
     },
     "@types/prop-types": {
@@ -2033,9 +2054,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "16.9.51",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.51.tgz",
-      "integrity": "sha512-lQa12IyO+DMlnSZ3+AGHRUiUcpK47aakMMoBG8f7HGxJT8Yfe+WE128HIXaHOHVPReAW0oDS3KAI0JI2DDe1PQ==",
+      "version": "16.14.2",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.2.tgz",
+      "integrity": "sha512-BzzcAlyDxXl2nANlabtT4thtvbbnhee8hMmH/CcJrISDBVcJS1iOsP1f0OAgSdGE0MsY9tqcrb9YoZcOFv9dbQ==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -2043,20 +2064,20 @@
       },
       "dependencies": {
         "csstype": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.3.tgz",
-          "integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag==",
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz",
+          "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ==",
           "dev": true
         }
       }
     },
     "@types/react-dom": {
-      "version": "16.9.8",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.8.tgz",
-      "integrity": "sha512-ykkPQ+5nFknnlU6lDd947WbQ6TE3NNzbQAkInC2EKY1qeYdTKp7onFusmYZb+ityzx2YviqT6BXSu+LyWWJwcA==",
+      "version": "16.9.10",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.10.tgz",
+      "integrity": "sha512-ItatOrnXDMAYpv6G8UCk2VhbYVTjZT9aorLtA/OzDN9XJ2GKcfam68jutoAcILdRjsRUO8qb7AmyObF77Q8QFw==",
       "dev": true,
       "requires": {
-        "@types/react": "*"
+        "@types/react": "^16"
       }
     },
     "@types/redux": {
@@ -2069,9 +2090,9 @@
       }
     },
     "@types/sinon": {
-      "version": "9.0.8",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-9.0.8.tgz",
-      "integrity": "sha512-IVnI820FZFMGI+u1R+2VdRaD/82YIQTdqLYC9DLPszZuynAJDtCvCtCs3bmyL66s7FqRM3+LPX7DhHnVTaagDw==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-9.0.9.tgz",
+      "integrity": "sha512-z/y8maYOQyYLyqaOB+dYQ6i0pxKLOsfwCmHmn4T7jS/SDHicIslr37oE3Dg8SCqKrKeBy6Lemu7do2yy+unLrw==",
       "requires": {
         "@types/sinonjs__fake-timers": "*"
       }
@@ -2103,25 +2124,24 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.49.0.tgz",
-      "integrity": "sha512-wfNQmLmm1VdMBr6iuNdprWmC1YdrgZ9dQzadv+l2eSjJlElOdJw8OTm4RU4oGTBcfvG6RZI2jOcppkdSS18mZw==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.51.0.tgz",
+      "integrity": "sha512-C/jZ35OT5k/rsJyAK8mS1kM++vMcm89oSWegkzxRCvHllIq0cToZAkIDs6eCY4SKrvik3nrhELizyLcM0onbQA==",
       "dev": true
     },
     "@types/ws": {
-      "version": "7.2.7",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.2.7.tgz",
-      "integrity": "sha512-UUFC/xxqFLP17hTva8/lVT0SybLUrfSD9c+iapKb0fEiC8uoDbA+xuZ3pAN603eW+bY8ebSMLm9jXdIPnD0ZgA==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.0.tgz",
+      "integrity": "sha512-Y29uQ3Uy+58bZrFLhX36hcI3Np37nqWE7ky5tjiDoy1GDZnIwVxS0CgF+s+1bXMzjKBFy+fqaRfb708iNzdinw==",
       "dev": true,
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/yargs": {
-      "version": "15.0.8",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
-      "integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
-      "dev": true,
+      "version": "13.0.11",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
+      "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
       "requires": {
         "@types/yargs-parser": "*"
       }
@@ -2181,6 +2201,12 @@
         "semver": "^7.3.2",
         "tsutils": "^3.17.1"
       }
+    },
+    "@ungap/promise-all-settled": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+      "dev": true
     },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
@@ -2491,9 +2517,9 @@
       }
     },
     "ajv": {
-      "version": "6.12.5",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
-      "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2638,12 +2664,12 @@
       }
     },
     "analytics-node": {
-      "version": "3.4.0-beta.2",
-      "resolved": "https://registry.npmjs.org/analytics-node/-/analytics-node-3.4.0-beta.2.tgz",
-      "integrity": "sha512-wjdCQQk412RBckuqGtyY7tdxaRpG7HLD0iBQrJBc7aUzHFNYyEbz3kepaUmNd5+ZbAGDqfnvKVsFO5DmzI1KNA==",
+      "version": "3.4.0-beta.3",
+      "resolved": "https://registry.npmjs.org/analytics-node/-/analytics-node-3.4.0-beta.3.tgz",
+      "integrity": "sha512-NIdpxiwlZ4cKgs9MDlDe89b5bg/pMq2W7XTA+cjzCM66IwW3ujZhVE49vk+zG6Yrxk0s/DXmennJ+cCQIsTKMA==",
       "requires": {
         "@segment/loosely-validate-event": "^2.0.0",
-        "axios": "^0.19.0",
+        "axios": "^0.19.2",
         "axios-retry": "^3.0.2",
         "lodash.isstring": "^4.0.1",
         "md5": "^2.2.1",
@@ -2696,9 +2722,9 @@
       }
     },
     "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -2834,13 +2860,15 @@
       "dev": true
     },
     "array-includes": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.1.tgz",
-      "integrity": "sha512-c2VXaCHl7zPsvpkFsw4nxvFie4fh1ur9bpcgsVkIjqn0H/Xwdg+7fv3n2r/isyS8EBj5b06M9kHyZuIr4El6WQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.2.tgz",
+      "integrity": "sha512-w2GspexNQpx+PutG3QpT437/BenZBj0M/MZGn5mzv/MofYqo0xmRHzn4lFsoDlWJ+THYsGJmFlW68WlDFx7VRw==",
       "dev": true,
       "requires": {
+        "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0",
+        "es-abstract": "^1.18.0-next.1",
+        "get-intrinsic": "^1.0.1",
         "is-string": "^1.0.5"
       }
     },
@@ -2869,39 +2897,56 @@
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.4"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.1",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        },
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+          "dev": true
+        }
       }
     },
     "array.prototype.flat": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz",
-      "integrity": "sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.4.tgz",
+      "integrity": "sha512-4470Xi3GAPAjZqFcljX2xzckv1qeKPizoNkiS0+O4IoPR2ZNpcjE0pkhdihlDouK+x6QOast26B4Q/O9DJnwSg==",
       "dev": true,
       "requires": {
+        "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1"
+        "es-abstract": "^1.18.0-next.1"
       }
     },
     "array.prototype.flatmap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.3.tgz",
-      "integrity": "sha512-OOEk+lkePcg+ODXIpvuU9PAryCikCJyo7GlDG1upleEpQRx6mzL9puEBkozQ5iAx20KV0l3DbyQwqciJtqe5Pg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.4.tgz",
+      "integrity": "sha512-r9Z0zYoxqHz60vvQbWEdXIEtCwHF0yxaWfno9qzXeNHvfyl3BZqygmGzb84dsubyaXLH4husF+NFgMSdpZhk2Q==",
       "dev": true,
       "requires": {
+        "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1",
+        "es-abstract": "^1.18.0-next.1",
         "function-bind": "^1.1.1"
-      }
-    },
-    "array.prototype.map": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.map/-/array.prototype.map-1.0.2.tgz",
-      "integrity": "sha512-Az3OYxgsa1g7xDYp86l0nnN4bcmuEITGe1rbdEBVkrqkzMgDcbdQ2R7r41pNzti+4NMces3H8gMmuioZUilLgw==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1",
-        "es-array-method-boxes-properly": "^1.0.0",
-        "is-string": "^1.0.4"
       }
     },
     "arrify": {
@@ -2983,9 +3028,9 @@
       "dev": true
     },
     "ast-module-types": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-2.6.0.tgz",
-      "integrity": "sha512-zXSoVaMrf2R+r+ISid5/9a8SXm1LLdkhHzh6pSRhj9jklzruOOl1hva1YmFT33wAstg/f9ZndJAlq1BSrFLSGA==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-2.7.1.tgz",
+      "integrity": "sha512-Rnnx/4Dus6fn7fTqdeLEAn5vUll5w7/vts0RN608yFa6si/rDOUonlIIiwugHBFWjylHjxm9owoSZn71KwG4gw==",
       "dev": true
     },
     "ast-types-flow": {
@@ -3057,9 +3102,9 @@
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
-      "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA=="
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "axios": {
       "version": "0.19.2",
@@ -3104,25 +3149,25 @@
       }
     },
     "babel-jest": {
-      "version": "26.5.2",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.5.2.tgz",
-      "integrity": "sha512-U3KvymF3SczA3vOL/cgiUFOznfMET+XDIXiWnoJV45siAp2pLMG8i2+/MGZlAC3f/F6Q40LR4M4qDrWZ9wkK8A==",
+      "version": "26.6.3",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.6.3.tgz",
+      "integrity": "sha512-pl4Q+GAVOHwvjrck6jKjvmGhnO3jHX/xuB9d27f+EJZ/6k+6nMuPjorrYp7s++bKKdANwzElBWnLWaObvTnaZA==",
       "dev": true,
       "requires": {
-        "@jest/transform": "^26.5.2",
-        "@jest/types": "^26.5.2",
+        "@jest/transform": "^26.6.2",
+        "@jest/types": "^26.6.2",
         "@types/babel__core": "^7.1.7",
         "babel-plugin-istanbul": "^6.0.0",
-        "babel-preset-jest": "^26.5.0",
+        "babel-preset-jest": "^26.6.2",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "slash": "^3.0.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -3139,6 +3184,15 @@
           "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.11",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
+          "integrity": "sha512-jfcNBxHFYJ4nPIacsi3woz1+kvUO6s1CyeEhtnDHBjHUMNj5UlW2GynmnSgiJJEdNg9yW5C8lfoNRZrHGv5EqA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
           }
         },
         "ansi-styles": {
@@ -3223,9 +3277,9 @@
       }
     },
     "babel-plugin-jest-hoist": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.5.0.tgz",
-      "integrity": "sha512-ck17uZFD3CDfuwCLATWZxkkuGGFhMij8quP8CNhwj8ek1mqFgbFzRJ30xwC04LLscj/aKsVFfRST+b5PT7rSuw==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.6.2.tgz",
+      "integrity": "sha512-PO9t0697lNTmcEHH69mdtYiOIkkOlj9fySqfO3K1eCcdISevLAE0xY59VLLUj0SoiPiTX/JU2CYFpILydUa5Lw==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.3.3",
@@ -3250,9 +3304,9 @@
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-preset-current-node-syntax": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.4.tgz",
-      "integrity": "sha512-5/INNCYhUGqw7VbVjT/hb3ucjgkVHKXY7lX3ZjlN4gm565VyFmJUrJ/h+h16ECVB38R/9SF6aACydpKMLZ/c9w==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.0.tgz",
+      "integrity": "sha512-mGkvkpocWJes1CmMKtgGUwCeeq0pOhALyymozzDWYomHTbDLwueDYG6p4TK1YOeYHCzBzYPsWkgTto10JubI1Q==",
       "dev": true,
       "requires": {
         "@babel/plugin-syntax-async-generators": "^7.8.4",
@@ -3265,17 +3319,18 @@
         "@babel/plugin-syntax-numeric-separator": "^7.8.3",
         "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
         "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.3"
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-top-level-await": "^7.8.3"
       }
     },
     "babel-preset-jest": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.5.0.tgz",
-      "integrity": "sha512-F2vTluljhqkiGSJGBg/jOruA8vIIIL11YrxRcO7nviNTMbbofPSHwnm8mgP7d/wS7wRSexRoI6X1A6T74d4LQA==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.6.2.tgz",
+      "integrity": "sha512-YvdtlVm9t3k777c5NPQIv6cxFFFapys25HiUmuSgHwIZhfifweR5c5Sf5nwE3MAbfu327CYSvps8Yx6ANLyleQ==",
       "dev": true,
       "requires": {
-        "babel-plugin-jest-hoist": "^26.5.0",
-        "babel-preset-current-node-syntax": "^0.1.3"
+        "babel-plugin-jest-hoist": "^26.6.2",
+        "babel-preset-current-node-syntax": "^1.0.0"
       }
     },
     "balanced-match": {
@@ -3339,9 +3394,9 @@
       }
     },
     "base64-js": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -3519,21 +3574,13 @@
       }
     },
     "browserify-rsa": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
-      "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.0.tgz",
+      "integrity": "sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.0",
+        "bn.js": "^5.0.0",
         "randombytes": "^2.0.1"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.9",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
-          "dev": true
-        }
       }
     },
     "browserify-sign": {
@@ -3591,15 +3638,16 @@
       }
     },
     "browserslist": {
-      "version": "4.14.5",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.5.tgz",
-      "integrity": "sha512-Z+vsCZIvCBvqLoYkBFTwEYH3v5MCQbsAjp50ERycpOjnPmolg1Gjy4+KaWWpm8QOJt9GHkhdqAl14NpCX73CWA==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.15.0.tgz",
+      "integrity": "sha512-IJ1iysdMkGmjjYeRlDU8PQejVwxvVO5QOfXH7ylW31GO6LwNRSmm/SgRXtNsEXqMLl2e+2H5eEJ7sfynF8TCaQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001135",
-        "electron-to-chromium": "^1.3.571",
-        "escalade": "^3.1.0",
-        "node-releases": "^1.1.61"
+        "caniuse-lite": "^1.0.30001164",
+        "colorette": "^1.2.1",
+        "electron-to-chromium": "^1.3.612",
+        "escalade": "^3.1.1",
+        "node-releases": "^1.1.67"
       }
     },
     "bs-logger": {
@@ -3621,20 +3669,20 @@
       }
     },
     "bson": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.2.0.tgz",
-      "integrity": "sha512-c3MlJqdROnCRvDr/+MLfaDvQ7CvGI4p1hKX45/fvgzSwKRdOjsfRug1NJJ8ty5mXCNtUdjJEWzoZWcBQxV4TyA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.2.2.tgz",
+      "integrity": "sha512-9fX257PVHAUpiRGmY3356RVWKQxLA73BgjA/x5MGuJkTEMeG7yzjuBrsiFB67EXRJnFVKrbJY9t/M+oElKYktQ==",
       "requires": {
         "buffer": "^5.6.0"
       }
     },
     "buffer": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4"
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "buffer-alloc": {
@@ -3705,6 +3753,15 @@
         "y18n": "^4.0.0"
       },
       "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
         "mkdirp": {
           "version": "0.5.5",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
@@ -3724,9 +3781,15 @@
           }
         },
         "y18n": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+          "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
           "dev": true
         }
       }
@@ -3746,6 +3809,16 @@
         "to-object-path": "^0.3.0",
         "union-value": "^1.0.0",
         "unset-value": "^1.0.0"
+      }
+    },
+    "call-bind": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
+      "integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.0"
       }
     },
     "call-me-maybe": {
@@ -3810,9 +3883,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001146",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001146.tgz",
-      "integrity": "sha512-VAy5RHDfTJhpxnDdp2n40GPPLp3KqNrXz1QqFv4J64HvArKs8nuNMOWkB3ICOaBTU/Aj4rYAo/ytdQDDFF/Pug==",
+      "version": "1.0.30001164",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001164.tgz",
+      "integrity": "sha512-G+A/tkf4bu0dSp9+duNiXc7bGds35DioCyC6vgK2m/rjA4Krpy5WeZgZyfH2f0wj2kI6yAWWucyap6oOwmY1mg==",
       "dev": true
     },
     "capture-exit": {
@@ -3932,9 +4005,9 @@
       }
     },
     "chokidar": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
-      "integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
+      "integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
       "dev": true,
       "requires": {
         "anymatch": "~3.1.1",
@@ -3944,7 +4017,16 @@
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.4.0"
+        "readdirp": "~3.5.0"
+      },
+      "dependencies": {
+        "fsevents": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+          "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "chownr": {
@@ -3976,6 +4058,12 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "cjs-module-lexer": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-0.6.0.tgz",
+      "integrity": "sha512-uc2Vix1frTfnuzxxu1Hp4ktSvM3QaI4oXl4ZUqL1wjTu/BGki9TrCWoqLTg/drR1KwAEarXuRFCG2Svr1GxPFw==",
+      "dev": true
     },
     "class-utils": {
       "version": "0.3.6",
@@ -4027,9 +4115,9 @@
       }
     },
     "cli-spinners": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.4.0.tgz",
-      "integrity": "sha512-sJAofoarcm76ZGpuooaO0eDy8saEy+YoZBLjC4h8srt4jeBnkYeOgqxgsJQTpyt2LjI5PTfLJHSL+41Yu4fEJA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.5.0.tgz",
+      "integrity": "sha512-PC+AmIuK04E6aeSs/pUccSujsTzBhu4HzC2dL+CfJB/Jcc2qTRbEwZQDfIUpt2Xl8BodYBEq8w4fc0kU2I9DjQ==",
       "dev": true
     },
     "cli-table": {
@@ -4384,9 +4472,9 @@
       }
     },
     "cross-env": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.2.tgz",
-      "integrity": "sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
       "dev": true,
       "requires": {
         "cross-spawn": "^7.0.1"
@@ -4518,9 +4606,9 @@
       }
     },
     "csstype": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.13.tgz",
-      "integrity": "sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A=="
+      "version": "2.6.14",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.14.tgz",
+      "integrity": "sha512-2mSc+VEpGPblzAxyeR+vZhJKgYg0Og0nnRi7pmRXFYYxSfnOnW8A5wwQb4n4cE2nIOzqKOAzLCaEX6aBmNEv8A=="
     },
     "cyclist": {
       "version": "1.0.1",
@@ -4562,9 +4650,9 @@
       "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
     },
     "debug": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
       "requires": {
         "ms": "2.1.2"
       }
@@ -4967,12 +5055,12 @@
       }
     },
     "detective-amd": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/detective-amd/-/detective-amd-3.0.0.tgz",
-      "integrity": "sha512-kOpKHyabdSKF9kj7PqYHLeHPw+TJT8q2u48tZYMkIcas28el1CYeLEJ42Nm+563/Fq060T5WknfwDhdX9+kkBQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/detective-amd/-/detective-amd-3.0.1.tgz",
+      "integrity": "sha512-vJgluSKkPyo+/McW9hzwmZwY1VPA3BS0VS1agdpPAWAhr65HwC1ox4Ig82rVfGYDYCa4GcKQON5JWBk++2Kf1Q==",
       "dev": true,
       "requires": {
-        "ast-module-types": "^2.3.1",
+        "ast-module-types": "^2.7.0",
         "escodegen": "^1.8.0",
         "get-amd-module-type": "^3.0.0",
         "node-source-walk": "^4.0.0"
@@ -5074,9 +5162,9 @@
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
     },
     "diff-sequences": {
-      "version": "25.2.6",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
-      "integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz",
+      "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==",
       "dev": true
     },
     "diffie-hellman": {
@@ -5399,9 +5487,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.578",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.578.tgz",
-      "integrity": "sha512-z4gU6dA1CbBJsAErW5swTGAaU2TBzc2mPAonJb00zqW1rOraDo2zfBMDRvaz9cVic+0JEZiYbHWPw/fTaZlG2Q==",
+      "version": "1.3.614",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.614.tgz",
+      "integrity": "sha512-JMDl46mg4G+n6q/hAJkwy9eMTj5FJjsE+8f/irAGRMLM4yeRVbMuRrdZrbbGGOrGVcZc4vJPjUpEUWNb/fA6hg==",
       "dev": true
     },
     "elliptic": {
@@ -5428,9 +5516,9 @@
       }
     },
     "emittery": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.1.tgz",
-      "integrity": "sha512-d34LN4L6h18Bzz9xpoku2nPwKxCPlPMr3EEKTkoEBi+1/+b0lcRkRJ1UVyyZaKNeqGR3swcGl6s390DNO4YVgQ==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.2.tgz",
+      "integrity": "sha512-A8OG5SR/ij3SsJdWDJdkkSYUjQdCUx6APQXem0SaEePBSRg4eymGYwBkKo1Y6DU+af/Jn2dBQqDBvjnr9Vi8nQ==",
       "dev": true
     },
     "emoji-regex": {
@@ -5660,9 +5748,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.17.7",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
-      "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+      "version": "1.18.0-next.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+      "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
@@ -5670,6 +5758,7 @@
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
         "is-callable": "^1.2.2",
+        "is-negative-zero": "^2.0.0",
         "is-regex": "^1.1.1",
         "object-inspect": "^1.8.0",
         "object-keys": "^1.1.1",
@@ -5682,35 +5771,6 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
           "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-          "dev": true
-        }
-      }
-    },
-    "es-array-method-boxes-properly": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
-      "dev": true
-    },
-    "es-get-iterator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.0.tgz",
-      "integrity": "sha512-UfrmHuWQlNMTs35e1ypnvikg6jCz3SK8v8ImvmDsh36fCVUR1MqoFDiyn0/k52C8NqO3YsO8Oe0azeesNuqSsQ==",
-      "dev": true,
-      "requires": {
-        "es-abstract": "^1.17.4",
-        "has-symbols": "^1.0.1",
-        "is-arguments": "^1.0.4",
-        "is-map": "^2.0.1",
-        "is-set": "^2.0.1",
-        "is-string": "^1.0.5",
-        "isarray": "^2.0.5"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
           "dev": true
         }
       }
@@ -5833,9 +5893,9 @@
       }
     },
     "escalade": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.0.tgz",
-      "integrity": "sha512-mAk+hPSO8fLDkhV7V0dXazH5pDc6MrjBTPyD3VeKzxnVFjH1MIxbCdqGZB9O8+EwWakZs3ZCbDS4IpRt79V1ig==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
       "dev": true
     },
     "escape-string-regexp": {
@@ -5910,12 +5970,6 @@
         "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
         "cross-spawn": {
           "version": "6.0.5",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -6330,21 +6384,21 @@
       "dev": true
     },
     "eslint-plugin-react": {
-      "version": "7.21.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.21.3.tgz",
-      "integrity": "sha512-OI4GwTCqyIb4ipaOEGLWdaOHCXZZydStAsBEPB2e1ZfNM37bojpgO1BoOQbFb0eLVz3QLDx7b+6kYcrxCuJfhw==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.21.5.tgz",
+      "integrity": "sha512-8MaEggC2et0wSF6bUeywF7qQ46ER81irOdWS4QWxnnlAEsnzeBevk1sWh7fhpCghPpXb+8Ks7hvaft6L/xsR6g==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.1",
         "array.prototype.flatmap": "^1.2.3",
         "doctrine": "^2.1.0",
         "has": "^1.0.3",
-        "jsx-ast-utils": "^2.4.1",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "object.entries": "^1.1.2",
         "object.fromentries": "^2.0.2",
         "object.values": "^1.1.1",
         "prop-types": "^15.7.2",
-        "resolve": "^1.17.0",
+        "resolve": "^1.18.1",
         "string.prototype.matchall": "^4.0.2"
       },
       "dependencies": {
@@ -6641,23 +6695,23 @@
       }
     },
     "expect": {
-      "version": "26.5.2",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-26.5.2.tgz",
-      "integrity": "sha512-ccTGrXZd8DZCcvCz4htGXTkd/LOoy6OEtiDS38x3/VVf6E4AQL0QoeksBiw7BtGR5xDNiRYPB8GN6pfbuTOi7w==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-26.6.2.tgz",
+      "integrity": "sha512-9/hlOBkQl2l/PLHJx6JjoDF6xPKcJEsUlWKb23rKE7KzeDqUZKXKNMW27KIue5JMdBV9HgmoJPcc8HtO85t9IA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.5.2",
+        "@jest/types": "^26.6.2",
         "ansi-styles": "^4.0.0",
         "jest-get-type": "^26.3.0",
-        "jest-matcher-utils": "^26.5.2",
-        "jest-message-util": "^26.5.2",
+        "jest-matcher-utils": "^26.6.2",
+        "jest-message-util": "^26.6.2",
         "jest-regex-util": "^26.0.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -6674,6 +6728,15 @@
           "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.11",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
+          "integrity": "sha512-jfcNBxHFYJ4nPIacsi3woz1+kvUO6s1CyeEhtnDHBjHUMNj5UlW2GynmnSgiJJEdNg9yW5C8lfoNRZrHGv5EqA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
           }
         },
         "ansi-styles": {
@@ -6714,12 +6777,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "jest-get-type": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-          "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
           "dev": true
         },
         "supports-color": {
@@ -6943,9 +7000,9 @@
       "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
     },
     "fastq": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
-      "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.9.0.tgz",
+      "integrity": "sha512-i7FVWL8HhVY+CTkwFxkN2mk3h+787ixS5S63eb78diVRc1MCssarHq3W5cj0av7YDSwmaV928RNag+U1etRQ7w==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -7249,21 +7306,10 @@
       }
     },
     "flat": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
-      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
-      "dev": true,
-      "requires": {
-        "is-buffer": "~2.0.3"
-      },
-      "dependencies": {
-        "is-buffer": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
-          "dev": true
-        }
-      }
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true
     },
     "flat-cache": {
       "version": "2.0.1",
@@ -7485,27 +7531,27 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.2.1.tgz",
+      "integrity": "sha512-bTLYHSeC0UH/EFXS9KqWnXuOl/wHK5Z/d+ghd5AsFMYN7wIGkUCOJyzy88+wJKkZPGON8u4Z9f6U4FdgURE9qA==",
       "dev": true,
       "optional": true
     },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "function.prototype.name": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.2.tgz",
-      "integrity": "sha512-C8A+LlHBJjB2AdcRPorc5JvJ5VUoWlXdEHLOJdCI7kjHEtGTpHQUiqMvCIKUwIsGwZX2jZJy761AXsn356bJQg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.3.tgz",
+      "integrity": "sha512-H51qkbNSp8mtkJt+nyW1gyStBiKZxfRqySNUR99ylq6BPXHKI4SEvIlTKp4odLfjRKJV04DFWMU3G/YRlQOsag==",
       "dev": true,
       "requires": {
+        "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1",
-        "functions-have-names": "^1.2.0"
+        "es-abstract": "^1.18.0-next.1",
+        "functions-have-names": "^1.2.1"
       }
     },
     "functional-red-black-tree": {
@@ -7547,9 +7593,9 @@
       }
     },
     "gensync": {
-      "version": "1.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
-      "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg=="
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
     },
     "get-amd-module-type": {
       "version": "3.0.0",
@@ -7571,6 +7617,17 @@
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
+    },
+    "get-intrinsic": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.1.tgz",
+      "integrity": "sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
     },
     "get-mongodb-version": {
       "version": "2.0.1",
@@ -7667,12 +7724,12 @@
       "dev": true
     },
     "global": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
-      "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
       "requires": {
         "min-document": "^2.19.0",
-        "process": "~0.5.1"
+        "process": "^0.11.10"
       }
     },
     "global-modules": {
@@ -7867,7 +7924,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -8185,9 +8241,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
@@ -8219,9 +8275,9 @@
       }
     },
     "ieee754": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "iferr": {
       "version": "0.1.5",
@@ -8257,9 +8313,9 @@
       }
     },
     "import-fresh": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
-      "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.2.tgz",
+      "integrity": "sha512-cTPNrlvJT6twpYy+YmKUKrTSjWFs3bjYjAhCwm+z4EOCubZxAuO+hHpRN64TqjEaYSHs7tJAE0w1CKMGmsG/lw==",
       "requires": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -8447,6 +8503,33 @@
         "es-abstract": "^1.17.0-next.1",
         "has": "^1.0.3",
         "side-channel": "^1.0.2"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.1",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        },
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+          "dev": true
+        }
       }
     },
     "interpret": {
@@ -8499,12 +8582,6 @@
         }
       }
     },
-    "is-arguments": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
-      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
-      "dev": true
-    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -8543,6 +8620,14 @@
       "dev": true,
       "requires": {
         "ci-info": "^2.0.0"
+      }
+    },
+    "is-core-module": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "requires": {
+        "has": "^1.0.3"
       }
     },
     "is-data-descriptor": {
@@ -8654,12 +8739,6 @@
       "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
       "dev": true
     },
-    "is-map": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.1.tgz",
-      "integrity": "sha512-T/S49scO8plUiAOA2DBTBG3JHpn1yiw0kRp6dgiZ0v2/6twi5eiB0rHtHFH9ZIrvlWc6+4O+m4zg5+Z833aXgw==",
-      "dev": true
-    },
     "is-mongodb-running": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-mongodb-running/-/is-mongodb-running-1.0.2.tgz",
@@ -8711,9 +8790,9 @@
       "dev": true
     },
     "is-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
+      "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==",
       "dev": true
     },
     "is-plain-obj": {
@@ -8776,12 +8855,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
       "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
-    },
-    "is-set": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.1.tgz",
-      "integrity": "sha512-eJEzOtVyenDs1TMzSQ3kU3K+E0GUS9sno+F0OBT97xsgcJsF9nXMBtkT9/kut5JEpM7oL7X/0qxR17K3mcwIAA==",
-      "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
@@ -8972,37 +9045,21 @@
         "is-object": "^1.0.1"
       }
     },
-    "iterate-iterator": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/iterate-iterator/-/iterate-iterator-1.0.1.tgz",
-      "integrity": "sha512-3Q6tudGN05kbkDQDI4CqjaBf4qf85w6W6GnuZDtUVYwKgtC1q8yxYX7CZed7N+tLzQqS6roujWvszf13T+n9aw==",
-      "dev": true
-    },
-    "iterate-value": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/iterate-value/-/iterate-value-1.0.2.tgz",
-      "integrity": "sha512-A6fMAio4D2ot2r/TYzr4yUWrmwNdsN5xL7+HUiyACE4DXm+q8HtPcnFTp+NnW3k4N05tZ7FVYFFb2CR13NxyHQ==",
-      "dev": true,
-      "requires": {
-        "es-get-iterator": "^1.0.2",
-        "iterate-iterator": "^1.0.1"
-      }
-    },
     "jest": {
-      "version": "26.5.2",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-26.5.2.tgz",
-      "integrity": "sha512-4HFabJVwsgDwul/7rhXJ3yFAF/aUkVIXiJWmgFxb+WMdZG39fVvOwYAs8/3r4AlFPc4m/n5sTMtuMbOL3kNtrQ==",
+      "version": "26.6.3",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-26.6.3.tgz",
+      "integrity": "sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==",
       "dev": true,
       "requires": {
-        "@jest/core": "^26.5.2",
+        "@jest/core": "^26.6.3",
         "import-local": "^3.0.2",
-        "jest-cli": "^26.5.2"
+        "jest-cli": "^26.6.3"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -9019,6 +9076,15 @@
           "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.11",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
+          "integrity": "sha512-jfcNBxHFYJ4nPIacsi3woz1+kvUO6s1CyeEhtnDHBjHUMNj5UlW2GynmnSgiJJEdNg9yW5C8lfoNRZrHGv5EqA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
           }
         },
         "ansi-regex": {
@@ -9101,22 +9167,22 @@
           "dev": true
         },
         "jest-cli": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.5.2.tgz",
-          "integrity": "sha512-usm48COuUvRp8YEG5OWOaxbSM0my7eHn3QeBWxiGUuFhvkGVBvl1fic4UjC02EAEQtDv8KrNQUXdQTV6ZZBsoA==",
+          "version": "26.6.3",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.6.3.tgz",
+          "integrity": "sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==",
           "dev": true,
           "requires": {
-            "@jest/core": "^26.5.2",
-            "@jest/test-result": "^26.5.2",
-            "@jest/types": "^26.5.2",
+            "@jest/core": "^26.6.3",
+            "@jest/test-result": "^26.6.2",
+            "@jest/types": "^26.6.2",
             "chalk": "^4.0.0",
             "exit": "^0.1.2",
             "graceful-fs": "^4.2.4",
             "import-local": "^3.0.2",
             "is-ci": "^2.0.0",
-            "jest-config": "^26.5.2",
-            "jest-util": "^26.5.2",
-            "jest-validate": "^26.5.2",
+            "jest-config": "^26.6.3",
+            "jest-util": "^26.6.2",
+            "jest-validate": "^26.6.2",
             "prompts": "^2.0.1",
             "yargs": "^15.4.1"
           }
@@ -9180,9 +9246,9 @@
           }
         },
         "y18n": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+          "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
           "dev": true
         },
         "yargs": {
@@ -9217,20 +9283,20 @@
       }
     },
     "jest-changed-files": {
-      "version": "26.5.2",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.5.2.tgz",
-      "integrity": "sha512-qSmssmiIdvM5BWVtyK/nqVpN3spR5YyvkvPqz1x3BR1bwIxsWmU/MGwLoCrPNLbkG2ASAKfvmJpOduEApBPh2w==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.6.2.tgz",
+      "integrity": "sha512-fDS7szLcY9sCtIip8Fjry9oGf3I2ht/QT21bAHm5Dmf0mD4X3ReNUf17y+bO6fR8WgbIZTlbyG1ak/53cbRzKQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.5.2",
+        "@jest/types": "^26.6.2",
         "execa": "^4.0.0",
         "throat": "^5.0.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -9247,6 +9313,15 @@
           "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.11",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
+          "integrity": "sha512-jfcNBxHFYJ4nPIacsi3woz1+kvUO6s1CyeEhtnDHBjHUMNj5UlW2GynmnSgiJJEdNg9yW5C8lfoNRZrHGv5EqA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
           }
         },
         "ansi-styles": {
@@ -9284,9 +9359,9 @@
           "dev": true
         },
         "execa": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
-          "integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+          "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
           "dev": true,
           "requires": {
             "cross-spawn": "^7.0.0",
@@ -9342,35 +9417,35 @@
       }
     },
     "jest-config": {
-      "version": "26.5.2",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.5.2.tgz",
-      "integrity": "sha512-dqJOnSegNdE5yDiuGHsjTM5gec7Z4AcAMHiW+YscbOYJAlb3LEtDSobXCq0or9EmGQI5SFmKy4T7P1FxetJOfg==",
+      "version": "26.6.3",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.6.3.tgz",
+      "integrity": "sha512-t5qdIj/bCj2j7NFVHb2nFB4aUdfucDn3JRKgrZnplb8nieAirAzRSHP8uDEd+qV6ygzg9Pz4YG7UTJf94LPSyg==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/test-sequencer": "^26.5.2",
-        "@jest/types": "^26.5.2",
-        "babel-jest": "^26.5.2",
+        "@jest/test-sequencer": "^26.6.3",
+        "@jest/types": "^26.6.2",
+        "babel-jest": "^26.6.3",
         "chalk": "^4.0.0",
         "deepmerge": "^4.2.2",
         "glob": "^7.1.1",
         "graceful-fs": "^4.2.4",
-        "jest-environment-jsdom": "^26.5.2",
-        "jest-environment-node": "^26.5.2",
+        "jest-environment-jsdom": "^26.6.2",
+        "jest-environment-node": "^26.6.2",
         "jest-get-type": "^26.3.0",
-        "jest-jasmine2": "^26.5.2",
+        "jest-jasmine2": "^26.6.3",
         "jest-regex-util": "^26.0.0",
-        "jest-resolve": "^26.5.2",
-        "jest-util": "^26.5.2",
-        "jest-validate": "^26.5.2",
+        "jest-resolve": "^26.6.2",
+        "jest-util": "^26.6.2",
+        "jest-validate": "^26.6.2",
         "micromatch": "^4.0.2",
-        "pretty-format": "^26.5.2"
+        "pretty-format": "^26.6.2"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -9387,6 +9462,15 @@
           "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.11",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
+          "integrity": "sha512-jfcNBxHFYJ4nPIacsi3woz1+kvUO6s1CyeEhtnDHBjHUMNj5UlW2GynmnSgiJJEdNg9yW5C8lfoNRZrHGv5EqA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
           }
         },
         "ansi-regex": {
@@ -9435,23 +9519,23 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
-        "jest-get-type": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-          "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
-          "dev": true
-        },
         "pretty-format": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.2.tgz",
-          "integrity": "sha512-VizyV669eqESlkOikKJI8Ryxl/kPpbdLwNdPs2GrbQs18MpySB5S0Yo0N7zkg2xTRiFq4CFw8ct5Vg4a0xP0og==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+          "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.5.2",
+            "@jest/types": "^26.6.2",
             "ansi-regex": "^5.0.0",
             "ansi-styles": "^4.0.0",
-            "react-is": "^16.12.0"
+            "react-is": "^17.0.1"
           }
+        },
+        "react-is": {
+          "version": "17.0.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+          "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
+          "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
@@ -9465,17 +9549,54 @@
       }
     },
     "jest-diff": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
-      "integrity": "sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.2.tgz",
+      "integrity": "sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==",
       "dev": true,
       "requires": {
-        "chalk": "^3.0.0",
-        "diff-sequences": "^25.2.6",
-        "jest-get-type": "^25.2.6",
-        "pretty-format": "^25.5.0"
+        "chalk": "^4.0.0",
+        "diff-sequences": "^26.6.2",
+        "jest-get-type": "^26.3.0",
+        "pretty-format": "^26.6.2"
       },
       "dependencies": {
+        "@jest/types": {
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/istanbul-reports": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.11",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
+          "integrity": "sha512-jfcNBxHFYJ4nPIacsi3woz1+kvUO6s1CyeEhtnDHBjHUMNj5UlW2GynmnSgiJJEdNg9yW5C8lfoNRZrHGv5EqA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -9486,9 +9607,9 @@
           }
         },
         "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -9514,6 +9635,24 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+          "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.6.2",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^17.0.1"
+          }
+        },
+        "react-is": {
+          "version": "17.0.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+          "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
           "dev": true
         },
         "supports-color": {
@@ -9537,22 +9676,22 @@
       }
     },
     "jest-each": {
-      "version": "26.5.2",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.5.2.tgz",
-      "integrity": "sha512-w7D9FNe0m2D3yZ0Drj9CLkyF/mGhmBSULMQTypzAKR746xXnjUrK8GUJdlLTWUF6dd0ks3MtvGP7/xNFr9Aphg==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.6.2.tgz",
+      "integrity": "sha512-Mer/f0KaATbjl8MCJ+0GEpNdqmnVmDYqCTJYTvoo7rqmRiDllmp2AYN+06F93nXcY3ur9ShIjS+CO/uD+BbH4A==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.5.2",
+        "@jest/types": "^26.6.2",
         "chalk": "^4.0.0",
         "jest-get-type": "^26.3.0",
-        "jest-util": "^26.5.2",
-        "pretty-format": "^26.5.2"
+        "jest-util": "^26.6.2",
+        "pretty-format": "^26.6.2"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -9569,6 +9708,15 @@
           "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.11",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
+          "integrity": "sha512-jfcNBxHFYJ4nPIacsi3woz1+kvUO6s1CyeEhtnDHBjHUMNj5UlW2GynmnSgiJJEdNg9yW5C8lfoNRZrHGv5EqA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
           }
         },
         "ansi-regex": {
@@ -9617,23 +9765,23 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
-        "jest-get-type": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-          "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
-          "dev": true
-        },
         "pretty-format": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.2.tgz",
-          "integrity": "sha512-VizyV669eqESlkOikKJI8Ryxl/kPpbdLwNdPs2GrbQs18MpySB5S0Yo0N7zkg2xTRiFq4CFw8ct5Vg4a0xP0og==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+          "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.5.2",
+            "@jest/types": "^26.6.2",
             "ansi-regex": "^5.0.0",
             "ansi-styles": "^4.0.0",
-            "react-is": "^16.12.0"
+            "react-is": "^17.0.1"
           }
+        },
+        "react-is": {
+          "version": "17.0.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+          "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
+          "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
@@ -9647,24 +9795,24 @@
       }
     },
     "jest-environment-jsdom": {
-      "version": "26.5.2",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.5.2.tgz",
-      "integrity": "sha512-fWZPx0bluJaTQ36+PmRpvUtUlUFlGGBNyGX1SN3dLUHHMcQ4WseNEzcGGKOw4U5towXgxI4qDoI3vwR18H0RTw==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.6.2.tgz",
+      "integrity": "sha512-jgPqCruTlt3Kwqg5/WVFyHIOJHsiAvhcp2qiR2QQstuG9yWox5+iHpU3ZrcBxW14T4fe5Z68jAfLRh7joCSP2Q==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^26.5.2",
-        "@jest/fake-timers": "^26.5.2",
-        "@jest/types": "^26.5.2",
+        "@jest/environment": "^26.6.2",
+        "@jest/fake-timers": "^26.6.2",
+        "@jest/types": "^26.6.2",
         "@types/node": "*",
-        "jest-mock": "^26.5.2",
-        "jest-util": "^26.5.2",
+        "jest-mock": "^26.6.2",
+        "jest-util": "^26.6.2",
         "jsdom": "^16.4.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -9681,6 +9829,15 @@
           "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.11",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
+          "integrity": "sha512-jfcNBxHFYJ4nPIacsi3woz1+kvUO6s1CyeEhtnDHBjHUMNj5UlW2GynmnSgiJJEdNg9yW5C8lfoNRZrHGv5EqA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
           }
         },
         "ansi-styles": {
@@ -9735,23 +9892,23 @@
       }
     },
     "jest-environment-node": {
-      "version": "26.5.2",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.5.2.tgz",
-      "integrity": "sha512-YHjnDsf/GKFCYMGF1V+6HF7jhY1fcLfLNBDjhAOvFGvt6d8vXvNdJGVM7uTZ2VO/TuIyEFhPGaXMX5j3h7fsrA==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.6.2.tgz",
+      "integrity": "sha512-zhtMio3Exty18dy8ee8eJ9kjnRyZC1N4C1Nt/VShN1apyXc8rWGtJ9lI7vqiWcyyXS4BVSEn9lxAM2D+07/Tag==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^26.5.2",
-        "@jest/fake-timers": "^26.5.2",
-        "@jest/types": "^26.5.2",
+        "@jest/environment": "^26.6.2",
+        "@jest/fake-timers": "^26.6.2",
+        "@jest/types": "^26.6.2",
         "@types/node": "*",
-        "jest-mock": "^26.5.2",
-        "jest-util": "^26.5.2"
+        "jest-mock": "^26.6.2",
+        "jest-util": "^26.6.2"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -9768,6 +9925,15 @@
           "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.11",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
+          "integrity": "sha512-jfcNBxHFYJ4nPIacsi3woz1+kvUO6s1CyeEhtnDHBjHUMNj5UlW2GynmnSgiJJEdNg9yW5C8lfoNRZrHGv5EqA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
           }
         },
         "ansi-styles": {
@@ -9822,18 +9988,18 @@
       }
     },
     "jest-get-type": {
-      "version": "25.2.6",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
-      "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+      "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
       "dev": true
     },
     "jest-haste-map": {
-      "version": "26.5.2",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.5.2.tgz",
-      "integrity": "sha512-lJIAVJN3gtO3k4xy+7i2Xjtwh8CfPcH08WYjZpe9xzveDaqGw9fVNCpkYu6M525wKFVkLmyi7ku+DxCAP1lyMA==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.6.2.tgz",
+      "integrity": "sha512-easWIJXIw71B2RdR8kgqpjQrbMRWQBgiBwXYEhtGUTaX+doCjBheluShdDMeR8IMfJiTqH4+zfhtg29apJf/8w==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.5.2",
+        "@jest/types": "^26.6.2",
         "@types/graceful-fs": "^4.1.2",
         "@types/node": "*",
         "anymatch": "^3.0.3",
@@ -9841,18 +10007,18 @@
         "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
-        "jest-serializer": "^26.5.0",
-        "jest-util": "^26.5.2",
-        "jest-worker": "^26.5.0",
+        "jest-serializer": "^26.6.2",
+        "jest-util": "^26.6.2",
+        "jest-worker": "^26.6.2",
         "micromatch": "^4.0.2",
         "sane": "^4.0.3",
         "walker": "^1.0.7"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -9869,6 +10035,15 @@
           "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.11",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
+          "integrity": "sha512-jfcNBxHFYJ4nPIacsi3woz1+kvUO6s1CyeEhtnDHBjHUMNj5UlW2GynmnSgiJJEdNg9yW5C8lfoNRZrHGv5EqA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
           }
         },
         "ansi-styles": {
@@ -9923,35 +10098,35 @@
       }
     },
     "jest-jasmine2": {
-      "version": "26.5.2",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.5.2.tgz",
-      "integrity": "sha512-2J+GYcgLVPTkpmvHEj0/IDTIAuyblGNGlyGe4fLfDT2aktEPBYvoxUwFiOmDDxxzuuEAD2uxcYXr0+1Yw4tjFA==",
+      "version": "26.6.3",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.6.3.tgz",
+      "integrity": "sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==",
       "dev": true,
       "requires": {
         "@babel/traverse": "^7.1.0",
-        "@jest/environment": "^26.5.2",
-        "@jest/source-map": "^26.5.0",
-        "@jest/test-result": "^26.5.2",
-        "@jest/types": "^26.5.2",
+        "@jest/environment": "^26.6.2",
+        "@jest/source-map": "^26.6.2",
+        "@jest/test-result": "^26.6.2",
+        "@jest/types": "^26.6.2",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
-        "expect": "^26.5.2",
+        "expect": "^26.6.2",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^26.5.2",
-        "jest-matcher-utils": "^26.5.2",
-        "jest-message-util": "^26.5.2",
-        "jest-runtime": "^26.5.2",
-        "jest-snapshot": "^26.5.2",
-        "jest-util": "^26.5.2",
-        "pretty-format": "^26.5.2",
+        "jest-each": "^26.6.2",
+        "jest-matcher-utils": "^26.6.2",
+        "jest-message-util": "^26.6.2",
+        "jest-runtime": "^26.6.3",
+        "jest-snapshot": "^26.6.2",
+        "jest-util": "^26.6.2",
+        "pretty-format": "^26.6.2",
         "throat": "^5.0.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -9968,6 +10143,15 @@
           "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.11",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
+          "integrity": "sha512-jfcNBxHFYJ4nPIacsi3woz1+kvUO6s1CyeEhtnDHBjHUMNj5UlW2GynmnSgiJJEdNg9yW5C8lfoNRZrHGv5EqA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
           }
         },
         "ansi-regex": {
@@ -10017,16 +10201,22 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.2.tgz",
-          "integrity": "sha512-VizyV669eqESlkOikKJI8Ryxl/kPpbdLwNdPs2GrbQs18MpySB5S0Yo0N7zkg2xTRiFq4CFw8ct5Vg4a0xP0og==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+          "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.5.2",
+            "@jest/types": "^26.6.2",
             "ansi-regex": "^5.0.0",
             "ansi-styles": "^4.0.0",
-            "react-is": "^16.12.0"
+            "react-is": "^17.0.1"
           }
+        },
+        "react-is": {
+          "version": "17.0.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+          "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
+          "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
@@ -10051,12 +10241,6 @@
         "xml": "^1.0.1"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
         "strip-ansi": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -10075,19 +10259,19 @@
       }
     },
     "jest-leak-detector": {
-      "version": "26.5.2",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.5.2.tgz",
-      "integrity": "sha512-h7ia3dLzBFItmYERaLPEtEKxy3YlcbcRSjj0XRNJgBEyODuu+3DM2o62kvIFvs3PsaYoIIv+e+nLRI61Dj1CNw==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.6.2.tgz",
+      "integrity": "sha512-i4xlXpsVSMeKvg2cEKdfhh0H39qlJlP5Ex1yQxwF9ubahboQYMgTtz5oML35AVA3B4Eu+YsmwaiKVev9KCvLxg==",
       "dev": true,
       "requires": {
         "jest-get-type": "^26.3.0",
-        "pretty-format": "^26.5.2"
+        "pretty-format": "^26.6.2"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -10104,6 +10288,15 @@
           "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.11",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
+          "integrity": "sha512-jfcNBxHFYJ4nPIacsi3woz1+kvUO6s1CyeEhtnDHBjHUMNj5UlW2GynmnSgiJJEdNg9yW5C8lfoNRZrHGv5EqA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
           }
         },
         "ansi-regex": {
@@ -10152,23 +10345,23 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
-        "jest-get-type": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-          "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
-          "dev": true
-        },
         "pretty-format": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.2.tgz",
-          "integrity": "sha512-VizyV669eqESlkOikKJI8Ryxl/kPpbdLwNdPs2GrbQs18MpySB5S0Yo0N7zkg2xTRiFq4CFw8ct5Vg4a0xP0og==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+          "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.5.2",
+            "@jest/types": "^26.6.2",
             "ansi-regex": "^5.0.0",
             "ansi-styles": "^4.0.0",
-            "react-is": "^16.12.0"
+            "react-is": "^17.0.1"
           }
+        },
+        "react-is": {
+          "version": "17.0.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+          "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
+          "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
@@ -10182,21 +10375,21 @@
       }
     },
     "jest-matcher-utils": {
-      "version": "26.5.2",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.5.2.tgz",
-      "integrity": "sha512-W9GO9KBIC4gIArsNqDUKsLnhivaqf8MSs6ujO/JDcPIQrmY+aasewweXVET8KdrJ6ADQaUne5UzysvF/RR7JYA==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.6.2.tgz",
+      "integrity": "sha512-llnc8vQgYcNqDrqRDXWwMr9i7rS5XFiCwvh6DTP7Jqa2mqpcCBBlpCbn+trkG0KNhPu/h8rzyBkriOtBstvWhw==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "jest-diff": "^26.5.2",
+        "jest-diff": "^26.6.2",
         "jest-get-type": "^26.3.0",
-        "pretty-format": "^26.5.2"
+        "pretty-format": "^26.6.2"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -10213,6 +10406,15 @@
           "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.11",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
+          "integrity": "sha512-jfcNBxHFYJ4nPIacsi3woz1+kvUO6s1CyeEhtnDHBjHUMNj5UlW2GynmnSgiJJEdNg9yW5C8lfoNRZrHGv5EqA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
           }
         },
         "ansi-regex": {
@@ -10255,47 +10457,29 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
-        "diff-sequences": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.5.0.tgz",
-          "integrity": "sha512-ZXx86srb/iYy6jG71k++wBN9P9J05UNQ5hQHQd9MtMPvcqXPx/vKU69jfHV637D00Q2gSgPk2D+jSx3l1lDW/Q==",
-          "dev": true
-        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
-        "jest-diff": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.5.2.tgz",
-          "integrity": "sha512-HCSWDUGwsov5oTlGzrRM+UPJI/Dpqi9jzeV0fdRNi3Ch5bnoXhnyJMmVg2juv9081zLIy3HGPI5mcuGgXM2xRA==",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.0.0",
-            "diff-sequences": "^26.5.0",
-            "jest-get-type": "^26.3.0",
-            "pretty-format": "^26.5.2"
-          }
-        },
-        "jest-get-type": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-          "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
-          "dev": true
-        },
         "pretty-format": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.2.tgz",
-          "integrity": "sha512-VizyV669eqESlkOikKJI8Ryxl/kPpbdLwNdPs2GrbQs18MpySB5S0Yo0N7zkg2xTRiFq4CFw8ct5Vg4a0xP0og==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+          "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.5.2",
+            "@jest/types": "^26.6.2",
             "ansi-regex": "^5.0.0",
             "ansi-styles": "^4.0.0",
-            "react-is": "^16.12.0"
+            "react-is": "^17.0.1"
           }
+        },
+        "react-is": {
+          "version": "17.0.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+          "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
+          "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
@@ -10309,25 +10493,26 @@
       }
     },
     "jest-message-util": {
-      "version": "26.5.2",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.5.2.tgz",
-      "integrity": "sha512-Ocp9UYZ5Jl15C5PNsoDiGEk14A4NG0zZKknpWdZGoMzJuGAkVt10e97tnEVMYpk7LnQHZOfuK2j/izLBMcuCZw==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.6.2.tgz",
+      "integrity": "sha512-rGiLePzQ3AzwUshu2+Rn+UMFk0pHN58sOG+IaJbk5Jxuqo3NYO1U2/MIR4S1sKgsoYSXSzdtSa0TgrmtUwEbmA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@jest/types": "^26.5.2",
+        "@jest/types": "^26.6.2",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "micromatch": "^4.0.2",
+        "pretty-format": "^26.6.2",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.2"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -10345,6 +10530,21 @@
           "requires": {
             "@types/istanbul-lib-report": "*"
           }
+        },
+        "@types/yargs": {
+          "version": "15.0.11",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
+          "integrity": "sha512-jfcNBxHFYJ4nPIacsi3woz1+kvUO6s1CyeEhtnDHBjHUMNj5UlW2GynmnSgiJJEdNg9yW5C8lfoNRZrHGv5EqA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
         },
         "ansi-styles": {
           "version": "4.3.0",
@@ -10384,6 +10584,24 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+          "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.6.2",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^17.0.1"
+          }
+        },
+        "react-is": {
+          "version": "17.0.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+          "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
           "dev": true
         },
         "supports-color": {
@@ -10398,19 +10616,19 @@
       }
     },
     "jest-mock": {
-      "version": "26.5.2",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.5.2.tgz",
-      "integrity": "sha512-9SiU4b5PtO51v0MtJwVRqeGEroH66Bnwtq4ARdNP7jNXbpT7+ByeWNAk4NeT/uHfNSVDXEXgQo1XRuwEqS6Rdw==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.6.2.tgz",
+      "integrity": "sha512-YyFjePHHp1LzpzYcmgqkJ0nm0gg/lJx2aZFzFy1S6eUqNjXsOqTK10zNRff2dNfssgokjkG65OlWNcIlgd3zew==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.5.2",
+        "@jest/types": "^26.6.2",
         "@types/node": "*"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -10427,6 +10645,15 @@
           "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.11",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
+          "integrity": "sha512-jfcNBxHFYJ4nPIacsi3woz1+kvUO6s1CyeEhtnDHBjHUMNj5UlW2GynmnSgiJJEdNg9yW5C8lfoNRZrHGv5EqA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
           }
         },
         "ansi-styles": {
@@ -10493,25 +10720,25 @@
       "dev": true
     },
     "jest-resolve": {
-      "version": "26.5.2",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.5.2.tgz",
-      "integrity": "sha512-XsPxojXGRA0CoDD7Vis59ucz2p3cQFU5C+19tz3tLEAlhYKkK77IL0cjYjikY9wXnOaBeEdm1rOgSJjbZWpcZg==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.6.2.tgz",
+      "integrity": "sha512-sOxsZOq25mT1wRsfHcbtkInS+Ek7Q8jCHUB0ZUTP0tc/c41QHriU/NunqMfCUWsL4H3MHpvQD4QR9kSYhS7UvQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.5.2",
+        "@jest/types": "^26.6.2",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^26.5.2",
+        "jest-util": "^26.6.2",
         "read-pkg-up": "^7.0.1",
-        "resolve": "^1.17.0",
+        "resolve": "^1.18.1",
         "slash": "^3.0.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -10528,6 +10755,15 @@
           "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.11",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
+          "integrity": "sha512-jfcNBxHFYJ4nPIacsi3woz1+kvUO6s1CyeEhtnDHBjHUMNj5UlW2GynmnSgiJJEdNg9yW5C8lfoNRZrHGv5EqA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
           }
         },
         "ansi-styles": {
@@ -10629,20 +10865,20 @@
       }
     },
     "jest-resolve-dependencies": {
-      "version": "26.5.2",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.5.2.tgz",
-      "integrity": "sha512-LLkc8LuRtxqOx0AtX/Npa2C4I23WcIrwUgNtHYXg4owYF/ZDQShcwBAHjYZIFR06+HpQcZ43+kCTMlQ3aDCYTg==",
+      "version": "26.6.3",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.6.3.tgz",
+      "integrity": "sha512-pVwUjJkxbhe4RY8QEWzN3vns2kqyuldKpxlxJlzEYfKSvY6/bMvxoFrYYzUO1Gx28yKWN37qyV7rIoIp2h8fTg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.5.2",
+        "@jest/types": "^26.6.2",
         "jest-regex-util": "^26.0.0",
-        "jest-snapshot": "^26.5.2"
+        "jest-snapshot": "^26.6.2"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -10659,6 +10895,15 @@
           "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.11",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
+          "integrity": "sha512-jfcNBxHFYJ4nPIacsi3woz1+kvUO6s1CyeEhtnDHBjHUMNj5UlW2GynmnSgiJJEdNg9yW5C8lfoNRZrHGv5EqA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
           }
         },
         "ansi-styles": {
@@ -10713,37 +10958,37 @@
       }
     },
     "jest-runner": {
-      "version": "26.5.2",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.5.2.tgz",
-      "integrity": "sha512-GKhYxtSX5+tXZsd2QwfkDqPIj5C2HqOdXLRc2x2qYqWE26OJh17xo58/fN/mLhRkO4y6o60ZVloan7Kk5YA6hg==",
+      "version": "26.6.3",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.6.3.tgz",
+      "integrity": "sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==",
       "dev": true,
       "requires": {
-        "@jest/console": "^26.5.2",
-        "@jest/environment": "^26.5.2",
-        "@jest/test-result": "^26.5.2",
-        "@jest/types": "^26.5.2",
+        "@jest/console": "^26.6.2",
+        "@jest/environment": "^26.6.2",
+        "@jest/test-result": "^26.6.2",
+        "@jest/types": "^26.6.2",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "emittery": "^0.7.1",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
-        "jest-config": "^26.5.2",
+        "jest-config": "^26.6.3",
         "jest-docblock": "^26.0.0",
-        "jest-haste-map": "^26.5.2",
-        "jest-leak-detector": "^26.5.2",
-        "jest-message-util": "^26.5.2",
-        "jest-resolve": "^26.5.2",
-        "jest-runtime": "^26.5.2",
-        "jest-util": "^26.5.2",
-        "jest-worker": "^26.5.0",
+        "jest-haste-map": "^26.6.2",
+        "jest-leak-detector": "^26.6.2",
+        "jest-message-util": "^26.6.2",
+        "jest-resolve": "^26.6.2",
+        "jest-runtime": "^26.6.3",
+        "jest-util": "^26.6.2",
+        "jest-worker": "^26.6.2",
         "source-map-support": "^0.5.6",
         "throat": "^5.0.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -10760,6 +11005,15 @@
           "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.11",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
+          "integrity": "sha512-jfcNBxHFYJ4nPIacsi3woz1+kvUO6s1CyeEhtnDHBjHUMNj5UlW2GynmnSgiJJEdNg9yW5C8lfoNRZrHGv5EqA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
           }
         },
         "ansi-styles": {
@@ -10814,43 +11068,44 @@
       }
     },
     "jest-runtime": {
-      "version": "26.5.2",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.5.2.tgz",
-      "integrity": "sha512-zArr4DatX/Sn0wswX/AnAuJgmwgAR5rNtrUz36HR8BfMuysHYNq5sDbYHuLC4ICyRdy5ae/KQ+sczxyS9G6Qvw==",
+      "version": "26.6.3",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.6.3.tgz",
+      "integrity": "sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==",
       "dev": true,
       "requires": {
-        "@jest/console": "^26.5.2",
-        "@jest/environment": "^26.5.2",
-        "@jest/fake-timers": "^26.5.2",
-        "@jest/globals": "^26.5.2",
-        "@jest/source-map": "^26.5.0",
-        "@jest/test-result": "^26.5.2",
-        "@jest/transform": "^26.5.2",
-        "@jest/types": "^26.5.2",
+        "@jest/console": "^26.6.2",
+        "@jest/environment": "^26.6.2",
+        "@jest/fake-timers": "^26.6.2",
+        "@jest/globals": "^26.6.2",
+        "@jest/source-map": "^26.6.2",
+        "@jest/test-result": "^26.6.2",
+        "@jest/transform": "^26.6.2",
+        "@jest/types": "^26.6.2",
         "@types/yargs": "^15.0.0",
         "chalk": "^4.0.0",
+        "cjs-module-lexer": "^0.6.0",
         "collect-v8-coverage": "^1.0.0",
         "exit": "^0.1.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.4",
-        "jest-config": "^26.5.2",
-        "jest-haste-map": "^26.5.2",
-        "jest-message-util": "^26.5.2",
-        "jest-mock": "^26.5.2",
+        "jest-config": "^26.6.3",
+        "jest-haste-map": "^26.6.2",
+        "jest-message-util": "^26.6.2",
+        "jest-mock": "^26.6.2",
         "jest-regex-util": "^26.0.0",
-        "jest-resolve": "^26.5.2",
-        "jest-snapshot": "^26.5.2",
-        "jest-util": "^26.5.2",
-        "jest-validate": "^26.5.2",
+        "jest-resolve": "^26.6.2",
+        "jest-snapshot": "^26.6.2",
+        "jest-util": "^26.6.2",
+        "jest-validate": "^26.6.2",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0",
         "yargs": "^15.4.1"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -10867,6 +11122,15 @@
           "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.11",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
+          "integrity": "sha512-jfcNBxHFYJ4nPIacsi3woz1+kvUO6s1CyeEhtnDHBjHUMNj5UlW2GynmnSgiJJEdNg9yW5C8lfoNRZrHGv5EqA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
           }
         },
         "ansi-regex": {
@@ -11013,9 +11277,9 @@
           }
         },
         "y18n": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+          "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
           "dev": true
         },
         "yargs": {
@@ -11050,9 +11314,9 @@
       }
     },
     "jest-serializer": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.5.0.tgz",
-      "integrity": "sha512-+h3Gf5CDRlSLdgTv7y0vPIAoLgX/SI7T4v6hy+TEXMgYbv+ztzbg5PSN6mUXAT/hXYHvZRWm+MaObVfqkhCGxA==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.6.2.tgz",
+      "integrity": "sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -11060,33 +11324,33 @@
       }
     },
     "jest-snapshot": {
-      "version": "26.5.2",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.5.2.tgz",
-      "integrity": "sha512-MkXIDvEefzDubI/WaDVSRH4xnkuirP/Pz8LhAIDXcVQTmcEfwxywj5LGwBmhz+kAAIldA7XM4l96vbpzltSjqg==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.6.2.tgz",
+      "integrity": "sha512-OLhxz05EzUtsAmOMzuupt1lHYXCNib0ECyuZ/PZOx9TrZcC8vL0x+DUG3TL+GLX3yHG45e6YGjIm0XwDc3q3og==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.0.0",
-        "@jest/types": "^26.5.2",
+        "@jest/types": "^26.6.2",
         "@types/babel__traverse": "^7.0.4",
         "@types/prettier": "^2.0.0",
         "chalk": "^4.0.0",
-        "expect": "^26.5.2",
+        "expect": "^26.6.2",
         "graceful-fs": "^4.2.4",
-        "jest-diff": "^26.5.2",
+        "jest-diff": "^26.6.2",
         "jest-get-type": "^26.3.0",
-        "jest-haste-map": "^26.5.2",
-        "jest-matcher-utils": "^26.5.2",
-        "jest-message-util": "^26.5.2",
-        "jest-resolve": "^26.5.2",
+        "jest-haste-map": "^26.6.2",
+        "jest-matcher-utils": "^26.6.2",
+        "jest-message-util": "^26.6.2",
+        "jest-resolve": "^26.6.2",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^26.5.2",
+        "pretty-format": "^26.6.2",
         "semver": "^7.3.2"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -11103,6 +11367,15 @@
           "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.11",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
+          "integrity": "sha512-jfcNBxHFYJ4nPIacsi3woz1+kvUO6s1CyeEhtnDHBjHUMNj5UlW2GynmnSgiJJEdNg9yW5C8lfoNRZrHGv5EqA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
           }
         },
         "ansi-regex": {
@@ -11145,47 +11418,29 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
-        "diff-sequences": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.5.0.tgz",
-          "integrity": "sha512-ZXx86srb/iYy6jG71k++wBN9P9J05UNQ5hQHQd9MtMPvcqXPx/vKU69jfHV637D00Q2gSgPk2D+jSx3l1lDW/Q==",
-          "dev": true
-        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
-        "jest-diff": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.5.2.tgz",
-          "integrity": "sha512-HCSWDUGwsov5oTlGzrRM+UPJI/Dpqi9jzeV0fdRNi3Ch5bnoXhnyJMmVg2juv9081zLIy3HGPI5mcuGgXM2xRA==",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.0.0",
-            "diff-sequences": "^26.5.0",
-            "jest-get-type": "^26.3.0",
-            "pretty-format": "^26.5.2"
-          }
-        },
-        "jest-get-type": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-          "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
-          "dev": true
-        },
         "pretty-format": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.2.tgz",
-          "integrity": "sha512-VizyV669eqESlkOikKJI8Ryxl/kPpbdLwNdPs2GrbQs18MpySB5S0Yo0N7zkg2xTRiFq4CFw8ct5Vg4a0xP0og==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+          "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.5.2",
+            "@jest/types": "^26.6.2",
             "ansi-regex": "^5.0.0",
             "ansi-styles": "^4.0.0",
-            "react-is": "^16.12.0"
+            "react-is": "^17.0.1"
           }
+        },
+        "react-is": {
+          "version": "17.0.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+          "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
+          "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
@@ -11205,12 +11460,12 @@
       "dev": true
     },
     "jest-util": {
-      "version": "26.5.2",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.2.tgz",
-      "integrity": "sha512-WTL675bK+GSSAYgS8z9FWdCT2nccO1yTIplNLPlP0OD8tUk/H5IrWKMMRudIQQ0qp8bb4k+1Qa8CxGKq9qnYdg==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.2.tgz",
+      "integrity": "sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.5.2",
+        "@jest/types": "^26.6.2",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
@@ -11219,9 +11474,9 @@
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -11238,6 +11493,15 @@
           "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.11",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
+          "integrity": "sha512-jfcNBxHFYJ4nPIacsi3woz1+kvUO6s1CyeEhtnDHBjHUMNj5UlW2GynmnSgiJJEdNg9yW5C8lfoNRZrHGv5EqA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
           }
         },
         "ansi-styles": {
@@ -11292,23 +11556,23 @@
       }
     },
     "jest-validate": {
-      "version": "26.5.2",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.5.2.tgz",
-      "integrity": "sha512-FmJks0zY36mp6Af/5sqO6CTL9bNMU45yKCJk3hrz8d2aIqQIlN1pr9HPIwZE8blLaewOla134nt5+xAmWsx3SQ==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.6.2.tgz",
+      "integrity": "sha512-NEYZ9Aeyj0i5rQqbq+tpIOom0YS1u2MVu6+euBsvpgIme+FOfRmoC4R5p0JiAUpaFvFy24xgrpMknarR/93XjQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.5.2",
+        "@jest/types": "^26.6.2",
         "camelcase": "^6.0.0",
         "chalk": "^4.0.0",
         "jest-get-type": "^26.3.0",
         "leven": "^3.1.0",
-        "pretty-format": "^26.5.2"
+        "pretty-format": "^26.6.2"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -11327,6 +11591,15 @@
             "@types/istanbul-lib-report": "*"
           }
         },
+        "@types/yargs": {
+          "version": "15.0.11",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
+          "integrity": "sha512-jfcNBxHFYJ4nPIacsi3woz1+kvUO6s1CyeEhtnDHBjHUMNj5UlW2GynmnSgiJJEdNg9yW5C8lfoNRZrHGv5EqA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
         "ansi-regex": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
@@ -11343,9 +11616,9 @@
           }
         },
         "camelcase": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
-          "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+          "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
           "dev": true
         },
         "chalk": {
@@ -11379,12 +11652,6 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
-        "jest-get-type": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-          "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
-          "dev": true
-        },
         "leven": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -11392,16 +11659,22 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.2.tgz",
-          "integrity": "sha512-VizyV669eqESlkOikKJI8Ryxl/kPpbdLwNdPs2GrbQs18MpySB5S0Yo0N7zkg2xTRiFq4CFw8ct5Vg4a0xP0og==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+          "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.5.2",
+            "@jest/types": "^26.6.2",
             "ansi-regex": "^5.0.0",
             "ansi-styles": "^4.0.0",
-            "react-is": "^16.12.0"
+            "react-is": "^17.0.1"
           }
+        },
+        "react-is": {
+          "version": "17.0.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+          "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
+          "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
@@ -11415,24 +11688,24 @@
       }
     },
     "jest-watcher": {
-      "version": "26.5.2",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.5.2.tgz",
-      "integrity": "sha512-i3m1NtWzF+FXfJ3ljLBB/WQEp4uaNhX7QcQUWMokcifFTUQBDFyUMEwk0JkJ1kopHbx7Een3KX0Q7+9koGM/Pw==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.6.2.tgz",
+      "integrity": "sha512-WKJob0P/Em2csiVthsI68p6aGKTIcsfjH9Gsx1f0A3Italz43e3ho0geSAVsmj09RWOELP1AZ/DXyJgOgDKxXQ==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^26.5.2",
-        "@jest/types": "^26.5.2",
+        "@jest/test-result": "^26.6.2",
+        "@jest/types": "^26.6.2",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
-        "jest-util": "^26.5.2",
+        "jest-util": "^26.6.2",
         "string-length": "^4.0.1"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -11449,6 +11722,15 @@
           "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.11",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
+          "integrity": "sha512-jfcNBxHFYJ4nPIacsi3woz1+kvUO6s1CyeEhtnDHBjHUMNj5UlW2GynmnSgiJJEdNg9yW5C8lfoNRZrHGv5EqA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
           }
         },
         "ansi-styles": {
@@ -11503,9 +11785,9 @@
       }
     },
     "jest-worker": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.5.0.tgz",
-      "integrity": "sha512-kTw66Dn4ZX7WpjZ7T/SUDgRhapFRKWmisVAF0Rv4Fu8SLFD7eLbqpLvbxVqYhSgaWa7I+bW7pHnbyfNsH6stug==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
+      "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -11695,13 +11977,13 @@
       }
     },
     "jsx-ast-utils": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.4.1.tgz",
-      "integrity": "sha512-z1xSldJ6imESSzOjd3NNkieVJKRlKYSOtMG8SFyCj2FIrvSaSuli/WjpBkEzCBoR9bYYYFgqJw61Xhu7Lcgk+w==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.1.0.tgz",
+      "integrity": "sha512-d4/UOjg+mxAWxCiF0c5UTSwyqbchkbqCvK87aBovhnh8GtysTjWmgC63tY0cJx/HzGgm9qnA147jVBdpOiQ2RA==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.1",
-        "object.assign": "^4.1.0"
+        "object.assign": "^4.1.1"
       }
     },
     "just-extend": {
@@ -12592,12 +12874,11 @@
       }
     },
     "lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "requires": {
-        "yallist": "^3.0.2"
+        "yallist": "^4.0.0"
       }
     },
     "lru-queue": {
@@ -13115,15 +13396,16 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "mocha": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.1.3.tgz",
-      "integrity": "sha512-ZbaYib4hT4PpF4bdSO2DohooKXIn4lDeiYqB+vTmCdr6l2woW0b6H3pf5x4sM5nwQMru9RvjjHYWVGltR50ZBw==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.2.1.tgz",
+      "integrity": "sha512-cuLBVfyFfFqbNR0uUKbDGXKGk+UDFe6aR4os78XIrMQpZl/nv7JYHcvP5MFIAb374b2zFXsdgEGwmzMtP0Xg8w==",
       "dev": true,
       "requires": {
+        "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
-        "chokidar": "3.4.2",
-        "debug": "4.1.1",
+        "chokidar": "3.4.3",
+        "debug": "4.2.0",
         "diff": "4.0.2",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
@@ -13134,25 +13416,18 @@
         "log-symbols": "4.0.0",
         "minimatch": "3.0.4",
         "ms": "2.1.2",
-        "object.assign": "4.1.0",
-        "promise.allsettled": "1.0.2",
-        "serialize-javascript": "4.0.0",
-        "strip-json-comments": "3.0.1",
-        "supports-color": "7.1.0",
+        "nanoid": "3.1.12",
+        "serialize-javascript": "5.0.1",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "7.2.0",
         "which": "2.0.2",
         "wide-align": "1.1.3",
-        "workerpool": "6.0.0",
+        "workerpool": "6.0.2",
         "yargs": "13.3.2",
         "yargs-parser": "13.1.2",
-        "yargs-unparser": "1.6.1"
+        "yargs-unparser": "2.0.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
         "cliui": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -13165,12 +13440,12 @@
           }
         },
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "emoji-regex": {
@@ -13222,31 +13497,13 @@
             "p-locate": "^5.0.0"
           }
         },
-        "object-keys": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-          "dev": true
-        },
-        "object.assign": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-          "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-          "dev": true,
-          "requires": {
-            "define-properties": "^1.1.2",
-            "function-bind": "^1.1.1",
-            "has-symbols": "^1.0.0",
-            "object-keys": "^1.0.11"
-          }
-        },
         "p-limit": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.2.tgz",
-          "integrity": "sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
           "dev": true,
           "requires": {
-            "p-try": "^2.0.0"
+            "yocto-queue": "^0.1.0"
           }
         },
         "p-locate": {
@@ -13290,16 +13547,10 @@
             "ansi-regex": "^4.1.0"
           }
         },
-        "strip-json-comments": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
-          "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
-          "dev": true
-        },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -13323,9 +13574,9 @@
           }
         },
         "y18n": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+          "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
           "dev": true
         },
         "yargs": {
@@ -13488,12 +13739,12 @@
       }
     },
     "module-definition": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/module-definition/-/module-definition-3.3.0.tgz",
-      "integrity": "sha512-HTplA9xwDzH67XJFC1YvZMUElWJD28DV0dUq7lhTs+JKJamUOWA/CcYWSlhW5amJO66uWtY7XdltT+LfX0wIVg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/module-definition/-/module-definition-3.3.1.tgz",
+      "integrity": "sha512-kLidGPwQ2yq484nSD+D3JoJp4Etc0Ox9P0L34Pu/cU4X4HcG7k7p62XI5BBuvURWMRX3RPyuhOcBHbKus+UH4A==",
       "dev": true,
       "requires": {
-        "ast-module-types": "^2.6.0",
+        "ast-module-types": "^2.7.1",
         "node-source-walk": "^4.0.0"
       }
     },
@@ -13504,9 +13755,9 @@
       "optional": true
     },
     "mongodb": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.2.tgz",
-      "integrity": "sha512-sSZOb04w3HcnrrXC82NEh/YGCmBuRgR+C1hZgmmv4L6dBz4BkRse6Y8/q/neXer9i95fKUBbFi4KgeceXmbsOA==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.3.tgz",
+      "integrity": "sha512-rOZuR0QkodZiM+UbQE5kDsJykBqWi0CL4Ec2i1nrGrUI3KO11r6Fbxskqmq3JK2NH7aW4dcccBuUujAP0ERl5w==",
       "requires": {
         "bl": "^2.2.1",
         "bson": "^1.1.4",
@@ -13532,9 +13783,9 @@
       }
     },
     "mongodb-build-info": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mongodb-build-info/-/mongodb-build-info-1.1.0.tgz",
-      "integrity": "sha512-ZlbQlpXv8DCvYK2I6UmyRO4z9zb4fyoph+RhEN/MSSsigaqcfl6dePkbgavemquvuKVEq0BbIiVkHw1DKwChxA=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/mongodb-build-info/-/mongodb-build-info-1.1.1.tgz",
+      "integrity": "sha512-HC4ZG98ObbWGM3ikL3VfSvuug3iQVpA2kBob/MxK+mn2PNdVTvR5lShio+Ev1rDqODfq3ePcfO6prfi0agQp8g=="
     },
     "mongodb-cloud-info": {
       "version": "1.1.2",
@@ -13682,9 +13933,9 @@
           }
         },
         "y18n": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+          "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
           "optional": true
         },
         "yargs": {
@@ -13762,9 +14013,9 @@
       }
     },
     "mongodb-data-service": {
-      "version": "17.0.3",
-      "resolved": "https://registry.npmjs.org/mongodb-data-service/-/mongodb-data-service-17.0.3.tgz",
-      "integrity": "sha512-xM+fgVv9b3eEONz5rXpr1+9GNPv//Q5kKtLf+q8Prec7L7po7/WneQa7JE0s2DrkXdzKhapnV5gxNxQVJbNeAw==",
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/mongodb-data-service/-/mongodb-data-service-17.0.4.tgz",
+      "integrity": "sha512-QQlMAYwA/mxSfpx8AtOu0OpKwWtjzyMryOxY9rgHjIC4abNYP9ySyVK108y70S6F+aZp+QSnm7JTOCT3tHtXOg==",
       "requires": {
         "async": "^3.2.0",
         "debug": "^4.2.0",
@@ -13784,29 +14035,6 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
           "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
-        },
-        "bson": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
-          "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg=="
-        },
-        "mongodb": {
-          "version": "3.6.3",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.3.tgz",
-          "integrity": "sha512-rOZuR0QkodZiM+UbQE5kDsJykBqWi0CL4Ec2i1nrGrUI3KO11r6Fbxskqmq3JK2NH7aW4dcccBuUujAP0ERl5w==",
-          "requires": {
-            "bl": "^2.2.1",
-            "bson": "^1.1.4",
-            "denque": "^1.4.1",
-            "require_optional": "^1.0.1",
-            "safe-buffer": "^5.1.2",
-            "saslprep": "^1.0.0"
-          }
-        },
-        "mongodb-build-info": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/mongodb-build-info/-/mongodb-build-info-1.1.1.tgz",
-          "integrity": "sha512-HC4ZG98ObbWGM3ikL3VfSvuug3iQVpA2kBob/MxK+mn2PNdVTvR5lShio+Ev1rDqODfq3ePcfO6prfi0agQp8g=="
         }
       }
     },
@@ -14867,9 +15095,9 @@
           }
         },
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
@@ -14998,6 +15226,12 @@
         "remove-array-items": "^1.0.0"
       }
     },
+    "nanoid": {
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
+      "integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A==",
+      "dev": true
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -15040,9 +15274,9 @@
       "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
     },
     "native-request": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/native-request/-/native-request-1.0.7.tgz",
-      "integrity": "sha512-9nRjinI9bmz+S7dgNtf4A70+/vPhnd+2krGpy4SUlADuOuSa24IDkNaZ+R/QT1wQ6S8jBdi6wE7fLekFZNfUpQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/native-request/-/native-request-1.0.8.tgz",
+      "integrity": "sha512-vU2JojJVelUGp6jRcLwToPoWGxSx23z/0iX+I77J3Ht17rf2INGjrhOoQnjVo60nQd8wVsgzKkPfRXBiVdD2ag==",
       "dev": true,
       "optional": true
     },
@@ -15053,9 +15287,9 @@
       "dev": true
     },
     "nearley": {
-      "version": "2.19.7",
-      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.19.7.tgz",
-      "integrity": "sha512-Y+KNwhBPcSJKeyQCFjn8B/MIe+DDlhaaDgjVldhy5xtFewIbiQgcbZV8k2gCVwkI1ZsKCnjIYZbR+0Fim5QYgg==",
+      "version": "2.19.9",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.19.9.tgz",
+      "integrity": "sha512-KpCXvcVWPmZrEs95tIkqWi+CgL48O8CJDVDgY/AQGWXR1O8KQPHt5iQrTLior0k0v3PGKIV2xPi879wR1sawwg==",
       "dev": true,
       "requires": {
         "commander": "^2.19.0",
@@ -15110,9 +15344,9 @@
       }
     },
     "node-abi": {
-      "version": "2.19.1",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.19.1.tgz",
-      "integrity": "sha512-HbtmIuByq44yhAzK7b9j/FelKlHYISKQn0mtvcBrU5QBkhoCMp5bu8Hv5AI34DcKfOAcJBcOEMwLlwO62FFu9A==",
+      "version": "2.19.3",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.19.3.tgz",
+      "integrity": "sha512-9xZrlyfvKhWme2EXFKQhZRp1yNWT/uI1luYPr3sFl+H4keYY4xR+1jO7mvTTijIsHf1M+QDe9uWuKeEpLInIlg==",
       "requires": {
         "semver": "^5.4.1"
       },
@@ -15181,12 +15415,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "process": {
-          "version": "0.11.10",
-          "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-          "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
           "dev": true
         },
         "punycode": {
@@ -15285,9 +15513,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.61",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.61.tgz",
-      "integrity": "sha512-DD5vebQLg8jLCOzwupn954fbIiZht05DAZs0k2u8NStSe6h9XdsuIQL8hSRKYiU8WUQRznmSDrKGbv3ObOmC7g==",
+      "version": "1.1.67",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.67.tgz",
+      "integrity": "sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg==",
       "dev": true
     },
     "node-source-walk": {
@@ -15581,47 +15809,19 @@
       }
     },
     "object-inspect": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
-      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
       "dev": true
     },
     "object-is": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.3.tgz",
-      "integrity": "sha512-teyqLvFWzLkq5B9ki8FVWA902UER2qkxmdA4nLf+wjOLAWgxzCWZNCxpDq9MvE8MmhWNr+I8w3BN49Vx36Y6Xg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.4.tgz",
+      "integrity": "sha512-1ZvAZ4wlF7IyPVOcE1Omikt7UpaFlOQq0HlSti+ZvDH3UiD2brwGMwDbyV43jao2bKJ+4+WdPJHSd7kgzKYVqg==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.1"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.18.0-next.1",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.2",
-            "is-negative-zero": "^2.0.0",
-            "is-regex": "^1.1.1",
-            "object-inspect": "^1.8.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.1",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
-          }
-        },
-        "object-keys": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-          "dev": true
-        }
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
       }
     },
     "object-keys": {
@@ -15639,37 +15839,17 @@
       }
     },
     "object.assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.1.tgz",
-      "integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
       "dev": true,
       "requires": {
+        "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.0",
         "has-symbols": "^1.0.1",
         "object-keys": "^1.1.1"
       },
       "dependencies": {
-        "es-abstract": {
-          "version": "1.18.0-next.1",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.2",
-            "is-negative-zero": "^2.0.0",
-            "is-regex": "^1.1.1",
-            "object-inspect": "^1.8.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.1",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
-          }
-        },
         "object-keys": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -15679,25 +15859,26 @@
       }
     },
     "object.entries": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.2.tgz",
-      "integrity": "sha512-BQdB9qKmb/HyNdMNWVr7O3+z5MUIx3aiegEIJqjMBbBf0YT9RRxTJSim4mzFqtyr7PDAHigq0N9dO0m0tRakQA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.3.tgz",
+      "integrity": "sha512-ym7h7OZebNS96hn5IJeyUmaWhaSM4SVtAPPfNLQEI2MYWCO2egsITb9nab2+i/Pwibx+R0mtn+ltKJXRSeTMGg==",
       "dev": true,
       "requires": {
+        "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5",
+        "es-abstract": "^1.18.0-next.1",
         "has": "^1.0.3"
       }
     },
     "object.fromentries": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.2.tgz",
-      "integrity": "sha512-r3ZiBH7MQppDJVLx6fhD618GKNG40CZYH9wgwdhKxBDDbQgjeWGGd4AtkZad84d291YxvWe7bJGuE65Anh0dxQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.3.tgz",
+      "integrity": "sha512-IDUSMXs6LOSJBWE++L0lzIbSqHl9KDCfff2x/JSEIDtEUavUnyMYC2ZGay/04Zq4UT8lvd4xNhU4/YHKibAOlw==",
       "dev": true,
       "requires": {
+        "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1",
-        "function-bind": "^1.1.1",
+        "es-abstract": "^1.18.0-next.1",
         "has": "^1.0.3"
       }
     },
@@ -15711,14 +15892,14 @@
       }
     },
     "object.values": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
-      "integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.2.tgz",
+      "integrity": "sha512-MYC0jvJopr8EK6dPBiO8Nb9mvjdypOachO5REGk6MXzujbBrAisKo3HmdEI6kZDL6fC31Mwee/5YbtMebixeag==",
       "dev": true,
       "requires": {
+        "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1",
-        "function-bind": "^1.1.1",
+        "es-abstract": "^1.18.0-next.1",
         "has": "^1.0.3"
       }
     },
@@ -15945,9 +16126,9 @@
       "dev": true
     },
     "p-each-series": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.1.0.tgz",
-      "integrity": "sha512-ZuRs1miPT4HrjFa+9fRfOFXxGJfORgelKV9f9nNOWw2gl6gVsRaVDOQP0+MI0G0wGKns1Yacsu0GjOFbTK0JFQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
+      "integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==",
       "dev": true
     },
     "p-event": {
@@ -16746,53 +16927,20 @@
       "integrity": "sha512-s1Iam6Gwz3JI5Hweaz4GoCD1WUNUIyzePFy5+Js2hjwGVt2Z79wNN+ZKOZ2vB6C+Xs6njyB84Z1IthQg8d9LxA=="
     },
     "pretty-format": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
-      "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
-      "dev": true,
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
+      "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
       "requires": {
-        "@jest/types": "^25.5.0",
-        "ansi-regex": "^5.0.0",
-        "ansi-styles": "^4.0.0",
-        "react-is": "^16.12.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        }
+        "@jest/types": "^24.9.0",
+        "ansi-regex": "^4.0.0",
+        "ansi-styles": "^3.2.0",
+        "react-is": "^16.8.4"
       }
     },
     "pretty-repl": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/pretty-repl/-/pretty-repl-2.3.1.tgz",
-      "integrity": "sha512-Ld3SICMUO+ceGD0Pak9PDj6R6/mxXqj4E7hUfssio6eoGyaWICDiqHPKxem6QyqJ3V2m8qnNIYeom3HqM8a35A==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/pretty-repl/-/pretty-repl-2.4.0.tgz",
+      "integrity": "sha512-yUgK2JqipMjtCpiohGLiU2XBX+n/SbgDeHf+s7v+9PkQ4xV5poNV/zHVUA9BB+/q7+bD/grgoXHmdD7jpKPVtg==",
       "requires": {
         "ansi": "^0.3.1",
         "chalk": "^4.0.0",
@@ -16846,9 +16994,9 @@
       }
     },
     "process": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-      "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -16866,27 +17014,14 @@
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
     },
-    "promise.allsettled": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/promise.allsettled/-/promise.allsettled-1.0.2.tgz",
-      "integrity": "sha512-UpcYW5S1RaNKT6pd+s9jp9K9rlQge1UXKskec0j6Mmuq7UJCvlS2J2/s/yuPN8ehftf9HXMxWlKiPbGGUzpoRg==",
-      "dev": true,
-      "requires": {
-        "array.prototype.map": "^1.0.1",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1",
-        "function-bind": "^1.1.1",
-        "iterate-value": "^1.0.0"
-      }
-    },
     "prompts": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
-      "integrity": "sha512-Q06uKs2CkNYVID0VqwfAl9mipo99zkBv/n2JtWY89Yxa3ZabWSrs0e2KTudKVa3peLUvYXMefDqIleLPVUBZMA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.0.tgz",
+      "integrity": "sha512-awZAKrk3vN6CroQukBL+R9051a4R3zCZBlJm/HBfrSZ8iTpYix3VX1vU4mveiLpiwmOJT4wokTF9m6HUk4KqWQ==",
       "dev": true,
       "requires": {
         "kleur": "^3.0.3",
-        "sisteransi": "^1.0.4"
+        "sisteransi": "^1.0.5"
       }
     },
     "prop-types": {
@@ -17085,9 +17220,9 @@
       }
     },
     "react": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
-      "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -17095,9 +17230,9 @@
       }
     },
     "react-dom": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
-      "integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -17111,21 +17246,21 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "react-redux": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.1.tgz",
-      "integrity": "sha512-T+VfD/bvgGTUA74iW9d2i5THrDQWbweXP0AVNI8tNd1Rk5ch1rnMiJkDD67ejw7YBKM4+REvcvqRuWJb7BLuEg==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.2.tgz",
+      "integrity": "sha512-8+CQ1EvIVFkYL/vu6Olo7JFLWop1qRUeb46sGtIMDCSpgwPQq8fPLpirIB0iTqFe9XYEFPHssdX8/UwN6pAkEA==",
       "requires": {
-        "@babel/runtime": "^7.5.5",
-        "hoist-non-react-statics": "^3.3.0",
+        "@babel/runtime": "^7.12.1",
+        "hoist-non-react-statics": "^3.3.2",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.7.2",
-        "react-is": "^16.9.0"
+        "react-is": "^16.13.1"
       }
     },
     "react-test-renderer": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.13.1.tgz",
-      "integrity": "sha512-Sn2VRyOK2YJJldOqoh8Tn/lWQ+ZiKhyZTPtaO0Q6yNj+QDbmRkVFap6pZPy3YQk8DScRDfyqm/KxKYP9gCMRiQ==",
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.14.0.tgz",
+      "integrity": "sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==",
       "dev": true,
       "requires": {
         "object-assign": "^4.1.1",
@@ -17208,9 +17343,9 @@
       }
     },
     "readdirp": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
-      "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
       "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
@@ -17264,6 +17399,33 @@
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.1",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        },
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+          "dev": true
+        }
       }
     },
     "regexpp": {
@@ -17396,10 +17558,11 @@
       "integrity": "sha1-8I6sFWSVEjA5y8XuBvP1iXnkVgU="
     },
     "resolve": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
       "requires": {
+        "is-core-module": "^2.1.0",
         "path-parse": "^1.0.6"
       }
     },
@@ -17517,9 +17680,9 @@
       "dev": true
     },
     "run-parallel": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
-      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
+      "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==",
       "dev": true
     },
     "run-queue": {
@@ -17701,10 +17864,8 @@
       }
     },
     "saslprep": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
-      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
-      "optional": true,
+      "version": "github:mongodb-js/saslprep#9813a626d0685f54e4f2fac6160470d6e01d8c96",
+      "from": "github:mongodb-js/saslprep#v1.0.4",
       "requires": {
         "sparse-bitfield": "^3.0.3"
       }
@@ -17769,14 +17930,17 @@
       }
     },
     "semver": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+      "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
     },
     "serialize-javascript": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
+      "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
       "dev": true,
       "requires": {
         "randombytes": "^2.1.0"
@@ -17862,40 +18026,12 @@
       "requires": {
         "es-abstract": "^1.18.0-next.0",
         "object-inspect": "^1.8.0"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.18.0-next.1",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.2",
-            "is-negative-zero": "^2.0.0",
-            "is-regex": "^1.1.1",
-            "object-inspect": "^1.8.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.1",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
-          }
-        },
-        "object-keys": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-          "dev": true
-        }
       }
     },
     "sift": {
-      "version": "13.3.5",
-      "resolved": "https://registry.npmjs.org/sift/-/sift-13.3.5.tgz",
-      "integrity": "sha512-apSwBXO0Xpl7zGb26xwq7KGre9/WwyzMxUv0zmI6mLpDJQGOX+CynBgKDaSrn+AXuAuiS4orQo1ty6bU+OEN/Q==",
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-13.4.0.tgz",
+      "integrity": "sha512-sJAs3ujQjx6QVzWPKmqK1LhTAnpEiP2Q7zJi4VSmRYGAuz9SmlyAzo8w4jJQrrGXJb/QNUd0iJvD17dRezzfAA==",
       "dev": true
     },
     "signal-exit": {
@@ -17919,9 +18055,9 @@
       }
     },
     "sinon": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.0.tgz",
-      "integrity": "sha512-eSNXz1XMcGEMHw08NJXSyTHIu6qTCOiN8x9ODACmZpNQpr0aXTBXBnI4xTzQzR+TEpOmLiKowGf9flCuKIzsbw==",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.1.tgz",
+      "integrity": "sha512-naPfsamB5KEE1aiioaoqJ6MEhdUs/2vtI5w1hPAXX/UwvoPjXcwh1m5HiKx0HGgKR8lQSoFIgY5jM6KK8VrS9w==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.8.1",
@@ -18219,9 +18355,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.6.tgz",
-      "integrity": "sha512-+orQK83kyMva3WyPf59k1+Y525csj5JejicWut55zeTWANuN17qSiSLUXWtzHeNWORSvT7GLDJ/E/XiIWoXBTw=="
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
+      "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ=="
     },
     "split": {
       "version": "1.0.1",
@@ -18322,9 +18458,9 @@
       }
     },
     "stack-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.2.tgz",
-      "integrity": "sha512-0H7QK2ECz3fyZMzQ8rH0j2ykpfbnd20BFtfg/SqVC2+sCTtcw0aDTGB7dk+de4U4uUeuz6nOtJcrkFFLG1B0Rg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^2.0.0"
@@ -18566,85 +18702,60 @@
       }
     },
     "string.prototype.matchall": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.2.tgz",
-      "integrity": "sha512-N/jp6O5fMf9os0JU3E72Qhf590RSRZU/ungsL/qJUYVTNv7hTG0P/dbPjxINVN9jpscu3nzYwKESU3P3RY5tOg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.3.tgz",
+      "integrity": "sha512-OBxYDA2ifZQ2e13cP82dWFMaCV9CGF8GzmN4fljBVw5O5wep0lu4gacm1OL6MjROoUnB8VbkWRThqkV2YFLNxw==",
       "dev": true,
       "requires": {
+        "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0",
+        "es-abstract": "^1.18.0-next.1",
         "has-symbols": "^1.0.1",
         "internal-slot": "^1.0.2",
         "regexp.prototype.flags": "^1.3.0",
-        "side-channel": "^1.0.2"
+        "side-channel": "^1.0.3"
       }
     },
     "string.prototype.padend": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.0.tgz",
-      "integrity": "sha512-3aIv8Ffdp8EZj8iLwREGpQaUZiPyrWrpzMBHvkiSW/bK/EGve9np07Vwy7IJ5waydpGXzQZu/F8Oze2/IWkBaA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.1.tgz",
+      "integrity": "sha512-eCzTASPnoCr5Ht+Vn1YXgm8SB015hHKgEIMu9Nr9bQmLhRBxKRfmzSj/IQsxDFc8JInJDDFA0qXwK+xxI7wDkg==",
       "dev": true,
       "requires": {
+        "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1"
+        "es-abstract": "^1.18.0-next.1"
       }
     },
     "string.prototype.trim": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.2.tgz",
-      "integrity": "sha512-b5yrbl3BXIjHau9Prk7U0RRYcUYdN4wGSVaqoBQS50CCE3KBuYU0TYRNPFCP7aVoNMX87HKThdMRVIP3giclKg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.3.tgz",
+      "integrity": "sha512-16IL9pIBA5asNOSukPfxX2W68BaBvxyiRK16H3RA/lWW9BDosh+w7f+LhomPHpXJ82QEe7w7/rY/S1CV97raLg==",
       "dev": true,
       "requires": {
+        "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.0"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.18.0-next.1",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.2",
-            "is-negative-zero": "^2.0.0",
-            "is-regex": "^1.1.1",
-            "object-inspect": "^1.8.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.1",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
-          }
-        },
-        "object-keys": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-          "dev": true
-        }
+        "es-abstract": "^1.18.0-next.1"
       }
     },
     "string.prototype.trimend": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
-      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
+      "integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
-      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz",
+      "integrity": "sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
       }
     },
     "string_decoder": {
@@ -18658,6 +18769,13 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        }
       }
     },
     "strip-bom": {
@@ -18793,12 +18911,6 @@
         "string-width": "^3.0.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
         "emoji-regex": {
           "version": "7.0.3",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
@@ -18849,14 +18961,14 @@
       "dev": true
     },
     "tar-fs": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.0.tgz",
-      "integrity": "sha512-9uW5iDvrIMCVpvasdFHW0wJPez0K4JnMZtsuIeDI7HyMGJNxmDZDOCQROr7lXyS+iL/QMpj07qcjGYTSdRFXUg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
       "requires": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
         "pump": "^3.0.0",
-        "tar-stream": "^2.0.0"
+        "tar-stream": "^2.1.4"
       }
     },
     "tar-stream": {
@@ -18969,6 +19081,15 @@
             "ajv-keywords": "^3.1.0"
           }
         },
+        "serialize-javascript": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+          "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+          "dev": true,
+          "requires": {
+            "randombytes": "^2.1.0"
+          }
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -19029,9 +19150,9 @@
       "dev": true
     },
     "timers-browserify": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
-      "integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
+      "integrity": "sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==",
       "dev": true,
       "requires": {
         "setimmediate": "^1.0.4"
@@ -19153,9 +19274,9 @@
       }
     },
     "ts-jest": {
-      "version": "26.4.1",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.4.1.tgz",
-      "integrity": "sha512-F4aFq01aS6mnAAa0DljNmKr/Kk9y4HVZ1m6/rtJ0ED56cuxINGq3Q9eVAh+z5vcYKe5qnTMvv90vE8vUMFxomg==",
+      "version": "26.4.4",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.4.4.tgz",
+      "integrity": "sha512-3lFWKbLxJm34QxyVNNCgXX1u4o/RV0myvA2y2Bxm46iGIjKlaY0own9gIckbjZJPn+WaJEnfPPJ20HHGpoq4yg==",
       "dev": true,
       "requires": {
         "@types/jest": "26.x",
@@ -19178,9 +19299,9 @@
           "dev": true
         },
         "yargs-parser": {
-          "version": "20.2.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.1.tgz",
-          "integrity": "sha512-yYsjuSkjbLMBp16eaOt7/siKTjNVjMm3SoJnIg3sEh/JsvqVVDyjRKmaJV4cl+lNIgq6QEco2i3gDebJl7/vLA==",
+          "version": "20.2.4",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+          "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
           "dev": true
         }
       }
@@ -19224,9 +19345,9 @@
       }
     },
     "tslib": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.0.tgz",
-      "integrity": "sha512-+Zw5lu0D9tvBMjGP8LpvMb0u2WW2QV3y+D8mO6J+cNzCYIN4sVy43Bf9vl92nqFahutN0I8zHa7cc4vihIshnw==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
     },
     "tsutils": {
@@ -19321,9 +19442,9 @@
       }
     },
     "typescript": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
-      "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz",
+      "integrity": "sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==",
       "dev": true
     },
     "uc.micro": {
@@ -19548,15 +19669,15 @@
       "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg=="
     },
     "v8-compile-cache": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
-      "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
+      "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
       "dev": true
     },
     "v8-to-istanbul": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-5.0.1.tgz",
-      "integrity": "sha512-mbDNjuDajqYe3TXFk5qxcQy8L1msXNE37WTlLoqqpBfRsimbNcrlhQlDPntmECEcUvdC+AQ8CyMMf6EUx1r74Q==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-7.0.0.tgz",
+      "integrity": "sha512-fLL2rFuQpMtm9r8hrAV2apXX/WqHJ6+IC4/eQVdMDGBUgH/YMV4Gv3duk3kjmyg6uiQWBAA9nJwue4iJUOkHeA==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.1",
@@ -19626,9 +19747,9 @@
       },
       "dependencies": {
         "commander": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-6.1.0.tgz",
-          "integrity": "sha512-wl7PNrYWd2y5mp1OK/LhTlv8Ff4kQJQRXXAvF+uU/TPNiVJUxZLRYGj/B0y/lPGAVcSbJqH2Za/cvHmrPMC8mA==",
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+          "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
           "dev": true
         },
         "leven": {
@@ -19703,9 +19824,9 @@
       "integrity": "sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ=="
     },
     "vscode-test": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.4.0.tgz",
-      "integrity": "sha512-Jt7HNGvSE0+++Tvtq5wc4hiXLIr2OjDShz/gbAfM/mahQpy4rKBnmOK33D+MR67ATWviQhl+vpmU3p/qwSH/Pg==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.4.1.tgz",
+      "integrity": "sha512-Ls7+JyC06cUCuomlTYk4aNJI00Rri09hgtkNl3zfQ1bj6meXglpSPpuzJ/RPNetlUHFMm4eGs0Xr/H5pFPVwfQ==",
       "dev": true,
       "requires": {
         "http-proxy-agent": "^2.1.0",
@@ -19757,21 +19878,21 @@
       }
     },
     "watchpack": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.4.tgz",
-      "integrity": "sha512-aWAgTW4MoSJzZPAicljkO1hsi1oKj/RRq/OJQh2PKI2UKL04c2Bs+MBOB+BBABHTXJpf9mCwHN7ANCvYsvY2sg==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.5.tgz",
+      "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
       "dev": true,
       "requires": {
         "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
         "neo-async": "^2.5.0",
-        "watchpack-chokidar2": "^2.0.0"
+        "watchpack-chokidar2": "^2.0.1"
       }
     },
     "watchpack-chokidar2": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.0.tgz",
-      "integrity": "sha512-9TyfOyN/zLUbA288wZ8IsMZ+6cbzvsNyEzSBp6e/zkifi6xxbl8SmQ/CxQq32k8NNqrdVEVUVSEf56L4rQ/ZxA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.1.tgz",
+      "integrity": "sha512-nCFfBIPKr5Sh61s4LPpy1Wtfi0HE8isJ3d2Yb5/Ppw2P2B/3eVSEBjKfN0fmHJSK14+31KwMKmcrzs2GM4P0Ww==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -20277,12 +20398,6 @@
         "yargs": "^13.3.2"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
         "cliui": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -20482,9 +20597,9 @@
           }
         },
         "y18n": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+          "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
           "dev": true
         },
         "yargs": {
@@ -20626,9 +20741,9 @@
       }
     },
     "workerpool": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.0.0.tgz",
-      "integrity": "sha512-fU2OcNA/GVAJLLyKUoHkAgIhKb0JoCpSjLC/G2vYKxUjVmQwGbRVeoPJ1a8U4pnVofz4AQV5Y/NEw8oKqxEBtA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.0.2.tgz",
+      "integrity": "sha512-DSNyvOpFKrNusaaUwk+ej6cBj1bmhLcBfj80elGk+ZIo5JSkq+unB1dLKEOcNfJDZgjGICfhQ0Q5TbP0PvF4+Q==",
       "dev": true
     },
     "wrap-ansi": {
@@ -20677,16 +20792,16 @@
       }
     },
     "ws": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
-      "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
+      "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ=="
     },
     "xhr": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.5.0.tgz",
-      "integrity": "sha512-4nlO/14t3BNUZRXIXfXe+3N6w3s1KoxcJUUURctd64BLRe67E4gRwp4PjywtDY72fXpZ1y6Ch0VZQRY/gMPzzQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.6.0.tgz",
+      "integrity": "sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==",
       "requires": {
-        "global": "~4.3.0",
+        "global": "~4.4.0",
         "is-function": "^1.0.1",
         "parse-headers": "^2.0.0",
         "xtend": "^4.0.0"
@@ -20767,10 +20882,9 @@
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
     },
     "yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
       "version": "1.10.0",
@@ -20815,170 +20929,34 @@
       }
     },
     "yargs-unparser": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.1.tgz",
-      "integrity": "sha512-qZV14lK9MWsGCmcr7u5oXGH0dbGqZAIxTDrWXZDo5zUr6b6iUmelNKO6x6R1dQT24AH3LgRxJpr8meWy2unolA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
       "dev": true,
       "requires": {
-        "camelcase": "^5.3.1",
-        "decamelize": "^1.2.0",
-        "flat": "^4.1.0",
-        "is-plain-obj": "^1.1.0",
-        "yargs": "^14.2.3"
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
         "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+          "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
           "dev": true
         },
-        "cliui": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-          "dev": true,
-          "requires": {
-            "string-width": "^3.1.0",
-            "strip-ansi": "^5.2.0",
-            "wrap-ansi": "^5.1.0"
-          }
-        },
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-          "dev": true
-        },
-        "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
-        "get-caller-file": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "path-exists": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-          "dev": true
-        },
-        "require-main-filename": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        },
-        "which-module": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-          "dev": true
-        },
-        "wrap-ansi": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.0",
-            "string-width": "^3.0.0",
-            "strip-ansi": "^5.0.0"
-          }
-        },
-        "y18n": {
+        "decamelize": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+          "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
           "dev": true
         },
-        "yargs": {
-          "version": "14.2.3",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
-          "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
-          "dev": true,
-          "requires": {
-            "cliui": "^5.0.0",
-            "decamelize": "^1.2.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^2.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^3.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^15.0.1"
-          }
-        },
-        "yargs-parser": {
-          "version": "15.0.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
-          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
-          "dev": true,
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          }
+        "is-plain-obj": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+          "dev": true
         }
       }
     },
@@ -21005,6 +20983,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true
     }
   }
 }

--- a/src/editors/documentIdStore.ts
+++ b/src/editors/documentIdStore.ts
@@ -1,0 +1,27 @@
+import { EJSON } from 'bson';
+import { v4 as uuidv4 } from 'uuid';
+
+// In order to provide opening documents with various _id types we need
+// to pass the _id from the document to open to vscode's document provider.
+// So that when we open a document we have an id in the uri which corresponds
+// to the document's _id in the `_ids` map.
+// We can't store the _id on the uri itself as the _id can potentially be large.
+export default class DocumentIdStore {
+  _ids: { [key: string]: EJSON.SerializableTypes } = {};
+
+  add(_id: EJSON.SerializableTypes): string {
+    const key = uuidv4();
+
+    this._ids[key] = _id;
+
+    return key;
+  }
+
+  get(key: string): EJSON.SerializableTypes {
+    return this._ids[key];
+  }
+
+  remove(key: string): void {
+    delete this._ids[key];
+  }
+}

--- a/src/editors/documentProvider.ts
+++ b/src/editors/documentProvider.ts
@@ -1,6 +1,4 @@
-// import { URLSearchParams } from 'url';
 import * as vscode from 'vscode';
-// import { EJSON } from 'bson';
 
 import ConnectionController from '../connectionController';
 import { StatusView } from '../views';
@@ -37,10 +35,9 @@ export default class DocumentViewProvider implements vscode.TextDocumentContentP
       const uriParams = new URLSearchParams(uri.query);
       const namespace = uriParams.get(NAMESPACE_URI_IDENTIFIER) || '';
       const connectionId = uriParams.get(CONNECTION_ID_URI_IDENTIFIER);
-      const documentIdReference = uriParams.get(DOCUMENT_ID_URI_IDENTIFIER) || '';
 
+      const documentIdReference = uriParams.get(DOCUMENT_ID_URI_IDENTIFIER) || '';
       const documentId = this._documentIdStore.get(documentIdReference);
-      // const jsonObjectId = JSON.parse(documentIdReference).value;
       if (!documentId) {
         vscode.window.showErrorMessage(
           'Unable to fetch document: reference has expired.'

--- a/src/editors/editorsController.ts
+++ b/src/editors/editorsController.ts
@@ -20,6 +20,7 @@ import ConnectionController from '../connectionController';
 import { createLogger } from '../logging';
 import { StatusView } from '../views';
 import PlaygroundController from './playgroundController';
+import DocumentIdStore from './documentIdStore';
 
 const log = createLogger('editors controller');
 
@@ -29,6 +30,7 @@ const log = createLogger('editors controller');
  */
 export default class EditorsController {
   _connectionController: ConnectionController;
+  _documentIdStore: DocumentIdStore;
   _playgroundController: PlaygroundController;
   _collectionDocumentsOperationsStore = new CollectionDocumentsOperationsStore();
   _collectionViewProvider: CollectionDocumentsProvider;
@@ -70,8 +72,12 @@ export default class EditorsController {
       )
     );
 
+    const documentIdStore = new DocumentIdStore();
+    this._documentIdStore = documentIdStore;
+
     const documentViewProvider = new DocumentProvider(
       connectionController,
+      documentIdStore,
       new StatusView(context)
     );
 
@@ -104,15 +110,9 @@ export default class EditorsController {
 
     const connectionId = this._connectionController.getActiveConnectionId();
     const connectionIdUriQuery = `${CONNECTION_ID_URI_IDENTIFIER}=${connectionId}`;
-    // Encode the _id field incase the document id is a custom string with
-    // special characters.
-    const documentIdString = JSON.stringify({
-      value: EJSON.serialize(documentId)
-    });
+    const documentIdReference = this._documentIdStore.add(documentId);
 
-    const documentIdUriQuery = `${DOCUMENT_ID_URI_IDENTIFIER}=${encodeURIComponent(
-      documentIdString
-    )}`;
+    const documentIdUriQuery = `${DOCUMENT_ID_URI_IDENTIFIER}=${documentIdReference}`;
     const namespaceUriQuery = `${NAMESPACE_URI_IDENTIFIER}=${namespace}`;
 
     // We attach the current time to ensure a new editor window is opened on
@@ -123,7 +123,8 @@ export default class EditorsController {
     const textDocumentUri = vscode.Uri.parse(
       `${VIEW_DOCUMENT_SCHEME}:${namespace}: ${JSON.stringify(
         documentId
-      )} - ${Date.now()}.json${uriQuery}`
+      )} - ${Date.now()}.json${uriQuery}`,
+      true
     );
 
     return new Promise((resolve, reject) => {

--- a/src/editors/editorsController.ts
+++ b/src/editors/editorsController.ts
@@ -123,8 +123,7 @@ export default class EditorsController {
     const textDocumentUri = vscode.Uri.parse(
       `${VIEW_DOCUMENT_SCHEME}:${namespace}: ${JSON.stringify(
         documentId
-      )} - ${Date.now()}.json${uriQuery}`,
-      true
+      )} - ${Date.now()}.json${uriQuery}`
     );
 
     return new Promise((resolve, reject) => {

--- a/src/editors/playgroundController.ts
+++ b/src/editors/playgroundController.ts
@@ -272,7 +272,10 @@ export default class PlaygroundController {
               this._outputChannel.clear();
               this._outputChannel.show(true);
 
-              return resolve(undefined);
+              return resolve({
+                outputLines: undefined,
+                result: undefined
+              });
             });
 
             // Run all playground scripts.
@@ -286,7 +289,10 @@ export default class PlaygroundController {
         .then(undefined, (error) => {
           log.error('Evaluate playground with cancel modal error', error);
 
-          return resolve(undefined);
+          return resolve({
+            outputLines: undefined,
+            result: undefined
+          });
         });
     });
   }
@@ -351,8 +357,7 @@ export default class PlaygroundController {
 
       this._outputChannel.clear();
       if (evaluateResponse.outputLines) {
-        for (const line of evaluateResponse.outputLines)
-          this._outputChannel.appendLine(line.content);
+        for (const line of evaluateResponse.outputLines) {this._outputChannel.appendLine(line.content);}
         this._outputChannel.show(true);
       }
 
@@ -392,7 +397,7 @@ export default class PlaygroundController {
       this.activeTextEditor.document.languageId !== 'mongodb'
     ) {
       vscode.window.showErrorMessage(
-        `Please open a '.mongodb' playground file before running it.`
+        'Please open a \'.mongodb\' playground file before running it.'
       );
 
       return Promise.resolve(false);
@@ -424,7 +429,7 @@ export default class PlaygroundController {
       this.activeTextEditor.document.languageId !== 'mongodb'
     ) {
       vscode.window.showErrorMessage(
-        `Please open a '.mongodb' playground file before running it.`
+        'Please open a \'.mongodb\' playground file before running it.'
       );
 
       return Promise.resolve(false);
@@ -442,7 +447,7 @@ export default class PlaygroundController {
       this.activeTextEditor.document.languageId !== 'mongodb'
     ) {
       vscode.window.showErrorMessage(
-        `Please open a '.mongodb' playground file before running it.`
+        'Please open a \'.mongodb\' playground file before running it.'
       );
 
       return Promise.resolve(false);

--- a/src/test/suite/editors/documentProvider.test.ts
+++ b/src/test/suite/editors/documentProvider.test.ts
@@ -20,6 +20,7 @@ import {
   documentWithBinaryId,
   documentWithBinaryIdString
 } from './documentStringFixtures';
+import DocumentIdStore from '../../../editors/documentIdStore';
 
 const mockDocumentAsJsonString = `{
   "_id": "first_id",
@@ -123,17 +124,18 @@ suite('Document Provider Test Suite', () => {
     );
     mockConnectionController.setActiveConnection(mockActiveConnection);
 
+    const docStore = new DocumentIdStore();
+
     const testCollectionViewProvider = new DocumentProvider(
       mockConnectionController,
+      docStore,
       new StatusView(mockExtensionContext)
     );
 
-    const documentId = EJSON.stringify({
-      value: '123'
-    });
+    const documentIdRef = docStore.add('123');
 
     const uri = vscode.Uri.parse(
-      `scheme:Results: filename.json?namespace=test.test&documentId=${documentId}`
+      `scheme:Results: filename.json?namespace=test.test&documentId=${documentIdRef}`
     );
 
     testCollectionViewProvider

--- a/src/test/suite/editors/documentProvider.test.ts
+++ b/src/test/suite/editors/documentProvider.test.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 import * as vscode from 'vscode';
 import { afterEach } from 'mocha';
 import * as sinon from 'sinon';
-import { ObjectId, EJSON } from 'bson';
+import { ObjectId } from 'bson';
 import TelemetryController from '../../../telemetry/telemetryController';
 import DocumentProvider from '../../../editors/documentProvider';
 import ConnectionController from '../../../connectionController';
@@ -72,17 +72,16 @@ suite('Document Provider Test Suite', () => {
     );
     mockConnectionController.setActiveConnection(mockActiveConnection);
 
+    const docStore = new DocumentIdStore();
     const testCollectionViewProvider = new DocumentProvider(
       mockConnectionController,
+      docStore,
       new StatusView(mockExtensionContext)
     );
 
-    const documentId = EJSON.stringify({
-      value: '123'
-    });
-
+    const documentIdRef = docStore.add('123');
     const uri = vscode.Uri.parse(
-      `scheme:Results: filename.json?namespace=fruit.pineapple&documentId=${documentId}`
+      `scheme:Results: filename.json?namespace=fruit.pineapple&documentId=${documentIdRef}`
     );
 
     testCollectionViewProvider
@@ -168,17 +167,18 @@ suite('Document Provider Test Suite', () => {
 
     const textStatusView = new StatusView(mockExtensionContext);
 
+    const docStore = new DocumentIdStore();
+
     const testCollectionViewProvider = new DocumentProvider(
       mockConnectionController,
+      docStore,
       textStatusView
     );
 
-    const documentId = EJSON.stringify({
-      value: '123'
-    });
+    const documentIdRef = docStore.add('123');
 
     const uri = vscode.Uri.parse(
-      `scheme:Results: filename.json?namespace=aaaaaaaa&documentId=${documentId}`
+      `scheme:Results: filename.json?namespace=aaaaaaaa&documentId=${documentIdRef}`
     );
 
     const mockShowMessage = sinon.fake();
@@ -236,16 +236,17 @@ suite('Document Provider Test Suite', () => {
 
           mockConnectionController.setActiveConnection(dataService);
 
+          const docStore = new DocumentIdStore();
+
           const testCollectionViewProvider = new DocumentProvider(
             mockConnectionController,
+            docStore,
             new StatusView(mockExtensionContext)
           );
 
-          const documentId = EJSON.stringify({
-            value: (documentWithAllBSONTypes as any)._id
-          });
+          const documentIdRef = docStore.add((documentWithAllBSONTypes as any)._id);
           const uri = vscode.Uri.parse(
-            `scheme:Results: filename.json?namespace=${TEST_DB_NAME}.ramen&documentId=${documentId}`
+            `scheme:Results: filename.json?namespace=${TEST_DB_NAME}.ramen&documentId=${documentIdRef}`
           );
 
           testCollectionViewProvider
@@ -282,16 +283,16 @@ suite('Document Provider Test Suite', () => {
 
       mockConnectionController.setActiveConnection(dataService);
 
+      const docStore = new DocumentIdStore();
       const testCollectionViewProvider = new DocumentProvider(
         mockConnectionController,
+        docStore,
         new StatusView(mockExtensionContext)
       );
 
-      const documentId = EJSON.stringify({
-        value: documentWithBinaryId._id
-      });
+      const documentIdRef = docStore.add(documentWithBinaryId._id);
       const uri = vscode.Uri.parse(
-        `scheme:Results: filename.json?namespace=${TEST_DB_NAME}.ramen&documentId=${documentId}`
+        `scheme:Results: filename.json?namespace=${TEST_DB_NAME}.ramen&documentId=${documentIdRef}`
       );
 
       const document = await testCollectionViewProvider
@@ -326,16 +327,16 @@ suite('Document Provider Test Suite', () => {
 
           mockConnectionController.setActiveConnection(dataService);
 
+          const docStore = new DocumentIdStore();
           const testCollectionViewProvider = new DocumentProvider(
             mockConnectionController,
+            docStore,
             new StatusView(mockExtensionContext)
           );
+          const documentIdRef = docStore.add(mockDocument._id);
 
-          const documentId = EJSON.stringify({
-            value: mockDocument._id
-          });
           const uri = vscode.Uri.parse(
-            `scheme:Results: filename.json?namespace=${TEST_DB_NAME}.ramen&documentId=${documentId}`
+            `scheme:Results: filename.json?namespace=${TEST_DB_NAME}.ramen&documentId=${documentIdRef}`
           );
 
           testCollectionViewProvider
@@ -376,16 +377,16 @@ suite('Document Provider Test Suite', () => {
 
           mockConnectionController.setActiveConnection(dataService);
 
+          const docStore = new DocumentIdStore();
           const testCollectionViewProvider = new DocumentProvider(
             mockConnectionController,
+            docStore,
             new StatusView(mockExtensionContext)
           );
 
-          const documentId = EJSON.stringify({
-            value: mockDocument._id
-          });
+          const documentIdRef = docStore.add(mockDocument._id);
           const uri = vscode.Uri.parse(
-            `scheme:Results: filename.json?namespace=${TEST_DB_NAME}.ramen&documentId=${documentId}`
+            `scheme:Results: filename.json?namespace=${TEST_DB_NAME}.ramen&documentId=${documentIdRef}`
           );
 
           testCollectionViewProvider

--- a/src/test/suite/editors/documentStringFixtures.ts
+++ b/src/test/suite/editors/documentStringFixtures.ts
@@ -58,7 +58,7 @@ export const documentWithAllBsonTypesJsonified = `{
 }`;
 
 export const documentWithBinaryId = {
-  _id: new Binary('aaa')
+  _id: new Binary('a+b')
 };
 export const documentWithBinaryIdString = JSON.stringify(
   documentWithBinaryId,

--- a/src/test/suite/editors/playgroundController.test.ts
+++ b/src/test/suite/editors/playgroundController.test.ts
@@ -69,7 +69,7 @@ suite('Playground Controller Test Suite', function () {
     });
 
     test('run all playground blocks should throw the playground not found error', async () => {
-      const errorMessage = `Please open a '.mongodb' playground file before running it.`;
+      const errorMessage = 'Please open a \'.mongodb\' playground file before running it.';
 
       fakeShowErrorMessage.resolves(errorMessage);
 
@@ -81,7 +81,7 @@ suite('Playground Controller Test Suite', function () {
     });
 
     test('run selected playground blocks should throw the playground not found error', async () => {
-      const errorMessage = `Please open a '.mongodb' playground file before running it.`;
+      const errorMessage = 'Please open a \'.mongodb\' playground file before running it.';
 
       fakeShowErrorMessage.resolves(errorMessage);
 
@@ -93,7 +93,7 @@ suite('Playground Controller Test Suite', function () {
     });
 
     test('run all or selected playground blocks should throw the playground not found error', async () => {
-      const errorMessage = `Please open a '.mongodb' playground file before running it.`;
+      const errorMessage = 'Please open a \'.mongodb\' playground file before running it.';
 
       fakeShowErrorMessage.resolves(errorMessage);
 
@@ -264,7 +264,10 @@ suite('Playground Controller Test Suite', function () {
           // No action.
         }
 
-        expect(result).to.be.undefined;
+        expect(result).to.deep.equal({
+          outputLines: undefined,
+          result: undefined
+        });
       });
 
       test('do not show code lens if a part of a line is selected', async () => {

--- a/src/test/suite/mdbExtensionController.test.ts
+++ b/src/test/suite/mdbExtensionController.test.ts
@@ -1215,7 +1215,7 @@ suite('MDBExtensionController Test Suite', function () {
       .then(done, done);
   });
 
-  test('mdb.viewDocument opens an editor with the document using its id', (done) => {
+  test('mdb.viewDocument opens an editor with the document using its id', async () => {
     const mockOpenTextDocument = sinon.fake.resolves('magna carta');
     sinon.replace(vscode.workspace, 'openTextDocument', mockOpenTextDocument);
 
@@ -1230,31 +1230,23 @@ suite('MDBExtensionController Test Suite', function () {
       0
     );
 
-    vscode.commands
-      .executeCommand('mdb.viewDocument', documentItem)
-      .then(() => {
-        assert(
-          mockOpenTextDocument.firstArg.path.includes(
-            'waffle.house: "pancakes"'
-          )
-        );
-        assert(mockOpenTextDocument.firstArg.path.includes('.json'));
-        assert(mockOpenTextDocument.firstArg.scheme === VIEW_DOCUMENT_SCHEME);
-        assert(
-          mockOpenTextDocument.firstArg.query.includes(
-            'documentId={"value":"pancakes"}'
-          )
-        );
-        assert(
-          mockOpenTextDocument.firstArg.query.includes('namespace=waffle.house')
-        );
+    await vscode.commands.executeCommand('mdb.viewDocument', documentItem);
+    assert(
+      mockOpenTextDocument.firstArg.path.includes(
+        'waffle.house: "pancakes"'
+      )
+    );
+    assert(mockOpenTextDocument.firstArg.path.includes('.json'));
+    assert(mockOpenTextDocument.firstArg.scheme === VIEW_DOCUMENT_SCHEME);
+    assert(mockOpenTextDocument.firstArg.query.includes('documentId='));
+    assert(
+      mockOpenTextDocument.firstArg.query.includes('namespace=waffle.house')
+    );
 
-        assert(
-          mockShowTextDocument.firstArg === 'magna carta',
-          'Expected it to call vscode to show the returned document from the provider'
-        );
-      })
-      .then(done, done);
+    assert(
+      mockShowTextDocument.firstArg === 'magna carta',
+      'Expected it to call vscode to show the returned document from the provider'
+    );
   });
 
   test('mdb.searchForDocuments should create a MongoDB playground with search template', async () => {

--- a/src/test/suite/stubs.ts
+++ b/src/test/suite/stubs.ts
@@ -12,7 +12,7 @@ class TestExtensionContext implements vscode.ExtensionContext {
   subscriptions: { dispose(): any }[];
   workspaceState: vscode.Memento;
   _workspaceState = {};
-  globalState: vscode.Memento;
+  globalState: vscode.Memento & { setKeysForSync(keys: string[]): void };
   _globalState = {};
   extensionPath: string;
   storagePath: string;
@@ -49,7 +49,8 @@ class TestExtensionContext implements vscode.ExtensionContext {
         return new Promise<void>(() => {
           this._globalState[key] = value;
         });
-      }
+      },
+      setKeysForSync: (keys: string[]): void => {}
     };
     this.extensionPath = path.join(__dirname, '..', '..', '..');
     this.storagePath = '';

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -5,5 +5,5 @@ export type OutputItem = {
 
 export type ExecuteAllResult = {
   outputLines: OutputItem[] | undefined;
-  result: OutputItem;
+  result: OutputItem | undefined;
 };


### PR DESCRIPTION
The solution introduced in https://github.com/mongodb-js/vscode/pull/213 didn't fully cover all the opening of documents with different typed `_id` cases. When we open documents in vscode, in the original solution we sort of hackily added the _id as a ejsoned string on the document's uri in vscode. This doesn't work well because we have to ejson stringify, parse, uri encode, uri decode, and also we're bound by uri constraints like character limits in the query.
This PR updates how we pass a document's `_id` to the [document provider in vscode](https://code.visualstudio.com/api/extension-guides/virtual-documents#:~:text=Document%20providers%20are%20first%20class,they%20are%20part%20of%20vscode.). It adds a store which we then pass a reference to, so that we can avoid any encoding/decoding of the `_id` value.
On the upcoming editing documents work we may revisit how we show these documents so that we can be a bit more generalized and we can accommodate opening documents from playground results.

Tested with binary ids with `+` characters, numberlongs, and some other possible _ids.

![opening all sorts of uuids](https://user-images.githubusercontent.com/1791149/101147785-d1002880-35ea-11eb-827f-b3e347a5cf39.gif)
