### PR TITLE
fix(VSCODE-209): update flaky test to use timers

### DIFF
--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -1,7 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import * as vscode from 'vscode';
-import Connection = require('mongodb-connection-model/lib/model');
-import DataService = require('mongodb-data-service');
+import Connection from 'mongodb-connection-model/lib/model';
+import DataService from 'mongodb-data-service';
 
 import { ConnectionModelType } from './connectionModelType';
 import { DataServiceType } from './dataServiceType';

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -945,7 +945,7 @@ suite('Connection Controller Test Suite', function () {
     await testConnectionController.removeSavedConnection(connectionId);
 
     // Wait for the connection to timeout and complete (and not error in the process).
-    await sleep(100);
+    await sleep(250);
 
     assert(
       !testConnectionController.isCurrentlyConnected(),

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -2,7 +2,8 @@ import assert from 'assert';
 import * as vscode from 'vscode';
 import { afterEach, beforeEach } from 'mocha';
 import * as sinon from 'sinon';
-import Connection = require('mongodb-connection-model/lib/model');
+import Connection from 'mongodb-connection-model/lib/model';
+import DataService from 'mongodb-data-service';
 
 import TelemetryController from '../../telemetry/telemetryController';
 import ConnectionController, {
@@ -920,17 +921,31 @@ suite('Connection Controller Test Suite', function () {
       storageLocation: StorageScope.NONE
     };
 
+    const originalConnect = DataService.connect;
+
+    sinon.replace(
+      DataService.prototype,
+      'connect',
+      sinon.fake(async (
+        callback
+      ) => {
+        await sleep(50);
+
+        return originalConnect(callback);
+      })
+    );
+
     testConnectionController.connectWithConnectionId(connectionId);
 
-    // Ensure the connection starts but doesn't time out yet.
-    await sleep(0);
+    // Ensure the connection attempt has started.
+    await sleep(10);
 
     assert(testConnectionController.isConnecting());
 
     await testConnectionController.removeSavedConnection(connectionId);
 
     // Wait for the connection to timeout and complete (and not error in the process).
-    await sleep(500);
+    await sleep(100);
 
     assert(
       !testConnectionController.isCurrentlyConnected(),


### PR DESCRIPTION
VSCODE-209

I think this should fix the flaky test by making the timer on connecting a set amount. It's a bit of a weird test, but it does test important behavior.
