### PR TITLE
fix(playground): Only open playground output when there are output lines

### DIFF
--- a/src/editors/playgroundController.ts
+++ b/src/editors/playgroundController.ts
@@ -190,21 +190,17 @@ export default class PlaygroundController {
     return this._languageServerController.disconnectFromServiceProvider();
   }
 
-  createPlaygroundFileWithContent(
+  async createPlaygroundFileWithContent(
     content: string | undefined
   ): Promise<boolean> {
-    return new Promise((resolve, reject) => {
-      vscode.workspace
-        .openTextDocument({
-          language: 'mongodb',
-          content
-        })
-        .then((document) => {
-          this._outputChannel.show(true);
-          vscode.window.showTextDocument(document);
-          resolve(true);
-        }, reject);
+    const document = await vscode.workspace.openTextDocument({
+      language: 'mongodb',
+      content
     });
+
+    vscode.window.showTextDocument(document);
+
+    return true;
   }
 
   createPlaygroundForSearch(
@@ -234,18 +230,9 @@ export default class PlaygroundController {
       .getConfiguration('mdb')
       .get('useDefaultTemplateForPlayground');
 
-    return new Promise((resolve, reject) => {
-      vscode.workspace
-        .openTextDocument({
-          language: 'mongodb',
-          content: useDefaultTemplate ? playgroundTemplate : ''
-        })
-        .then((document) => {
-          this._outputChannel.show(true);
-          vscode.window.showTextDocument(document);
-          resolve(true);
-        }, reject);
-    });
+    return this.createPlaygroundFileWithContent(
+      useDefaultTemplate ? playgroundTemplate : ''
+    );
   }
 
   async evaluate(codeToEvaluate: string): Promise<ExecuteAllResult> {
@@ -294,7 +281,6 @@ export default class PlaygroundController {
               // If a user clicked the cancel button terminate all playground scripts.
               this._languageServerController.cancelAll();
               this._outputChannel.clear();
-              this._outputChannel.show(true);
 
               return resolve({
                 outputLines: undefined,

--- a/src/test/suite/editors/playgroundController.test.ts
+++ b/src/test/suite/editors/playgroundController.test.ts
@@ -8,7 +8,7 @@ import { TestExtensionContext, MockLanguageServerController } from '../stubs';
 import { before, beforeEach, afterEach } from 'mocha';
 import TelemetryController from '../../../telemetry/telemetryController';
 
-import sinon from 'sinon';
+const sinon = require('sinon');
 const chai = require('chai');
 const expect = chai.expect;
 

--- a/src/test/suite/editors/playgroundController.test.ts
+++ b/src/test/suite/editors/playgroundController.test.ts
@@ -8,7 +8,7 @@ import { TestExtensionContext, MockLanguageServerController } from '../stubs';
 import { before, beforeEach, afterEach } from 'mocha';
 import TelemetryController from '../../../telemetry/telemetryController';
 
-const sinon = require('sinon');
+import sinon from 'sinon';
 const chai = require('chai');
 const expect = chai.expect;
 
@@ -346,6 +346,22 @@ suite('Playground Controller Test Suite', function () {
         const isEditprOpened = await testPlaygroundController.evaluatePlayground();
 
         expect(isEditprOpened).to.be.equal(true);
+      });
+
+      test('evaluatePlayground should open and clear an output channel to show output', async () => {
+        await vscode.workspace
+          .getConfiguration('mdb')
+          .update('confirmRunAll', false);
+
+        sinon.spy();
+        const spy = sandbox.spy(
+          testPlaygroundController._outputChannel,
+          'show'
+        );
+
+        await testPlaygroundController.evaluatePlayground();
+
+        expect(spy.calledOnce).to.be.equal(true);
       });
 
       test('getDocumentLanguage returns json if content is object', async () => {


### PR DESCRIPTION
This PR makes it so we only show the playground output panel when there are output lines to show (by removing the places we open it without output).
Addresses part of https://github.com/mongodb-js/vscode/issues/223

Here's where it's shown: https://github.com/mongodb-js/vscode/blob/master/src/editors/playgroundController.ts#L423