### PR TITLE
styling(connect-form): add divider, tweak tabs overflow

### DIFF
--- a/src/views/webview-app/components/connect-form/connection-form.less
+++ b/src/views/webview-app/components/connect-form/connection-form.less
@@ -26,7 +26,6 @@
   padding: 0;
   margin: 0;
   margin-top: 10px;
-  overflow: hidden;
 }
 
 .connection-form-tab {
@@ -75,6 +74,7 @@
   height: 4px;
   left: -1px;
   right: -1px;
+  margin-bottom: -1px;
   pointer-events: none;
   outline: none;
   background-color: @green;

--- a/src/views/webview-app/components/connect-form/general-tab/general-tab.tsx
+++ b/src/views/webview-app/components/connect-form/general-tab/general-tab.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import Divider from '../../form/divider/divider';
 import HostInput from './host/host';
 import Authentication from './authentication/authentication';
 
@@ -8,6 +9,7 @@ export class GeneralTab extends React.Component {
     return (
       <React.Fragment>
         <HostInput />
+        <Divider />
         <Authentication />
       </React.Fragment>
     );

--- a/src/views/webview-app/components/form/divider/divider.less
+++ b/src/views/webview-app/components/form/divider/divider.less
@@ -1,6 +1,6 @@
 
 .form-divider {
-  background-color: rgba(255, 255, 255, 0.1);
+  background-color: rgba(75, 75, 75, 0.5);
   height: 1px;
   margin: 0;
   margin-top: 24px;

--- a/src/views/webview-app/components/form/divider/divider.less
+++ b/src/views/webview-app/components/form/divider/divider.less
@@ -1,0 +1,10 @@
+
+.form-divider {
+  background-color: rgba(255, 255, 255, 0.1);
+  height: 1px;
+  margin: 0;
+  margin-top: 24px;
+  margin-bottom: 24px;
+  padding: 0;
+  width: 100%;
+}

--- a/src/views/webview-app/components/form/divider/divider.tsx
+++ b/src/views/webview-app/components/form/divider/divider.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+import styles from './divider.less';
+
+export class Divider extends React.Component {
+  render(): React.ReactNode {
+    return (
+      <div className={styles['form-divider']} />
+    );
+  }
+}
+
+export default Divider;

--- a/src/views/webview-app/components/form/radio-box-group/radio-box-group.tsx
+++ b/src/views/webview-app/components/form/radio-box-group/radio-box-group.tsx
@@ -4,9 +4,6 @@ import * as React from 'react';
 const styles = require('./radio-box-group.less');
 const formStyles = require('../form.less');
 
-
-//
-
 type props = {
   label: string;
   name: string;

--- a/src/views/webview-app/components/form/radio-box-group/radio-box-group.tsx
+++ b/src/views/webview-app/components/form/radio-box-group/radio-box-group.tsx
@@ -4,6 +4,9 @@ import * as React from 'react';
 const styles = require('./radio-box-group.less');
 const formStyles = require('../form.less');
 
+
+//
+
 type props = {
   label: string;
   name: string;


### PR DESCRIPTION
Adds divider to separate host info from authentication.
Updates the styling on the connection tabs (there was a 1px space between the bottom of the active state and the divider). Kinda of hard to see but a bit easier to see on other color themes.

<img width="869" alt="Screen Shot 2021-01-14 at 7 02 42 PM" src="https://user-images.githubusercontent.com/1791149/104630807-9387c400-569b-11eb-8649-c8951c3ed6dd.png">
<img width="904" alt="Screen Shot 2021-01-14 at 7 07 38 PM" src="https://user-images.githubusercontent.com/1791149/104630944-ccc03400-569b-11eb-8f15-99a7b51a98cd.png">
