### PR TITLE
fix: deserialize document id before fetching document

### DIFF
--- a/src/editors/editDocumentCodeLensProvider.ts
+++ b/src/editors/editDocumentCodeLensProvider.ts
@@ -46,7 +46,6 @@ implements vscode.CodeLensProvider {
     }
 
     this._codeLensesInfo = codeLensesInfo;
-    this._onDidChangeCodeLenses.fire();
   }
 
   _updateCodeLensesForCursor(data: {

--- a/src/editors/editDocumentCodeLensProvider.ts
+++ b/src/editors/editDocumentCodeLensProvider.ts
@@ -3,6 +3,7 @@ import EXTENSION_COMMANDS from '../commands';
 import type { OutputItem, ResultCodeLensInfo } from '../utils/types';
 import ConnectionController from '../connectionController';
 import { DocumentSource } from '../telemetry/telemetryService';
+import { EJSON } from 'bson';
 
 export default class EditDocumentCodeLensProvider
 implements vscode.CodeLensProvider {
@@ -25,6 +26,7 @@ implements vscode.CodeLensProvider {
 
   updateCodeLensesForPlayground(playgroundResult: OutputItem) {
     const source = DocumentSource.DOCUMENT_SOURCE_PLAYGROUND;
+    let codeLensesInfo: ResultCodeLensInfo[] = [];
 
     if (!playgroundResult || !playgroundResult.content) {
       this._codeLensesInfo = [];
@@ -38,17 +40,20 @@ implements vscode.CodeLensProvider {
     // Show code lenses only for the list of documents or a single document
     // that are returned by the find() method.
     if (type === 'Cursor') {
-      this._updateCodeLensesForCursor(data);
+      codeLensesInfo = this._updateCodeLensesForCursor(data);
     } else if (type === 'Document') {
-      this._updateCodeLensesForDocument(data);
+      codeLensesInfo = this._updateCodeLensesForDocument(data);
     }
+
+    this._codeLensesInfo = codeLensesInfo;
+    this._onDidChangeCodeLenses.fire();
   }
 
   _updateCodeLensesForCursor(data: {
     content: any,
     namespace: string | null,
     source: string
-  }) {
+  }): ResultCodeLensInfo[] {
     const codeLensesInfo: ResultCodeLensInfo[] = [];
 
     if (Array.isArray(data.content)) {
@@ -64,7 +69,7 @@ implements vscode.CodeLensProvider {
         // to be able to save the editable document.
         if (item !== null && item._id && namespace) {
           codeLensesInfo.push({
-            documentId: item._id,
+            documentId: EJSON.deserialize(EJSON.serialize(item._id)),
             source,
             line,
             namespace,
@@ -79,17 +84,16 @@ implements vscode.CodeLensProvider {
       });
     }
 
-    this._codeLensesInfo = codeLensesInfo;
-    this._onDidChangeCodeLenses.fire();
+    return codeLensesInfo;
   }
 
   _updateCodeLensesForDocument(data: {
     content: any,
     namespace: string | null,
     source: string
-  }): void {
-    const codeLensesInfo: ResultCodeLensInfo[] = [];
+  }): ResultCodeLensInfo[] {
     const { content, namespace, source } = data;
+    const codeLensesInfo: ResultCodeLensInfo[] = [];
 
     if (content._id && namespace) {
       const connectionId = this._connectionController.getActiveConnectionId();
@@ -97,7 +101,7 @@ implements vscode.CodeLensProvider {
       // When the playground result is the single document,
       // show the single code lense after {.
       codeLensesInfo.push({
-        documentId: content._id,
+        documentId: EJSON.deserialize(EJSON.serialize(content._id)),
         source,
         line: 1,
         namespace,
@@ -105,8 +109,7 @@ implements vscode.CodeLensProvider {
       });
     }
 
-    this._codeLensesInfo = codeLensesInfo;
-    this._onDidChangeCodeLenses.fire();
+    return codeLensesInfo;
   }
 
   provideCodeLenses(): vscode.CodeLens[] {

--- a/src/test/suite/editors/editDocumentCodeLensProvider.test.ts
+++ b/src/test/suite/editors/editDocumentCodeLensProvider.test.ts
@@ -44,9 +44,10 @@ suite('Edit Document Code Lens Provider Test Suite', () => {
     const testCodeLensProvider = new EditDocumentCodeLensProvider(
       testConnectionController
     );
+    const ejsinId = { $oid: '5d973ae744376d2aae72a160' };
     const playgroundResult = {
       content: [{
-        _id: { $oid: '5d973ae744376d2aae72a160' },
+        _id: ejsinId,
         name: 'test name'
       }],
       namespace: 'db.coll',
@@ -68,6 +69,7 @@ suite('Edit Document Code Lens Provider Test Suite', () => {
     assert(!!codeLensesInfo.documentId);
     const bsonId = new ObjectId('5d973ae744376d2aae72a160');
 
+    assert(util.inspect(codeLensesInfo.documentId) !== util.inspect(ejsinId));
     assert(util.inspect(codeLensesInfo.documentId) === util.inspect(bsonId));
   });
 
@@ -75,9 +77,10 @@ suite('Edit Document Code Lens Provider Test Suite', () => {
     const testCodeLensProvider = new EditDocumentCodeLensProvider(
       testConnectionController
     );
+    const ejsinId = { $oid: '5d973ae744376d2aae72a160' };
     const playgroundResult = {
       content: {
-        _id: { $oid: '5d973ae744376d2aae72a160' },
+        _id: ejsinId,
         name: 'test name'
       },
       namespace: 'db.coll',
@@ -99,6 +102,7 @@ suite('Edit Document Code Lens Provider Test Suite', () => {
     assert(!!codeLensesInfo.documentId);
     const bsonId = new ObjectId('5d973ae744376d2aae72a160');
 
+    assert(util.inspect(codeLensesInfo.documentId) !== util.inspect(ejsinId));
     assert(util.inspect(codeLensesInfo.documentId) === util.inspect(bsonId));
   });
 

--- a/src/test/suite/editors/mongoDBDocumentService.test.ts
+++ b/src/test/suite/editors/mongoDBDocumentService.test.ts
@@ -9,8 +9,8 @@ import TelemetryService from '../../../telemetry/telemetryService';
 import { afterEach } from 'mocha';
 import { EJSON } from 'bson';
 
-const sinon = require('sinon');
-const chai = require('chai');
+import sinon from 'sinon';
+import chai from 'chai';
 const expect = chai.expect;
 
 suite('MongoDB Document Service Test Suite', () => {


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
Data service's `find()` does not accept ids in ejson format (e.g. `_id: {$oid: ‘5d973ae744376d2aae72a160’}`) and throws the following error:

<img width="582" alt="Screen Shot 2021-01-14 at 6 32 24 PM" src="https://user-images.githubusercontent.com/16307679/104641008-7fe35a00-56a9-11eb-8053-ad162a03a20c.png">

Deserialize document id before fetching a document to make sure id is `BSON.ObjectId()`.

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
