### PR TITLE
fix: refactor partial execution to use only provideCodeLenses without…

### DIFF
--- a/src/editors/partialExecutionCodeLensProvider.ts
+++ b/src/editors/partialExecutionCodeLensProvider.ts
@@ -3,7 +3,6 @@ import EXTENSION_COMMANDS from '../commands';
 
 export default class PartialExecutionCodeLensProvider
 implements vscode.CodeLensProvider {
-  _codeLenses: vscode.CodeLens[] = [];
   _selection?: vscode.Range;
   _onDidChangeCodeLenses: vscode.EventEmitter<
     void
@@ -28,13 +27,8 @@ implements vscode.CodeLensProvider {
       return [];
     }
 
-    this._codeLenses = [new vscode.CodeLens(this._selection)];
-
-    return this._codeLenses;
-  }
-
-  resolveCodeLens?(codeLens: vscode.CodeLens): vscode.CodeLens {
     const message = '► Run Selected Lines From Playground';
+    const codeLens = new vscode.CodeLens(this._selection);
 
     codeLens.command = {
       title: message,
@@ -42,6 +36,6 @@ implements vscode.CodeLensProvider {
       arguments: [message]
     };
 
-    return codeLens;
+    return [codeLens];
   }
 }


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
Refactor partial execution to use only provideCodeLenses without resolveCodeLens to ensure the code lens is always displayed with text.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
