### PR TITLE
0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to the "mongodb" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [0.4.0] - 2021-1-25
+
+### Added
+
+- Added the ability to edit documents opened from the explorer panel (VSCODE-219, #226, #239)
+- Added the ability to open and edit documents from playground results (VSCODE-222, #232)
+- Added icons for connect and playground panel actions (VSCODE-179, #240)
+- Added the ability to specify multiple hosts and ports in the connection form (VSCODE-208, #224)
+- Added a feature where we show the overview page when the extension is first installed (VSCODE-167, #225)
+
+### Changed
+
+- Changed how we generate default connection names for new connections to better represent multiple hosts and ports, and srv records (VSCODE-221, #227)
+- Changed how we show connectivity errors with the connection form (VSCODE-196, #217)
+
+### Fixed
+
+- Fix opening documents with a binary `_id` from the explorer panel (VSCODE-118, #220)
+- Fixed playground log output panel to not display when a playground is open and when a playground is run and there was no log output (#234)
+- Fixed code lenses for partial playground executions sometimes being missing (VSCODE-226, #243)
+
 ## [0.3.0] - 2020-11-24
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mongodb-vscode",
-  "version": "0.3.1-dev.0",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "mongodb-vscode",
   "displayName": "MongoDB for VS Code",
   "description": "Connect to MongoDB and Atlas directly from your VS Code environment, navigate your databases and collections, inspect your schema and use playgrounds to prototype queries and aggregations.",
-  "version": "0.3.1-dev.0",
+  "version": "0.4.0",
   "homepage": "https://github.com/mongodb-js/vscode",
   "qna": "https://developer.mongodb.com/community/forums/",
   "repository": {

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -512,7 +512,7 @@ suite('Connection Controller Test Suite', function () {
 
   test('"getConnectionStringFromConnectionId" returns the driver uri of a connection', async () => {
     const expectedDriverUri =
-      'mongodb://localhost:27018/?readPreference=primary&appname=mongodb-vscode%200.3.1-dev.0&ssl=false';
+      'mongodb://localhost:27018/?readPreference=primary&appname=mongodb-vscode%200.4.0&ssl=false';
 
     await testConnectionController.loadSavedConnections();
     await testConnectionController.addNewConnectionStringAndConnect(


### PR DESCRIPTION
VSCODE-218

Changelog update:

## [0.4.0] - 2021-1-25

### Added

- Added the ability to edit documents opened from the explorer panel (VSCODE-219, #226, #239)
- Added the ability to open and edit documents from playground results (VSCODE-222, #232)
- Added icons for connect and playground panel actions (VSCODE-179, #240)
- Added the ability to specify multiple hosts and ports in the connection form (VSCODE-208, #224)
- Added a feature where we show the overview page when the extension is first installed (VSCODE-167, #225)

### Changed

- Changed how we generate default connection names for new connections to better represent multiple hosts and ports, and srv records (VSCODE-221, #227)
- Changed how we show connectivity errors with the connection form (VSCODE-196, #217)

### Fixed

- Fix opening documents with a binary `_id` from the explorer panel (VSCODE-118, #220)
- Fixed playground log output panel to not display when a playground is open and when a playground is run and there was no log output (#234)
- Fixed code lenses for partial playground executions sometimes being missing (VSCODE-226, #243)