### PR TITLE
chore(telemetry): Add extension version to connected event VSCODE-126

### DIFF
--- a/src/telemetry/telemetryService.ts
+++ b/src/telemetry/telemetryService.ts
@@ -14,6 +14,8 @@ import { DocumentSource } from '../utils/documentSource';
 import fs from 'fs';
 import * as util from 'util';
 
+const { version } = require('../../package.json');
+
 const log = createLogger('telemetry');
 
 const ATLAS_REGEX = /mongodb.net[:/]/i;
@@ -45,8 +47,9 @@ type ExtensionCommandRunTelemetryEventProperties = {
   command: string;
 };
 
-type NewConnectionTelemetryEventProperties = {
+export type NewConnectionTelemetryEventProperties = {
   /* eslint-disable camelcase */
+  extension_version: string;
   is_atlas: boolean;
   is_localhost: boolean;
   is_data_lake: boolean;
@@ -279,7 +282,8 @@ export default class TelemetryService {
         const nonGenuineServerName = data.genuineMongoDB.isGenuine
           ? null
           : data.genuineMongoDB.dbType;
-        const preparedProperties = {
+        const preparedProperties: NewConnectionTelemetryEventProperties = {
+          extension_version: `${version}`,
           is_atlas: !!ATLAS_REGEX.exec(data.client.s.url),
           is_localhost: !!LOCALHOST_REGEX.exec(data.client.s.url),
           is_data_lake: data.dataLake.isDataLake,

--- a/src/telemetry/telemetryService.ts
+++ b/src/telemetry/telemetryService.ts
@@ -27,10 +27,10 @@ type PlaygroundTelemetryEventProperties = {
   error: boolean;
 };
 
-type SegmentProperties = {
+export type SegmentProperties = {
   event: string;
   userId: string;
-  properties?: any;
+  properties: any;
 };
 
 type CloudInfo = {
@@ -49,7 +49,6 @@ type ExtensionCommandRunTelemetryEventProperties = {
 
 export type NewConnectionTelemetryEventProperties = {
   /* eslint-disable camelcase */
-  extension_version: string;
   is_atlas: boolean;
   is_localhost: boolean;
   is_data_lake: boolean;
@@ -178,7 +177,7 @@ export default class TelemetryService {
 
   // Checks user settings and extension running mode
   // to determine whether or not we should track telemetry.
-  private isTelemetryFeatureEnabled(): boolean {
+  _isTelemetryFeatureEnabled(): boolean {
     // If tests run the extension we do not track telemetry.
     if (this._shouldTrackTelemetry !== true) {
       return false;
@@ -201,15 +200,15 @@ export default class TelemetryService {
     eventType: TelemetryEventTypes,
     properties?: TelemetryEventProperties
   ): void {
-    if (this.isTelemetryFeatureEnabled()) {
+    if (this._isTelemetryFeatureEnabled()) {
       const segmentProperties: SegmentProperties = {
         event: eventType,
-        userId: this._segmentUserID
+        userId: this._segmentUserID,
+        properties: {
+          ...properties,
+          extension_version: `${version}`
+        }
       };
-
-      if (properties) {
-        segmentProperties.properties = properties;
-      }
 
       log.info('TELEMETRY track', segmentProperties);
 
@@ -226,7 +225,7 @@ export default class TelemetryService {
   private async getCloudInfoFromDataService(
     firstServerHostname: string
   ): Promise<CloudInfo> {
-    if (!this.isTelemetryFeatureEnabled()) {
+    if (!this._isTelemetryFeatureEnabled()) {
       return {};
     }
 
@@ -283,7 +282,6 @@ export default class TelemetryService {
           ? null
           : data.genuineMongoDB.dbType;
         const preparedProperties: NewConnectionTelemetryEventProperties = {
-          extension_version: `${version}`,
           is_atlas: !!ATLAS_REGEX.exec(data.client.s.url),
           is_localhost: !!LOCALHOST_REGEX.exec(data.client.s.url),
           is_data_lake: data.dataLake.isDataLake,


### PR DESCRIPTION
VSCODE-126

Adds the extension version to the connection telemetry event.
Also adds a test w/ a real database for instance detail since I think we didn't have one before.

