### PR TITLE
0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Fixed
 
 - Fixed an issue with playground connectivity not defaulting the `directConnection` option to true (VSCODE-234, #255)
-- Fixed an issue around showing an error while editing a playground file without an active MongoDB connection	(VSCODE-231, #251)
+- Fixed an issue around showing an error while editing a playground file without an active MongoDB connection (VSCODE-231, #251)
 
 ## [0.4.0] - 2021-1-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the "mongodb" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [0.4.1] - 2021-2-10
+
+### Changed
+
+- Updated the Atlas link in the overview page (#250)
+
+### Fixed
+
+- Fixed an issue with playground connectivity not defaulting the `directConnection` option to true (VSCODE-234, #255)
+- Fixed an issue around showing an error while editing a playground file without an active MongoDB connection	(VSCODE-231, #251)
+
 ## [0.4.0] - 2021-1-25
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mongodb-vscode",
-  "version": "0.4.1-dev.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "mongodb-vscode",
   "displayName": "MongoDB for VS Code",
   "description": "Connect to MongoDB and Atlas directly from your VS Code environment, navigate your databases and collections, inspect your schema and use playgrounds to prototype queries and aggregations.",
-  "version": "0.4.1-dev.0",
+  "version": "0.4.1",
   "homepage": "https://github.com/mongodb-js/vscode",
   "qna": "https://developer.mongodb.com/community/forums/",
   "repository": {

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -512,7 +512,7 @@ suite('Connection Controller Test Suite', function () {
 
   test('"getConnectionStringFromConnectionId" returns the driver uri of a connection', async () => {
     const expectedDriverUri =
-      'mongodb://localhost:27018/?readPreference=primary&appname=mongodb-vscode%200.4.1-dev.0&ssl=false';
+      'mongodb://localhost:27018/?readPreference=primary&appname=mongodb-vscode%200.4.1&ssl=false';
 
     await testConnectionController.loadSavedConnections();
     await testConnectionController.addNewConnectionStringAndConnect(


### PR DESCRIPTION
VSCODE-233

Changelog changes:

## [0.4.1] - 2021-2-10

### Changed

- Updated the Atlas link in the overview page (#250)

### Fixed

- Fixed an issue with playground connectivity not defaulting the `directConnection` option to true (VSCODE-234, #255)
- Fixed an issue around showing an error while editing a playground file without an active MongoDB connection (VSCODE-231, #251)
