### PR TITLE
Changed Atlas links to https and adjused CTA copy

### DIFF
--- a/src/explorer/helpTree.ts
+++ b/src/explorer/helpTree.ts
@@ -101,7 +101,7 @@ export default class HelpTree implements vscode.TreeDataProvider<vscode.TreeItem
 
       const atlas = new HelpLinkTreeItem(
         'Create Free Atlas Cluster',
-        'http://mongodb.com/products/vs-code/vs-code-atlas-signup?utm_campaign=vs-code-extension&utm_source=visual-studio&utm_medium=product',
+        'https://mongodb.com/products/vs-code/vs-code-atlas-signup?utm_campaign=vs-code-extension&utm_source=visual-studio&utm_medium=product',
         'freeClusterCTA',
         'atlas',
         true

--- a/src/test/suite/explorer/helpExplorer.test.ts
+++ b/src/test/suite/explorer/helpExplorer.test.ts
@@ -44,11 +44,13 @@ suite('Help Explorer Test Suite', function () {
     assert(atlasHelpItem.label === 'Create Free Atlas Cluster');
     assert(
       atlasHelpItem.url ===
-      'http://mongodb.com/products/vs-code/vs-code-atlas-signup?utm_campaign=vs-code-extension&utm_source=visual-studio&utm_medium=product'
+      'https://mongodb.com/products/vs-code/vs-code-atlas-signup?utm_campaign=vs-code-extension&utm_source=visual-studio&utm_medium=product'
     );
     assert(atlasHelpItem.iconName === 'atlas');
     assert(atlasHelpItem.linkId === 'freeClusterCTA');
     assert(atlasHelpItem.useRedirect === true);
+    // The assert below is a bit redundant but will prevent us from redirecting to a non-https URL by mistake
+    assert(atlasHelpItem.url.startsWith('https://') === true);
   });
 
   test('when a help item that does not require a redirect is clicked on it should open the url with vscode', async () => {

--- a/src/test/suite/views/webview-app/components/atlas-cta/atlas-cta.test.tsx
+++ b/src/test/suite/views/webview-app/components/atlas-cta/atlas-cta.test.tsx
@@ -53,7 +53,9 @@ describe('Resources Panel Component Test Suite', () => {
       wrapper.find('a').at(1).simulate('click');
       assert(fakeVscodeWindowPostMessage.called);
       assert(fakeVscodeWindowPostMessage.firstCall.args[0].command === 'OPEN_TRUSTED_LINK');
-      assert(fakeVscodeWindowPostMessage.firstCall.args[0].linkTo === 'http://mongodb.com/products/vs-code/vs-code-atlas-signup?utm_campaign=vs-code-extension&utm_source=visual-studio&utm_medium=product');
+      assert(fakeVscodeWindowPostMessage.firstCall.args[0].linkTo === 'https://mongodb.com/products/vs-code/vs-code-atlas-signup?utm_campaign=vs-code-extension&utm_source=visual-studio&utm_medium=product');
+      // The assert below is a bit redundant but will prevent us from redirecting to a non-https URL by mistake
+      assert(fakeVscodeWindowPostMessage.firstCall.args[0].linkTo.startsWith('https://') === true);
     });
   });
 });

--- a/src/views/webview-app/components/atlas-cta/atlas-cta.tsx
+++ b/src/views/webview-app/components/atlas-cta/atlas-cta.tsx
@@ -19,7 +19,7 @@ type DispatchProps = {
 class AtlasCTA extends React.Component<DispatchProps> {
   onAtlasCtaClicked = (): void => {
     this.props.openTrustedLink(
-      'http://mongodb.com/products/vs-code/vs-code-atlas-signup?utm_campaign=vs-code-extension&utm_source=visual-studio&utm_medium=product'
+      'https://mongodb.com/products/vs-code/vs-code-atlas-signup?utm_campaign=vs-code-extension&utm_source=visual-studio&utm_medium=product'
     );
 
     this.onLinkClicked(
@@ -43,8 +43,7 @@ class AtlasCTA extends React.Component<DispatchProps> {
             <strong>New to MongoDB and don't have a cluster?</strong>
           </div>
           <div>
-            If you don't already have a cluster you can create one for free
-            using&nbsp;
+            Create one for free using&nbsp;
             <a
               className={styles['atlas-cta-text-link']}
               target="_blank"


### PR DESCRIPTION
## Description

Adjusted the Atlas links to go to a `https` page and tweaked the copy in CTA after chatting with product marketing.

![image](https://user-images.githubusercontent.com/761042/107612855-75d05f00-6c47-11eb-901f-217ff86b43b9.png)

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
