### PR TITLE
feat: Add icon for collection documents list refresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -330,7 +330,11 @@
       },
       {
         "command": "mdb.refreshDocumentList",
-        "title": "Refresh"
+        "title": "Refresh",
+        "icon": {
+          "light": "images/light/refresh.svg",
+          "dark": "images/dark/refresh.svg"
+        }
       },
       {
         "command": "mdb.copyCollectionName",
@@ -512,6 +516,11 @@
         },
         {
           "command": "mdb.searchForDocuments",
+          "when": "view == mongoDBConnectionExplorer && viewItem == documentListTreeItem",
+          "group": "inline"
+        },
+        {
+          "command": "mdb.refreshDocumentList",
           "when": "view == mongoDBConnectionExplorer && viewItem == documentListTreeItem",
           "group": "inline"
         },

--- a/src/explorer/collectionTreeItem.ts
+++ b/src/explorer/collectionTreeItem.ts
@@ -325,7 +325,7 @@ export default class CollectionTreeItem extends vscode.TreeItem
     });
   }
 
-  refreshDocumentCount = async (): Promise<boolean> => {
+  refreshDocumentCount = async (): Promise<number> => {
     try {
       // We fetch the document when we expand in order to show
       // the document count in the document list tree item `description`.
@@ -334,10 +334,10 @@ export default class CollectionTreeItem extends vscode.TreeItem
       vscode.window.showInformationMessage(
         `Unable to fetch document count: ${err}`
       );
-      return false;
+      return 0;
     }
 
-    return true;
+    return this.documentCount;
   };
 
   async onDropCollectionClicked(): Promise<boolean> {

--- a/src/explorer/documentListTreeItem.ts
+++ b/src/explorer/documentListTreeItem.ts
@@ -86,7 +86,7 @@ export default class DocumentListTreeItem extends vscode.TreeItem
   // document list tree item, even when it hasn't been expanded.
   // When it is expanded, we want to ensure that number is up to date.
   // This function tells the parent collection folder to refresh the count.
-  refreshDocumentCount: () => Promise<boolean>;
+  refreshDocumentCount: () => Promise<number>;
 
   _documentCount: number | null;
   private _maxDocumentsToShow: number;
@@ -108,7 +108,7 @@ export default class DocumentListTreeItem extends vscode.TreeItem
     isExpanded: boolean,
     maxDocumentsToShow: number,
     cachedDocumentCount: number | null,
-    refreshDocumentCount: () => Promise<boolean>,
+    refreshDocumentCount: () => Promise<number>,
     cacheIsUpToDate: boolean,
     existingCache: Array<DocumentTreeItem | ShowMoreDocumentsTreeItem>
   ) {
@@ -267,11 +267,12 @@ export default class DocumentListTreeItem extends vscode.TreeItem
   }
 
   async resetCache(): Promise<void> {
-    this.isExpanded = false;
     this._childrenCache = [];
     this.cacheIsUpToDate = false;
 
-    await this.refreshDocumentCount();
+    const docCount = await this.refreshDocumentCount();
+    this._documentCount = docCount;
+    this.description = formatDocCount(docCount);
   }
 
   getChildrenCache(): Array<DocumentTreeItem | ShowMoreDocumentsTreeItem> {

--- a/src/test/suite/explorer/documentListTreeItem.test.ts
+++ b/src/test/suite/explorer/documentListTreeItem.test.ts
@@ -22,7 +22,7 @@ suite('DocumentListTreeItem Test Suite', () => {
       false,
       MAX_DOCUMENTS_VISIBLE,
       null,
-      (): Promise<boolean> => Promise.resolve(true),
+      (): Promise<number> => Promise.resolve(25),
       false,
       []
     );
@@ -48,7 +48,7 @@ suite('DocumentListTreeItem Test Suite', () => {
       false,
       MAX_DOCUMENTS_VISIBLE,
       null,
-      (): Promise<boolean> => Promise.resolve(true),
+      (): Promise<number> => Promise.resolve(25),
       false,
       []
     );
@@ -78,7 +78,7 @@ suite('DocumentListTreeItem Test Suite', () => {
         false,
         MAX_DOCUMENTS_VISIBLE,
         null,
-        (): Promise<boolean> => Promise.resolve(true),
+        (): Promise<number> => Promise.resolve(25),
         false,
         []
       );
@@ -99,7 +99,7 @@ suite('DocumentListTreeItem Test Suite', () => {
         false,
         MAX_DOCUMENTS_VISIBLE,
         null,
-        (): Promise<boolean> => Promise.resolve(true),
+        (): Promise<number> => Promise.resolve(25),
         false,
         []
       );
@@ -122,7 +122,7 @@ suite('DocumentListTreeItem Test Suite', () => {
       false,
       MAX_DOCUMENTS_VISIBLE,
       null,
-      (): Promise<boolean> => Promise.resolve(true),
+      (): Promise<number> => Promise.resolve(25),
       false,
       []
     );
@@ -142,7 +142,7 @@ suite('DocumentListTreeItem Test Suite', () => {
       false,
       MAX_DOCUMENTS_VISIBLE,
       25,
-      (): Promise<boolean> => Promise.resolve(true),
+      (): Promise<number> => Promise.resolve(25),
       false,
       []
     );
@@ -169,7 +169,7 @@ suite('DocumentListTreeItem Test Suite', () => {
       false,
       MAX_DOCUMENTS_VISIBLE,
       25,
-      (): Promise<boolean> => Promise.resolve(true),
+      (): Promise<number> => Promise.resolve(25),
       false,
       []
     );
@@ -196,7 +196,7 @@ suite('DocumentListTreeItem Test Suite', () => {
       false,
       MAX_DOCUMENTS_VISIBLE,
       25,
-      (): Promise<boolean> => Promise.resolve(true),
+      (): Promise<number> => Promise.resolve(25),
       false,
       []
     );
@@ -228,7 +228,7 @@ suite('DocumentListTreeItem Test Suite', () => {
       false,
       MAX_DOCUMENTS_VISIBLE,
       25,
-      (): Promise<boolean> => Promise.resolve(true),
+      (): Promise<number> => Promise.resolve(25),
       false,
       []
     );
@@ -261,9 +261,9 @@ suite('DocumentListTreeItem Test Suite', () => {
       false,
       MAX_DOCUMENTS_VISIBLE,
       maxDocs,
-      (): Promise<boolean> => {
+      (): Promise<number> => {
         maxDocs = 25;
-        return Promise.resolve(true);
+        return Promise.resolve(25);
       },
       false,
       []
@@ -278,7 +278,7 @@ suite('DocumentListTreeItem Test Suite', () => {
       false,
       MAX_DOCUMENTS_VISIBLE,
       maxDocs,
-      (): Promise<boolean> => Promise.resolve(true),
+      (): Promise<number> => Promise.resolve(25),
       false,
       []
     );
@@ -303,7 +303,7 @@ suite('DocumentListTreeItem Test Suite', () => {
       false,
       MAX_DOCUMENTS_VISIBLE,
       null,
-      (): Promise<boolean> => Promise.resolve(true),
+      (): Promise<number> => Promise.resolve(25),
       false,
       []
     );
@@ -322,7 +322,7 @@ suite('DocumentListTreeItem Test Suite', () => {
       false,
       MAX_DOCUMENTS_VISIBLE,
       null,
-      (): Promise<boolean> => Promise.resolve(true),
+      (): Promise<number> => Promise.resolve(25),
       false,
       []
     );
@@ -343,7 +343,7 @@ suite('DocumentListTreeItem Test Suite', () => {
       false,
       MAX_DOCUMENTS_VISIBLE,
       25,
-      (): Promise<boolean> => Promise.resolve(true),
+      (): Promise<number> => Promise.resolve(25),
       false,
       []
     );
@@ -360,7 +360,7 @@ suite('DocumentListTreeItem Test Suite', () => {
       false,
       MAX_DOCUMENTS_VISIBLE,
       2200000,
-      (): Promise<boolean> => Promise.resolve(true),
+      (): Promise<number> => Promise.resolve(25),
       false,
       []
     );

--- a/src/test/suite/mdbExtensionController.test.ts
+++ b/src/test/suite/mdbExtensionController.test.ts
@@ -481,10 +481,6 @@ suite('MDBExtensionController Test Suite', function () {
       'Expected document list cache to be out of date.'
     );
     assert(
-      docListTreeItem.isExpanded === false,
-      'Expected document list cache to be out of date.'
-    );
-    assert(
       mockTreeItem.documentCount === 10000,
       `Expected document count to be 10000, found ${mockTreeItem.documentCount}.`
     );


### PR DESCRIPTION
This PR adds an icon to the documents list to refresh them.
Motivation https://feedback.mongodb.com/forums/929236-mongodb-for-vs-code/suggestions/42462064-refresh-button-or-automatic-refresh-for-the-collec

Would like to revisit how we structure/render all of the tree elements, it could be done in a cleaner way. Works though, maybe in a later pr.


https://user-images.githubusercontent.com/1791149/108073087-f0461800-7067-11eb-8cee-525ca7392828.mp4

