### PR TITLE
Autocomplete details

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1792,6 +1792,17 @@
         "pretty-repl": "^2.3.1",
         "semver": "^7.1.2",
         "text-table": "^0.2.0"
+      },
+      "dependencies": {
+        "@mongosh/i18n": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/@mongosh/i18n/-/i18n-0.6.1.tgz",
+          "integrity": "sha512-8Jsf1nKGNwLuQkM/WYFgKbr9Zvaqg6YBujuYe1rzKeHN51ihKTTPpI4U5Ytl+1HsgMbjTcNegpsz8EsDg5xp/Q==",
+          "requires": {
+            "@mongosh/errors": "^0.6.1",
+            "mustache": "^4.0.0"
+          }
+        }
       }
     },
     "@mongosh/errors": {
@@ -1808,12 +1819,19 @@
       }
     },
     "@mongosh/i18n": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@mongosh/i18n/-/i18n-0.6.1.tgz",
-      "integrity": "sha512-8Jsf1nKGNwLuQkM/WYFgKbr9Zvaqg6YBujuYe1rzKeHN51ihKTTPpI4U5Ytl+1HsgMbjTcNegpsz8EsDg5xp/Q==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@mongosh/i18n/-/i18n-0.8.0.tgz",
+      "integrity": "sha512-sBGzsTuiEIYv4VgzzpC7wJdgxRj3id1bd8SwYeyAtyhLIvkeSRDrKe3jaQ9WXzpbyJtu4Czip1QXOxzdXKL7yQ==",
       "requires": {
-        "@mongosh/errors": "^0.6.1",
+        "@mongosh/errors": "0.8.0",
         "mustache": "^4.0.0"
+      },
+      "dependencies": {
+        "@mongosh/errors": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/@mongosh/errors/-/errors-0.8.0.tgz",
+          "integrity": "sha512-sDYnQrpvj1MdDCII5mjmvf2yxop7/d14mhVyIaelfNZg2RIHbO92t6YA0rXlVT2a+1X2bb33iCGyLzqh804A3g=="
+        }
       }
     },
     "@mongosh/service-provider-core": {
@@ -1825,6 +1843,17 @@
         "@mongosh/i18n": "^0.6.1",
         "bson": "^4.2.0",
         "mongodb-build-info": "^1.1.1"
+      },
+      "dependencies": {
+        "@mongosh/i18n": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/@mongosh/i18n/-/i18n-0.6.1.tgz",
+          "integrity": "sha512-8Jsf1nKGNwLuQkM/WYFgKbr9Zvaqg6YBujuYe1rzKeHN51ihKTTPpI4U5Ytl+1HsgMbjTcNegpsz8EsDg5xp/Q==",
+          "requires": {
+            "@mongosh/errors": "^0.6.1",
+            "mustache": "^4.0.0"
+          }
+        }
       }
     },
     "@mongosh/service-provider-server": {
@@ -1858,6 +1887,17 @@
         "@mongosh/i18n": "^0.6.1",
         "@mongosh/service-provider-core": "^0.6.1",
         "mongodb-redact": "^0.2.2"
+      },
+      "dependencies": {
+        "@mongosh/i18n": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/@mongosh/i18n/-/i18n-0.6.1.tgz",
+          "integrity": "sha512-8Jsf1nKGNwLuQkM/WYFgKbr9Zvaqg6YBujuYe1rzKeHN51ihKTTPpI4U5Ytl+1HsgMbjTcNegpsz8EsDg5xp/Q==",
+          "requires": {
+            "@mongosh/errors": "^0.6.1",
+            "mustache": "^4.0.0"
+          }
+        }
       }
     },
     "@mongosh/shell-evaluator": {

--- a/package.json
+++ b/package.json
@@ -868,7 +868,7 @@
     "@iconify/react": "^1.1.3",
     "@leafygreen-ui/toggle": "3.0.1",
     "@mongosh/browser-runtime-electron": "^0.6.1",
-    "@mongosh/i18n": "^0.6.1",
+    "@mongosh/i18n": "^0.8.0",
     "@mongosh/service-provider-server": "^0.6.1",
     "@mongosh/shell-api": "^0.6.1",
     "analytics-node": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -868,7 +868,7 @@
     "@iconify/react": "^1.1.3",
     "@leafygreen-ui/toggle": "3.0.1",
     "@mongosh/browser-runtime-electron": "^0.6.1",
-    "@mongosh/i18n": "^0.8.0",
+    "@mongosh/i18n": "^0.6.1",
     "@mongosh/service-provider-server": "^0.6.1",
     "@mongosh/shell-api": "^0.6.1",
     "analytics-node": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -868,6 +868,7 @@
     "@iconify/react": "^1.1.3",
     "@leafygreen-ui/toggle": "3.0.1",
     "@mongosh/browser-runtime-electron": "^0.6.1",
+    "@mongosh/i18n": "^0.8.0",
     "@mongosh/service-provider-server": "^0.6.1",
     "@mongosh/shell-api": "^0.6.1",
     "analytics-node": "^3.5.0",

--- a/src/language/mongoDBService.ts
+++ b/src/language/mongoDBService.ts
@@ -4,6 +4,7 @@ import { CompletionItemKind, CancellationToken, Connection, CompletionItem } fro
 import fs from 'fs';
 import path from 'path';
 import { signatures } from '@mongosh/shell-api';
+import Translator from '@mongosh/i18n/lib/translator';
 import { Worker as WorkerThreads } from 'worker_threads';
 
 import { CollectionItem } from '../types/collectionItemType';
@@ -398,14 +399,21 @@ export default class MongoDBService {
   // Get shell API symbols/methods completion from mongosh.
   _getShellCompletionItems(): ShellCompletionItem {
     const shellSymbols = {};
+    const translator = new Translator();
 
     Object.keys(signatures).map((symbol) => {
       shellSymbols[symbol] = Object.keys(
         signatures[symbol].attributes || {}
-      ).map((item) => ({
-        label: item,
-        kind: CompletionItemKind.Method
-      }));
+      ).map((item) => {
+        const documentation = translator.translate(`shell-api.classes.${symbol}.help.attributes.${item}.description`) || '';
+        const detail = translator.translate(`shell-api.classes.${symbol}.help.attributes.${item}.example`) || '';
+        return {
+          label: item,
+          kind: CompletionItemKind.Method,
+          documentation,
+          detail
+        };
+      });
     });
 
     return shellSymbols;

--- a/src/language/mongoDBService.ts
+++ b/src/language/mongoDBService.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-sync */
 import * as util from 'util';
-import { CompletionItemKind, CancellationToken, Connection, CompletionItem } from 'vscode-languageserver';
+import { CompletionItemKind, CancellationToken, Connection, CompletionItem, MarkupContent, MarkupKind } from 'vscode-languageserver';
 import fs from 'fs';
 import path from 'path';
 import { signatures } from '@mongosh/shell-api';
@@ -406,11 +406,18 @@ export default class MongoDBService {
         signatures[symbol].attributes || {}
       ).map((item) => {
         const documentation = translator.translate(`shell-api.classes.${symbol}.help.attributes.${item}.description`) || '';
+        const link = translator.translate(`shell-api.classes.${symbol}.help.attributes.${item}.link`) || '';
         const detail = translator.translate(`shell-api.classes.${symbol}.help.attributes.${item}.example`) || '';
+
+        const markdownDocumentation: MarkupContent = {
+          kind: MarkupKind.Markdown,
+          value: link ? `${documentation}\n\n[Read More](${link})` : documentation
+        };
+
         return {
           label: item,
           kind: CompletionItemKind.Method,
-          documentation,
+          documentation: markdownDocumentation,
           detail
         };
       });

--- a/src/test/suite/language/mongoDBService.test.ts
+++ b/src/test/suite/language/mongoDBService.test.ts
@@ -106,7 +106,7 @@ suite('MongoDBService Test Suite', () => {
     const testMongoDBService = new MongoDBService(connection);
 
     before(async () => {
-      testMongoDBService._getDatabasesCompletionItems = (): void => {};
+      testMongoDBService._getDatabasesCompletionItems = (): void => { };
       testMongoDBService._getCollectionsCompletionItems = (): Promise<boolean> =>
         Promise.resolve(true);
       testMongoDBService._getFieldsCompletionItems = (): Promise<boolean> =>
@@ -642,6 +642,12 @@ suite('MongoDBService Test Suite', () => {
         'kind',
         CompletionItemKind.Method
       );
+      expect(findShellCompletion).to.have.property(
+        'documentation'
+      );
+      expect(findShellCompletion).to.have.property(
+        'detail'
+      );
     });
 
     test('provide only collection names and shell db symbol completion after find cursor', async () => {
@@ -672,6 +678,12 @@ suite('MongoDBService Test Suite', () => {
       expect(findShellCompletion).to.have.property(
         'kind',
         CompletionItemKind.Method
+      );
+      expect(findShellCompletion).to.have.property(
+        'documentation'
+      );
+      expect(findShellCompletion).to.have.property(
+        'detail'
       );
       expect(findCursorCompletion).to.be.undefined;
     });
@@ -710,6 +722,12 @@ suite('MongoDBService Test Suite', () => {
       expect(findShellCompletion).to.have.property(
         'kind',
         CompletionItemKind.Method
+      );
+      expect(findShellCompletion).to.have.property(
+        'documentation'
+      );
+      expect(findShellCompletion).to.have.property(
+        'detail'
       );
       expect(findCursorCompletion).to.be.undefined;
     });


### PR DESCRIPTION
Given that we are pulling the autocomplete symbols from the shell API, we can pull the documentation details from there too.

![Feb-22-2021 08-19-58](https://user-images.githubusercontent.com/761042/108675752-8609f900-74e7-11eb-95ee-7a29c38f277d.gif)

## Description

This change pulls in the shell's `i18n` package and uses that to enrich the shell `CompletionItem`s with an example and a one-sentence explanation of what the command does. Unfortunately it does not look like the CompletionItem API supports links.

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
That string that is passed to `Translator.translate()` is overly verbose but there does not seem to be a way around that.

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
