### PR TITLE
fix: make tests work with changed vscode clipboard object VSCODE-241

### DIFF
--- a/src/test/suite/mdbExtensionController.test.ts
+++ b/src/test/suite/mdbExtensionController.test.ts
@@ -250,7 +250,7 @@ suite('MDBExtensionController Test Suite', function () {
     );
 
     const mockCopyToClipboard: any = sinon.fake();
-    sinon.replace(vscode.env.clipboard, 'writeText', mockCopyToClipboard);
+    sinon.replaceGetter(vscode.env, 'clipboard', () => ({ writeText: mockCopyToClipboard, readText: sinon.fake() as any }));
 
     const mockStubUri: any = sinon.fake.returns('weStubThisUri');
     sinon.replace(
@@ -284,7 +284,7 @@ suite('MDBExtensionController Test Suite', function () {
     );
 
     const mockCopyToClipboard: any = sinon.fake();
-    sinon.replace(vscode.env.clipboard, 'writeText', mockCopyToClipboard);
+    sinon.replaceGetter(vscode.env, 'clipboard', () => ({ writeText: mockCopyToClipboard, readText: sinon.fake() as any }));
 
     vscode.commands
       .executeCommand('mdb.copyDatabaseName', mockTreeItem)
@@ -315,7 +315,7 @@ suite('MDBExtensionController Test Suite', function () {
     );
 
     const mockCopyToClipboard: any = sinon.fake();
-    sinon.replace(vscode.env.clipboard, 'writeText', mockCopyToClipboard);
+    sinon.replaceGetter(vscode.env, 'clipboard', () => ({ writeText: mockCopyToClipboard, readText: sinon.fake() as any }));
 
     vscode.commands
       .executeCommand('mdb.copyCollectionName', mockTreeItem)
@@ -345,7 +345,7 @@ suite('MDBExtensionController Test Suite', function () {
     );
 
     const mockCopyToClipboard: any = sinon.fake();
-    sinon.replace(vscode.env.clipboard, 'writeText', mockCopyToClipboard);
+    sinon.replaceGetter(vscode.env, 'clipboard', () => ({ writeText: mockCopyToClipboard, readText: sinon.fake() as any }));
 
     const commandResult = await vscode.commands.executeCommand(
       'mdb.copySchemaFieldName',


### PR DESCRIPTION
We can’t modify a frozen object, which `vscode.env.clipboard` has
recently become.

Refs: https://github.com/microsoft/vscode/commit/4cfd5f850806fd293d5ca6e988c612a5514f93b3#diff-635fc88732ee6c5c620c7b69dc4b9a56ba478d96505aec360fce3d6fa6b8c314

<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
