### PR TITLE
fix(explorer): Mark dropped db/coll tree item; Do not re-create dropped items in children cache VSCODE-244

### DIFF
--- a/src/explorer/collectionTreeItem.ts
+++ b/src/explorer/collectionTreeItem.ts
@@ -375,7 +375,7 @@ export default class CollectionTreeItem extends vscode.TreeItem
     return new Promise((resolve) => {
       this._dataService.dropCollection(
         `${this.databaseName}.${collectionName}`,
-        (err, successfullyDroppedCollection) => {
+        (err: Error | null, successfullyDroppedCollection = false) => {
           if (err) {
             vscode.window.showErrorMessage(
               `Drop collection failed: ${err.message}`
@@ -383,7 +383,7 @@ export default class CollectionTreeItem extends vscode.TreeItem
             return resolve(false);
           }
 
-          this.isDropped = true;
+          this.isDropped = successfullyDroppedCollection;
 
           return resolve(successfullyDroppedCollection);
         }

--- a/src/explorer/collectionTreeItem.ts
+++ b/src/explorer/collectionTreeItem.ts
@@ -74,6 +74,8 @@ export default class CollectionTreeItem extends vscode.TreeItem
 
   cacheIsUpToDate = false;
 
+  isDropped = false;
+
   constructor(
     collection: CollectionModelType,
     databaseName: string,
@@ -380,6 +382,8 @@ export default class CollectionTreeItem extends vscode.TreeItem
             );
             return resolve(false);
           }
+
+          this.isDropped = true;
 
           return resolve(successfullyDroppedCollection);
         }

--- a/src/explorer/connectionTreeItem.ts
+++ b/src/explorer/connectionTreeItem.ts
@@ -110,6 +110,7 @@ export default class ConnectionTreeItem extends vscode.TreeItem
     }
 
     const dataService = this._connectionController.getActiveDataService();
+
     if (dataService === null) {
       throw new Error('Not currently connected.');
     }
@@ -121,12 +122,18 @@ export default class ConnectionTreeItem extends vscode.TreeItem
       // We create a new database tree item here instead of reusing the
       // cached one in order to ensure the expanded state is set.
       Object.keys(pastChildrenCache).forEach((databaseName) => {
+        const prevChild = pastChildrenCache[databaseName];
+
+        if (prevChild.isDropped) {
+          return;
+        }
+
         this._childrenCache[databaseName] = new DatabaseTreeItem(
           databaseName,
           dataService,
-          pastChildrenCache[databaseName].isExpanded,
-          pastChildrenCache[databaseName].cacheIsUpToDate,
-          pastChildrenCache[databaseName].getChildrenCache()
+          prevChild.isExpanded,
+          prevChild.cacheIsUpToDate,
+          prevChild.getChildrenCache()
         );
       });
 

--- a/src/explorer/databaseTreeItem.ts
+++ b/src/explorer/databaseTreeItem.ts
@@ -272,18 +272,21 @@ export default class DatabaseTreeItem extends vscode.TreeItem
     }
 
     return new Promise((resolve) => {
-      this._dataService.dropDatabase(databaseName, (err) => {
-        if (err) {
-          vscode.window.showErrorMessage(
-            `Drop database failed: ${err.message}`
-          );
-          return resolve(false);
+      this._dataService.dropDatabase(
+        databaseName,
+        (err: Error | null, successfullyDroppedDatabase = false) => {
+          if (err) {
+            vscode.window.showErrorMessage(
+              `Drop database failed: ${err.message}`
+            );
+            return resolve(false);
+          }
+
+          this.isDropped = successfullyDroppedDatabase;
+
+          return resolve(successfullyDroppedDatabase);
         }
-
-        this.isDropped = true;
-
-        return resolve(true);
-      });
+      );
     });
   }
 }

--- a/src/explorer/databaseTreeItem.ts
+++ b/src/explorer/databaseTreeItem.ts
@@ -30,6 +30,8 @@ export default class DatabaseTreeItem extends vscode.TreeItem
   databaseName: string;
   isExpanded: boolean;
 
+  isDropped = false;
+
   constructor(
     databaseName: string,
     dataService: any,
@@ -88,16 +90,22 @@ export default class DatabaseTreeItem extends vscode.TreeItem
 
       // We manually rebuild each node to ensure we update the expanded state.
       Object.keys(pastChildrenCache).forEach((collectionName) => {
+        const prevChild = pastChildrenCache[collectionName];
+
+        if (prevChild.isDropped) {
+          return;
+        }
+
         this._childrenCache[collectionName] = new CollectionTreeItem(
-          pastChildrenCache[collectionName].collection,
+          prevChild.collection,
           this.databaseName,
           this._dataService,
-          pastChildrenCache[collectionName].isExpanded,
-          pastChildrenCache[collectionName].cacheIsUpToDate,
-          pastChildrenCache[collectionName].documentCount,
-          pastChildrenCache[collectionName].getDocumentListChild(),
-          pastChildrenCache[collectionName].getSchemaChild(),
-          pastChildrenCache[collectionName].getIndexListChild()
+          prevChild.isExpanded,
+          prevChild.cacheIsUpToDate,
+          prevChild.documentCount,
+          prevChild.getDocumentListChild(),
+          prevChild.getSchemaChild(),
+          prevChild.getIndexListChild()
         );
       });
 
@@ -272,7 +280,8 @@ export default class DatabaseTreeItem extends vscode.TreeItem
           return resolve(false);
         }
 
-        this.cacheIsUpToDate = false;
+        this.isDropped = true;
+
         return resolve(true);
       });
     });


### PR DESCRIPTION
Fixes the issue with dropped collections and databases still being displayed in the explorer tree view due to cache still keeping a reference to them. This PR addresses the issue by introducing new `isDropped` property for db/coll that their parent tree view can use to prune cache on refresh

![Kapture 2021-04-21 at 18 03 05](https://user-images.githubusercontent.com/5036933/115585411-dd4ffe00-a2cb-11eb-8360-fc9cfa9f59cd.gif)

