### PR TITLE
fix: save big files without error and preserve playground focus

### DIFF
--- a/src/editors/editorsController.ts
+++ b/src/editors/editorsController.ts
@@ -158,7 +158,7 @@ export default class EditorsController {
     const activeEditor = vscode.window.activeTextEditor;
 
     if (!activeEditor) {
-      vscode.window.showErrorMessage('Unable to save mongodb document: The active editor cannot be found');
+      await vscode.commands.executeCommand('workbench.action.files.save');
 
       return false;
     }

--- a/src/editors/playgroundController.ts
+++ b/src/editors/playgroundController.ts
@@ -391,6 +391,7 @@ export default class PlaygroundController {
   async _showResultAsVirtualDocument(): Promise<void> {
     await vscode.window.showTextDocument(PLAYGROUND_RESULT_URI, {
       preview: false,
+      preserveFocus: true,
       viewColumn: this._playgroundResultViewColumn || vscode.ViewColumn.Beside
     });
   }

--- a/src/test/suite/editors/editorsController.test.ts
+++ b/src/test/suite/editors/editorsController.test.ts
@@ -44,13 +44,16 @@ suite('Editors Controller Test Suite', () => {
 
   test('saveMongoDBDocument returns false if there is no active editor', async () => {
     sandbox.replaceGetter(vscode.window, 'activeTextEditor', () => undefined);
-    sinon.replace(vscode.window, 'showErrorMessage', sinon.fake());
+
+    const fakeShowErrorMessage: any = sinon.fake();
+    sinon.replace(vscode.window, 'showErrorMessage', fakeShowErrorMessage);
 
     const result = await vscode.commands.executeCommand(
       'mdb.saveMongoDBDocument'
     );
 
     expect(result).to.be.equal(false);
+    expect(fakeShowErrorMessage.firstArg).to.be.equal(null);
   });
 
   test('saveMongoDBDocument returns false if this is not a mongodb document', async () => {

--- a/src/test/suite/editors/playgroundController.test.ts
+++ b/src/test/suite/editors/playgroundController.test.ts
@@ -342,6 +342,19 @@ suite('Playground Controller Test Suite', function () {
         await testPlaygroundController._connectToServiceProvider();
       });
 
+      test('keep a playground in focus after running it', async () => {
+        const mockShowTextDocument: any = sinon.fake();
+        sinon.replace(vscode.window, 'showTextDocument', mockShowTextDocument);
+
+        await testPlaygroundController._showResultAsVirtualDocument();
+
+        const showTextDocumentOptions = mockShowTextDocument.lastArg;
+
+        expect(showTextDocumentOptions.preview).to.be.equal(false);
+        expect(showTextDocumentOptions.preserveFocus).to.be.equal(true);
+        expect(showTextDocumentOptions.viewColumn).to.be.equal(-2);
+      });
+
       test('show a confirmation message if mdb.confirmRunAll is true', async () => {
         fakeShowInformationMessage.resolves('Yes');
 


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

1) Preserve focus after running playgrounds to be able quickly to make additional changes and run the playground again: https://jira.mongodb.org/browse/VSCODE-214

- Related issue: https://github.com/mongodb-js/vscode/issues/222
- Note: We made a decision to preserve focus by default and do not make it configurable in settings.

2) For large files VSCode turns off tokenization, wrapping, and folding in order to reduce memory usage and avoid freezing or crashing. This causes situations when the file is open, but the `vscode.window.activeTextEditor` is `undefined`. This PR removes throwing an error when there is no active editor and keeps the default behavior for such files, that is saving files to disc: https://jira.mongodb.org/browse/VSCODE-250

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
