### PR TITLE
chore: Add segment telemetry id to create atlas cluster

### DIFF
--- a/src/explorer/helpTree.ts
+++ b/src/explorer/helpTree.ts
@@ -43,6 +43,7 @@ export class HelpLinkTreeItem extends vscode.TreeItem {
 
 export default class HelpTree implements vscode.TreeDataProvider<vscode.TreeItem> {
   contextValue = 'helpTree';
+  _telemetryService?: TelemetryService;
 
   getTreeItem(element: vscode.TreeItem): vscode.TreeItem {
     return element;
@@ -52,6 +53,7 @@ export default class HelpTree implements vscode.TreeDataProvider<vscode.TreeItem
     treeView: vscode.TreeView<vscode.TreeItem>,
     telemetryService: TelemetryService
   ): void => {
+    this._telemetryService = telemetryService;
     treeView.onDidChangeSelection(async (event: any) => {
       if (event.selection && event.selection.length === 1) {
         const selectedItem = event.selection[0];
@@ -99,9 +101,11 @@ export default class HelpTree implements vscode.TreeDataProvider<vscode.TreeItem
         'report'
       );
 
+      const userId = this._telemetryService?.getSegmentUserId();
+      const segmentId = userId ? `&ajs_aid=${userId}` : '';
       const atlas = new HelpLinkTreeItem(
         'Create Free Atlas Cluster',
-        'https://mongodb.com/products/vs-code/vs-code-atlas-signup?utm_campaign=vs-code-extension&utm_source=visual-studio&utm_medium=product',
+        `https://mongodb.com/products/vs-code/vs-code-atlas-signup?utm_campaign=vs-code-extension&utm_source=visual-studio&utm_medium=product${segmentId}`,
         'freeClusterCTA',
         'atlas',
         true

--- a/src/telemetry/telemetryService.ts
+++ b/src/telemetry/telemetryService.ts
@@ -250,6 +250,10 @@ export default class TelemetryService {
     return 'other';
   }
 
+  getSegmentUserId(): string {
+    return this._segmentUserID;
+  }
+
   trackPlaygroundCodeExecuted(
     result: ShellExecuteAllResult,
     partial: boolean,

--- a/src/test/suite/explorer/helpExplorer.test.ts
+++ b/src/test/suite/explorer/helpExplorer.test.ts
@@ -41,13 +41,13 @@ suite('Help Explorer Test Suite', function () {
     const helpTreeItems = await testHelpExplorer._treeController.getChildren();
     const atlasHelpItem = helpTreeItems[5];
 
-    assert(atlasHelpItem.label === 'Create Free Atlas Cluster');
-    assert(
-      atlasHelpItem.url ===
-      'https://mongodb.com/products/vs-code/vs-code-atlas-signup?utm_campaign=vs-code-extension&utm_source=visual-studio&utm_medium=product'
+    assert.strictEqual(atlasHelpItem.label, 'Create Free Atlas Cluster');
+    assert.strictEqual(
+      atlasHelpItem.url,
+      `https://mongodb.com/products/vs-code/vs-code-atlas-signup?utm_campaign=vs-code-extension&utm_source=visual-studio&utm_medium=product&ajs_aid=${mdbTestExtension.testExtensionController._telemetryService.getSegmentUserId()}`
     );
-    assert(atlasHelpItem.iconName === 'atlas');
-    assert(atlasHelpItem.linkId === 'freeClusterCTA');
+    assert.strictEqual(atlasHelpItem.iconName, 'atlas');
+    assert.strictEqual(atlasHelpItem.linkId, 'freeClusterCTA');
     assert(atlasHelpItem.useRedirect === true);
     // The assert below is a bit redundant but will prevent us from redirecting to a non-https URL by mistake
     assert(atlasHelpItem.url.startsWith('https://') === true);

--- a/src/test/suite/telemetry/telemetryService.test.ts
+++ b/src/test/suite/telemetry/telemetryService.test.ts
@@ -90,6 +90,8 @@ suite('Telemetry Controller Test Suite', () => {
     expect(segmentKey).to.be.equal(process.env.SEGMENT_KEY);
     expect(testTelemetryService._segmentKey).to.be.a('string');
     expect(testTelemetryService._segmentUserID).to.be.a('string');
+    expect(testTelemetryService.getSegmentUserId()).to.be.a('string');
+    expect(testTelemetryService.getSegmentUserId()).to.equal(testTelemetryService._segmentUserID);
   });
 
   test('track command run event', async () => {


### PR DESCRIPTION
Follow up on https://github.com/mongodb-js/vscode/pull/302 since there's another link spot I missed.

Attach anonymous ID of user to the url of the cta link to Atlas VSCODE-249