### PR TITLE
fix(tree-explorer): dont show message when cannot fetch estimated count VSCODE-268

### DIFF
--- a/src/explorer/collectionTreeItem.ts
+++ b/src/explorer/collectionTreeItem.ts
@@ -73,7 +73,7 @@ export default class CollectionTreeItem extends vscode.TreeItem
 
   private _dataService: any;
   private _type: CollectionTypes;
-  documentCount: number | null;
+  documentCount: number | null = null;
 
   isExpanded: boolean;
 
@@ -333,6 +333,15 @@ export default class CollectionTreeItem extends vscode.TreeItem
   }
 
   refreshDocumentCount = async (): Promise<number> => {
+    // Skip the count on views and time-series collections since it will error.
+    if (
+      this._type === CollectionTypes.view ||
+      this._type === CollectionTypes.timeseries
+    ) {
+      this.documentCount = null;
+      return 0;
+    }
+
     try {
       // We fetch the document when we expand in order to show
       // the document count in the document list tree item `description`.

--- a/src/explorer/collectionTreeItem.ts
+++ b/src/explorer/collectionTreeItem.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-const path = require('path');
+import path from 'path';
 
 import { createLogger } from '../logging';
 import DocumentListTreeItem, {
@@ -338,9 +338,6 @@ export default class CollectionTreeItem extends vscode.TreeItem
       // the document count in the document list tree item `description`.
       this.documentCount = await this.getCount();
     } catch (err) {
-      vscode.window.showInformationMessage(
-        `Unable to fetch document count: ${err}`
-      );
       return 0;
     }
 


### PR DESCRIPTION
VSCODE-268

Small change to quietly handle when getting the estimated count on a collections fails, since views and time-series collections error with `estimatedDocumentCount`. 