### PR TITLE
chore: replace formatOnSave with fixAll.eslint

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,9 @@
 // Place your settings in this file to overwrite default and user settings.
 {
-  "editor.formatOnSave": true,
+  "editor.formatOnSave": false,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
   "editor.tabSize": 2,
   // Insert spaces when pressing Tab.
   "editor.insertSpaces": true,
@@ -15,8 +18,6 @@
   },
   // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
   "typescript.tsc.autoDetect": "off",
-  "prettier.singleQuote": true,
-  "prettier.arrowParens": "always",
   // Language server logging for
   // https://github.com/Microsoft/language-server-protocol-inspector
   "mongodbLanguageServer.trace.server": {


### PR DESCRIPTION
That setting gave me a few headaches since VSCode was formatting the code in a way eslint didn't like.

I suggest to replace it with something more true to our style rules. ... also dropping the auto save entirely unless we find it super useful wouldn't be all that bad. 
