### PR TITLE
feat(data-explorer): Add support for solo db users VSCODE-157

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "mongodb-cloud-info": "^1.1.2",
         "mongodb-connection-model": "^21.5.3",
         "mongodb-data-service": "^21.5.3",
+        "mongodb-js-errors": "^0.5.0",
         "mongodb-ns": "^2.2.0",
         "mongodb-schema": "^8.2.5",
         "numeral": "^2.0.6",

--- a/package.json
+++ b/package.json
@@ -882,6 +882,7 @@
     "mongodb-cloud-info": "^1.1.2",
     "mongodb-connection-model": "^21.5.3",
     "mongodb-data-service": "^21.5.3",
+    "mongodb-js-errors": "^0.5.0",
     "mongodb-ns": "^2.2.0",
     "mongodb-schema": "^8.2.5",
     "numeral": "^2.0.6",

--- a/src/explorer/connectionTreeItem.ts
+++ b/src/explorer/connectionTreeItem.ts
@@ -142,13 +142,9 @@ export default class ConnectionTreeItem extends vscode.TreeItem
       return dbs;
     } catch (err) {
       if (isNotAuthorized(err)) {
-        console.log('got auth error, try');
-
         // Check for which databases privilages this user has, and list those.
         return this.listDatabasesUserHasAccessTo(dataService.client.client);
       }
-      console.log('got error from list dbs', err);
-
 
       throw new Error(`Unable to list databases: ${err.message}`);
     }

--- a/src/test/suite/dbTestHelper.ts
+++ b/src/test/suite/dbTestHelper.ts
@@ -1,7 +1,11 @@
 import Connection = require('mongodb-connection-model/lib/model');
 import DataService = require('mongodb-data-service');
 
+export const TEST_USER_USERNAME = 'testUser';
+export const TEST_USER_PASSWORD = 'password';
+
 export const TEST_DATABASE_URI = 'mongodb://localhost:27018';
+export const TEST_DATABASE_URI_USER = `mongodb://${TEST_USER_USERNAME}:${TEST_USER_PASSWORD}@localhost:27018`;
 
 export const TEST_DB_NAME = 'vscodeTestDatabaseAA';
 

--- a/src/test/suite/explorer/connectionTreeItem.test.ts
+++ b/src/test/suite/explorer/connectionTreeItem.test.ts
@@ -1,8 +1,41 @@
+/* eslint-disable @typescript-eslint/no-unsafe-return */
 import assert from 'assert';
+import * as vscode from 'vscode';
+import { beforeEach, afterEach } from 'mocha';
+import sinon from 'sinon';
+import { MongoClient } from 'mongodb';
 
 const { contributes } = require('../../../../package.json');
 
-import { ConnectionItemContextValues } from '../../../explorer/connectionTreeItem';
+import ConnectionTreeItem, {
+  ConnectionItemContextValues,
+  getDatabaseNamesFromPrivileges
+} from '../../../explorer/connectionTreeItem';
+import { mdbTestExtension } from '../stubbableMdbExtension';
+import { DataServiceStub } from '../stubs';
+import { TEST_DATABASE_URI, TEST_DATABASE_URI_USER, TEST_USER_PASSWORD, TEST_USER_USERNAME } from '../dbTestHelper';
+
+const mockPrivileges = [{}, {
+  resource: {
+    db: 'db2',
+    roles: ['readWrite', 'listCollections']
+  }
+}, {
+  resource: {
+    db: 'db3',
+    roles: ['readWrite', 'listCollections']
+  }
+}, {
+  resource: {
+    db: 'pineapple',
+    roles: ['read', 'listCollections']
+  },
+}, {
+  resource: {
+    db: 'db1',
+    roles: ['readWrite', 'listCollections']
+  }
+}];
 
 suite('ConnectionTreeItem Test Suite', () => {
   test('its context value should be in the package json', function () {
@@ -26,5 +59,244 @@ suite('ConnectionTreeItem Test Suite', () => {
       disconnectedRegisteredCommandInPackageJson,
       'Expected disconnected connection tree item to be registered with a command in package json'
     );
+  });
+
+  suite('#getChildren', () => {
+    let testConnectionTreeItem: ConnectionTreeItem;
+
+    beforeEach(() => {
+      testConnectionTreeItem = new ConnectionTreeItem(
+        '',
+        vscode.TreeItemCollapsibleState.Expanded,
+        true,
+        mdbTestExtension.testExtensionController._connectionController,
+        false,
+        {}
+      );
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    test('returns database tree items with the databases', async () => {
+      sinon.replace(
+        mdbTestExtension.testExtensionController._connectionController,
+        'getActiveDataService',
+        () => new DataServiceStub() as any
+      );
+
+      const databaseItems = await testConnectionTreeItem.getChildren();
+
+      assert.strictEqual(databaseItems.length, 3);
+      assert.strictEqual(databaseItems[0].label, 'mockDatabase1');
+      assert.strictEqual(databaseItems[2].label, 'mockDatabase3');
+    });
+
+    test('when listDatabases errors it wraps it in a nice message', async () => {
+      sinon.replace(
+        mdbTestExtension.testExtensionController._connectionController,
+        'getActiveDataService',
+        () => ({
+          listDatabases: (cb) => { cb(new Error('peaches')); }
+        }) as any
+      );
+
+      try {
+        await testConnectionTreeItem.getChildren();
+        assert(false);
+      } catch (err) {
+        assert.strictEqual(err.message, 'Unable to list databases: peaches');
+      }
+    });
+  });
+
+  suite('#listDatabases', () => {
+    let testConnectionTreeItem: ConnectionTreeItem;
+
+    beforeEach(() => {
+      testConnectionTreeItem = new ConnectionTreeItem(
+        '',
+        vscode.TreeItemCollapsibleState.Expanded,
+        true,
+        mdbTestExtension.testExtensionController._connectionController,
+        false,
+        {}
+      );
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    test('returns a list of database names', async () => {
+      sinon.replace(
+        mdbTestExtension.testExtensionController._connectionController,
+        'getActiveDataService',
+        () => new DataServiceStub() as any
+      );
+
+      const dbNames = await testConnectionTreeItem.listDatabases();
+
+      assert.strictEqual(dbNames.length, 3);
+      assert(dbNames.includes('mockDatabase2'));
+    });
+
+    test('when list databases errors with not authorization error it does not call listDatabasesUserHasAccessTo', async () => {
+      sinon.replace(
+        mdbTestExtension.testExtensionController._connectionController,
+        'getActiveDataService',
+        () => ({
+          listDatabases: (cb) => { cb(new Error('the dog is barking at a squirrel')); }
+        }) as any
+      );
+
+      const fake = sinon.fake.resolves([]);
+      sinon.replace(
+        testConnectionTreeItem,
+        'listDatabasesUserHasAccessTo',
+        fake
+      );
+
+      try {
+        await testConnectionTreeItem.listDatabases();
+        assert(false, 'Expected to error and did not');
+      } catch (_) {
+        assert(!fake.called);
+      }
+    });
+
+    test('when list databases errors with authorization error it calls listDatabasesUserHasAccessTo', async () => {
+      sinon.replace(
+        mdbTestExtension.testExtensionController._connectionController,
+        'getActiveDataService',
+        () => ({
+          listDatabases: (cb) => {
+            cb(new Error('not allowed to listDatabases'));
+          },
+          client: {}
+        }) as any
+      );
+
+      const fake = sinon.fake.resolves([]);
+      sinon.replace(
+        testConnectionTreeItem,
+        'listDatabasesUserHasAccessTo',
+        fake
+      );
+
+      await testConnectionTreeItem.listDatabases();
+      assert(fake.called);
+    });
+
+    test('when list databases errors with authorization error it reads privileges to get possible dbs', async () => {
+      const mockDbCommandResult = {
+        authInfo: {
+          authenticatedUserPrivileges: mockPrivileges
+        }
+      };
+
+      const mockDataserviceClient = {
+        client: {
+          db: () => ({
+            databaseName: 'admin',
+            command: () => {
+              return new Promise(resolve => {
+                resolve(mockDbCommandResult);
+              });
+            }
+          })
+        }
+      };
+
+      sinon.replace(
+        mdbTestExtension.testExtensionController._connectionController,
+        'getActiveDataService',
+        () => ({
+          listDatabases: (cb) => {
+            cb(new Error('not allowed to listDatabases'));
+          },
+          client: mockDataserviceClient
+        }) as any
+      );
+
+      const dbs = await testConnectionTreeItem.listDatabases();
+
+      assert.strictEqual(dbs.length, 4);
+      assert(dbs.includes('pineapple'));
+    });
+  });
+
+  suite('#listDatabasesUserHasAccessTo', () => {
+    let testConnectionTreeItem: ConnectionTreeItem;
+    let adminClient = new MongoClient(TEST_DATABASE_URI);
+    let userClient = new MongoClient(TEST_DATABASE_URI);
+
+    beforeEach(async () => {
+      testConnectionTreeItem = new ConnectionTreeItem(
+        '',
+        vscode.TreeItemCollapsibleState.Expanded,
+        true,
+        mdbTestExtension.testExtensionController._connectionController,
+        false,
+        {}
+      );
+      adminClient = new MongoClient(TEST_DATABASE_URI);
+      await adminClient.connect();
+
+      const adminDb = adminClient.db().admin();
+      // Create a new user with access to a db.
+      await adminDb.addUser(
+        TEST_USER_USERNAME,
+        TEST_USER_PASSWORD,
+        {
+          roles: [{
+            role: 'readWrite',
+            db: 'coffee'
+          }]
+        }
+      );
+
+      userClient = new MongoClient(TEST_DATABASE_URI_USER);
+      await userClient.connect();
+    });
+
+    afterEach(async () => {
+      // Remove the user we created.
+      const adminDb = adminClient.db().admin();
+      await adminDb.removeUser(TEST_USER_USERNAME);
+
+      await adminClient.close();
+      await userClient.close();
+      sinon.restore();
+    });
+
+    test('returns a list of database names the authenticated user might be able to use', async () => {
+      const dbNames = await testConnectionTreeItem.listDatabasesUserHasAccessTo(
+        userClient
+      );
+
+      assert.strictEqual(dbNames.length, 1);
+      assert.strictEqual(dbNames[0], 'coffee');
+    });
+  });
+
+  suite('#getDatabaseNamesFromPrivileges', () => {
+    test('it returns a sorted list of privileges', () => {
+      assert.deepStrictEqual(
+        getDatabaseNamesFromPrivileges(mockPrivileges),
+        ['db1', 'db2', 'db3', 'pineapple']
+      );
+    });
+
+    test('it returns an empty array when there are no privileges', () => {
+      const privs = [];
+      assert.deepStrictEqual(getDatabaseNamesFromPrivileges(privs), []);
+    });
+
+    test('it returns an empty array when there are no resources', () => {
+      const privs = [{}];
+      assert.deepStrictEqual(getDatabaseNamesFromPrivileges(privs), []);
+    });
   });
 });

--- a/src/test/suite/stubs.ts
+++ b/src/test/suite/stubs.ts
@@ -126,7 +126,7 @@ for (let i = 0; i < numberOfDocumentsToMock; i++) {
 
 class DataServiceStub {
   listDatabases(callback: any): void {
-    callback(null, mockDatabaseNames);
+    callback(null, mockDatabaseNames.map(dbName => ({ name: dbName })));
   }
 
   listCollections(databaseName: string, filter: object, callback: any): void {

--- a/src/types/connectionModelType.ts
+++ b/src/types/connectionModelType.ts
@@ -10,6 +10,8 @@ export type ConnectionModel = {
   port: number;
   driverUrl: string;
   driverUrlWithSsh: string;
+  ns: string;
+  mongodbDatabaseName: string;
   sshTunnel?: SSH_TUNNEL_TYPES;
   getAttributes(options: {
     derived?: boolean,

--- a/src/types/connectionModelType.ts
+++ b/src/types/connectionModelType.ts
@@ -10,8 +10,6 @@ export type ConnectionModel = {
   port: number;
   driverUrl: string;
   driverUrlWithSsh: string;
-  ns: string;
-  mongodbDatabaseName: string;
   sshTunnel?: SSH_TUNNEL_TYPES;
   getAttributes(options: {
     derived?: boolean,

--- a/src/types/dataServiceType.ts
+++ b/src/types/dataServiceType.ts
@@ -1,4 +1,6 @@
 import { EJSON } from 'bson';
+import { MongoClient } from 'mongodb';
+
 import { ConnectionOptions } from './connectionOptionsType';
 
 export type DataServiceType = {
@@ -37,5 +39,7 @@ export type DataServiceType = {
 
   instance(opts: any, callback: any): any;
 
-  client: any;
+  client: {
+    client: MongoClient
+  };
 };

--- a/src/types/dataServiceType.ts
+++ b/src/types/dataServiceType.ts
@@ -13,7 +13,10 @@ export type DataServiceType = {
   }
 
   listDatabases(
-    callback: (error: Error | undefined, databases: string[]) => void
+    callback: (
+      error: Error | undefined,
+      databases: { name: string }[]
+    ) => void
   ): void;
 
   createCollection(


### PR DESCRIPTION
VSCODE-157

This PR makes it so that we show databases in the tree view that a user might be able to use, even if that user doesn't have the ability to `listDatabases`. To do this we're fetching the privileges for the currently authenticated user, and using the db names found there to populate the database list. The user will still need access to `listCollections` to use the database in the connection tree explorer, but at least the database will be shown.

Should address https://github.com/mongodb-js/vscode/issues/96

For reference:
https://docs.mongodb.com/manual/tutorial/manage-users-and-roles/
https://docs.mongodb.com/compass/master/connect/required-access/#required-access

Creating a role and user restricted to database `aa` (Be sure to start `mongod` with `--auth` or authorization enabled in the config file):
```js
db.createRole({
  role: "listCollectionsFindAA",
  privileges: [
    {
      actions: [ "find", "listIndexes", "listCollections" ],
      resource: { db: "aa", collection: "" }
    }
  ],
  roles: []
});

db.createUser({
  user: 'test2',
  pwd: 'password',
  roles: ['restrictedAccessToAA']
});
```