### PR TITLE
fix(ci): fix release github actions

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -22,7 +22,7 @@ jobs:
           filename=$(basename -- "$ASSET_URL")
           extension="${filename##*.}"
 
-          if [[ ! $extension != "vsix" ]]; then
+          if [[ $extension != "vsix" ]]; then
             echo "Wrong asset extension ${extension} in ${ASSET_URL}"
             exit 1
           else

--- a/.github/workflows/rebuild-changelog.yaml
+++ b/.github/workflows/rebuild-changelog.yaml
@@ -28,24 +28,21 @@ jobs:
           echo "# Change Log" > CHANGELOG.md
           echo "" >> CHANGELOG.md
 
-          gh release list | while read line; do
-            line=${line/Latest/" "}
-            tagName=$(echo $line | awk '{ print $2 }')
-            echo "line: $line --- tag: $tagName"
+          tags=$(gh api repos/mongodb-js/vscode/releases | jq -r .[].tag_name | grep -v internal | grep -v pre | grep -v beta)
 
-            if [ "$tagName" != "Pre-release" ] && [ "$tagName" != "Preview" ]; then
+          # NOTE: here the quotes around $tags are necessary
+          echo "$tags" | while read tagName; do
 
-              json=$(gh release view $tagName --json=name,publishedAt,url,body)
-              url=$(echo $json | jq -r .url)
-              name=$(echo $json | jq -r .name)
-              date=$(echo $json | jq -r .publishedAt | cut -f1 -dT)
-              body=$(echo $json | jq -r .body)
-              echo "## [$name]($url) - $date" >> CHANGELOG.md
-              echo "" >> CHANGELOG.md
-              echo "$body" >> CHANGELOG.md
-              echo "" >> CHANGELOG.md
-              echo "" >> CHANGELOG.md
-            fi
+            json=$(gh release view $tagName --json=name,publishedAt,url,body)
+            url=$(echo $json | jq -r .url)
+            name=$(echo $json | jq -r .name)
+            date=$(echo $json | jq -r .publishedAt | cut -f1 -dT)
+            body=$(echo $json | jq -r .body)
+            echo "## [$name]($url) - $date" >> CHANGELOG.md
+            echo "" >> CHANGELOG.md
+            echo "$body" >> CHANGELOG.md
+            echo "" >> CHANGELOG.md
+            echo "" >> CHANGELOG.md
           done
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rebuild-changelog.yaml
+++ b/.github/workflows/rebuild-changelog.yaml
@@ -33,16 +33,19 @@ jobs:
             tagName=$(echo $line | awk '{ print $2 }')
             echo "line: $line --- tag: $tagName"
 
-            json=$(gh release view $tagName --json=name,publishedAt,url,body)
-            url=$(echo $json | jq -r .url)
-            name=$(echo $json | jq -r .name)
-            date=$(echo $json | jq -r .publishedAt | cut -f1 -dT)
-            body=$(echo $json | jq -r .body)
-            echo "## [$name]($url) - $date" >> CHANGELOG.md
-            echo "" >> CHANGELOG.md
-            echo "$body" >> CHANGELOG.md
-            echo "" >> CHANGELOG.md
-            echo "" >> CHANGELOG.md
+            if [ "$tagName" != "Pre-release" ] && [ "$tagName" != "Preview" ]; then
+
+              json=$(gh release view $tagName --json=name,publishedAt,url,body)
+              url=$(echo $json | jq -r .url)
+              name=$(echo $json | jq -r .name)
+              date=$(echo $json | jq -r .publishedAt | cut -f1 -dT)
+              body=$(echo $json | jq -r .body)
+              echo "## [$name]($url) - $date" >> CHANGELOG.md
+              echo "" >> CHANGELOG.md
+              echo "$body" >> CHANGELOG.md
+              echo "" >> CHANGELOG.md
+              echo "" >> CHANGELOG.md
+            fi
           done
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -71,7 +71,7 @@ jobs:
           echo "See full release notes at: https://github.com/mongodb-js/vscode/releases/tag/${RELEASE_TAG}\n" > CHANGELOG.md
           npx json -I -f package.json -e "this.version='${RELEASE_VERSION}'"
           npx json -I -f package-lock.json -e "this.version='${RELEASE_VERSION}'"
-        if: startsWith(github.ref, 'refs/tags/')
+        if: ${{ startsWith(github.ref, 'refs/tags/') && runner.os == 'Linux' }}
 
       - name: Build .vsix
         env:
@@ -93,7 +93,7 @@ jobs:
         run: |
           echo Creating draft release for: "${RELEASE_TAG}"
           gh release create "${RELEASE_TAG}" \
-            --title "${RELEASE_VERSION}" \
+            --title "v${RELEASE_VERSION}" \
             --notes "Edit the release notes before publishing." \
             --target main \
             --draft \

--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -61,6 +61,8 @@ jobs:
         shell: bash
 
       - name: Prepare build for release
+        shell: bash
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
           export "RELEASE_TAG=${GITHUB_REF#refs/*/}"
           export "RELEASE_VERSION=${RELEASE_TAG:1}"
@@ -71,7 +73,6 @@ jobs:
           echo "See full release notes at: https://github.com/mongodb-js/vscode/releases/tag/${RELEASE_TAG}\n" > CHANGELOG.md
           npx json -I -f package.json -e "this.version='${RELEASE_VERSION}'"
           npx json -I -f package-lock.json -e "this.version='${RELEASE_VERSION}'"
-        if: ${{ startsWith(github.ref, 'refs/tags/') && runner.os == 'Linux' }}
 
       - name: Build .vsix
         env:


### PR DESCRIPTION
Fixes a couple issues on building/releasing/building changelog. 
Updated our release version title to have a `v` in the front, this is mostly since our previous release titles are named like that. I read somewhere it's a recommended practice, but I think it could probably go either way - any preferences?