### PR TITLE
feat(playgrounds): Show code lens at end of selection

### DIFF
--- a/src/editors/partialExecutionCodeLensProvider.ts
+++ b/src/editors/partialExecutionCodeLensProvider.ts
@@ -1,6 +1,57 @@
 import * as vscode from 'vscode';
 import EXTENSION_COMMANDS from '../commands';
 
+// Returns a boolean if the selection is one that is valid to show a
+// code lens for (isn't a partial line etc.).
+export function isSelectionValidForCodeLens(
+  selections: vscode.Selection[],
+  textDocument: vscode.TextDocument
+): boolean {
+  if (selections.length > 1) {
+    // Show codelens when it's multi cursor.
+    return true;
+  }
+
+  if (!selections[0].isSingleLine) {
+    // Show codelens when it's a multi-line selection.
+    return true;
+  }
+
+  const lineContent = (textDocument.lineAt(selections[0].end.line).text || '').trim();
+  const selectionContent = (textDocument.getText(selections[0]) || '').trim();
+
+  // Show codelens when it contains the whole line.
+  return lineContent === selectionContent;
+}
+
+export function getCodeLensLineOffsetForSelection(
+  selections: vscode.Selection[],
+  editor: vscode.TextEditor
+): number {
+  const lastSelection = selections[selections.length - 1];
+  const lastSelectedLineNumber = lastSelection.end.line;
+  const lastSelectedLineContent = editor.document.lineAt(lastSelectedLineNumber).text || '';
+
+  // Show a code lens after the selected line, unless the
+  // contents of the selection in the last line is empty.
+  const lastSelectedLineContentRange = new vscode.Range(
+    new vscode.Position(
+      lastSelection.end.line,
+      0
+    ),
+    new vscode.Position(
+      lastSelection.end.line,
+      lastSelectedLineContent.length
+    )
+  );
+  const interectedSelection = lastSelection.intersection(lastSelectedLineContentRange);
+  if (!interectedSelection || interectedSelection.isEmpty) {
+    return 0;
+  }
+
+  return lastSelectedLineContent.trim().length > 0 ? 1 : 0;
+}
+
 export default class PartialExecutionCodeLensProvider
 implements vscode.CodeLensProvider {
   _selection?: vscode.Range;


### PR DESCRIPTION
Chatting and pairing on this w/ @alenakhineika - we were thinking until we decide if code actions are a better alternative we could go back to putting the code lenses at the bottom of selections just to hopefully improve that ux.

This PR has a few fixes for situations where we weren't showing codelenses, for instance if a user had a multi selection and the last selection was an empty space it wouldn't show a code lens.

In cases where the selection includes the end of the playground, and that last line is not empty, we now add an empty line so we can show a code lens nicely at the end. This is shown in the video below. I don't totally remember, but I think this maybe have been the reason we changed to putting code lenses on top.


https://user-images.githubusercontent.com/1791149/126701660-93b22e68-56d8-4c49-ade6-2ad54350e182.mp4

