### PR TITLE
fix(ci): use wget instead of curl for asset dl

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -29,7 +29,7 @@ jobs:
             echo "Wrong asset extension ${extension} in ${ASSET_URL}"
             exit 1
           else
-            curl "${ASSET_URL}" > ${filename}
+            wget -O ${filename} "${ASSET_URL}"
             ls -al ${filename}
             echo "VSIX_PATH=${filename}" >> $GITHUB_ENV
           fi


### PR DESCRIPTION
fixes `ERROR  end of central directory record signature not found` 