### PR TITLE
fix(ci): make published readme reference main branch instead of master

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -39,6 +39,6 @@ jobs:
       - name: Publish to marketplace
         run: |
           echo "Publishing ${VSIX_PATH} to marketplace"
-          npx vsce publish --packagePath "${VSIX_PATH}" -p ${VSCE_PAT}
+          npx vsce publish --packagePath "${VSIX_PATH}" --githubBranch main
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Changed
 
 - Updated code lenses in playgrounds to now appear at the end of a selection for partially running (#324)
-- Update our CI release pipeline - this is the first automated release ✨ 
+- Update our CI release pipeline - this is the first automated release ✨
 
 
 ## [v0.6.0](https://github.com/mongodb-js/vscode/releases/tag/v0.6.0) - 2021-07-13
@@ -209,7 +209,7 @@ This is the marketplace preview release of MongoDB for VS Code.
 * MongoDB Playgrounds
 * Quick access to the MongoDB Shell
 
-Take a look at [README.md](https://github.com/mongodb-js/vscode/blob/master/README.md) for an overview of the features.
+Take a look at [README.md](https://github.com/mongodb-js/vscode/blob/main/README.md) for an overview of the features.
 
 This release can be found on the VS Code marketplace: https://marketplace.visualstudio.com/items?itemName=mongodb.mongodb-vscode
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,8 +209,7 @@ This is the marketplace preview release of MongoDB for VS Code.
 * MongoDB Playgrounds
 * Quick access to the MongoDB Shell
 
-Take a look at [README.md](https://github.com/mongodb-js/vscode/blob/main/README.md) for an overview of the features.
+Take a look at [README.md](https://github.com/mongodb-js/vscode/blob/master/README.md) for an overview of the features.
 
 This release can be found on the VS Code marketplace: https://marketplace.visualstudio.com/items?itemName=mongodb.mongodb-vscode
-
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MongoDB for VS Code ![PREVIEW](https://img.shields.io/badge/-PREVIEW-orange)
 
-[![Build Status](https://dev.azure.com/team-compass/vscode/_apis/build/status/mongodb-js.vscode?branchName=master)](https://dev.azure.com/team-compass/vscode/_build/latest?definitionId=10&branchName=master)
+[![Build Status](https://dev.azure.com/team-compass/vscode/_apis/build/status/mongodb-js.vscode?branchName=main)](https://dev.azure.com/team-compass/vscode/_build/latest?definitionId=10&branchName=main)
 
 MongoDB for VS Code makes it easy to work with MongoDB, whether your own instance or in [MongoDB Atlas](https://www.mongodb.com/cloud/atlas/register).
 

--- a/src/explorer/helpTree.ts
+++ b/src/explorer/helpTree.ts
@@ -68,7 +68,7 @@ export default class HelpTree implements vscode.TreeDataProvider<vscode.TreeItem
     if (!element) {
       const whatsNew = new HelpLinkTreeItem(
         'What\'s New',
-        'https://github.com/mongodb-js/vscode/blob/master/CHANGELOG.md',
+        'https://github.com/mongodb-js/vscode/blob/main/CHANGELOG.md',
         'whatsNew',
         'megaphone'
       );

--- a/src/telemetry/telemetryService.ts
+++ b/src/telemetry/telemetryService.ts
@@ -230,7 +230,7 @@ export default class TelemetryService {
 
     const shellApiType = res.result.type.toLocaleLowerCase();
 
-    // See: https://github.com/mongodb-js/mongosh/blob/master/packages/shell-api/src/shell-api.js
+    // See: https://github.com/mongodb-js/mongosh/blob/main/packages/shell-api/src/shell-api.js
     if (shellApiType.includes('insert')) {
       return 'insert';
     }


### PR DESCRIPTION
VSCODE-281

We now supply the `--githubBranch main` option to `vsce publish` so that the generated README at https://marketplace.visualstudio.com/items?itemName=mongodb.mongodb-vscode has correct addresses for the referenced images (currently they're defaulting to `master` and not loading images).

You can view the `vsce publish` options here: https://github.com/Microsoft/vscode-vsce/blob/main/src/main.ts#L136
