### PR TITLE
refactor: add no-floating-promises rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -48,6 +48,8 @@ module.exports = {
     'restrict-template-expressions': 0,
     '@typescript-eslint/restrict-template-expressions': 0,
 
+    '@typescript-eslint/no-floating-promises': 2,
+
     // VV These rules we'd like to turn off one day so they error.
     '@typescript-eslint/no-unsafe-assignment': 0,
     '@typescript-eslint/no-unsafe-member-access': 0,

--- a/src/commands/launchMongoShell.ts
+++ b/src/commands/launchMongoShell.ts
@@ -95,7 +95,7 @@ const openMongoDBShell = (connectionController: ConnectionController): Promise<b
   if (
     !connectionController.isCurrentlyConnected()
   ) {
-    vscode.window.showErrorMessage(
+    void vscode.window.showErrorMessage(
       'You need to be connected before launching the MongoDB Shell.'
     );
 
@@ -106,7 +106,7 @@ const openMongoDBShell = (connectionController: ConnectionController): Promise<b
   const shellCommand: string | undefined = vscode.workspace.getConfiguration('mdb').get('shell');
 
   if (!userShell) {
-    vscode.window.showErrorMessage(
+    void vscode.window.showErrorMessage(
       'Error: No shell found, please set your default shell environment in vscode.'
     );
 
@@ -114,7 +114,7 @@ const openMongoDBShell = (connectionController: ConnectionController): Promise<b
   }
 
   if (!shellCommand) {
-    vscode.window.showErrorMessage(
+    void vscode.window.showErrorMessage(
       'No MongoDB shell command found. Please set the shell command in the MongoDB extension settings.'
     );
     return Promise.resolve(false);

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -210,7 +210,7 @@ export default class ConnectionController {
     try {
       return this.addNewConnectionStringAndConnect(connectionString);
     } catch (error) {
-      vscode.window.showErrorMessage(error.message);
+      void vscode.window.showErrorMessage(error.message);
 
       return false;
     }
@@ -244,7 +244,7 @@ export default class ConnectionController {
     connectionModel: ConnectionModel,
     connectionType: ConnectionTypes
   ): void {
-    this._telemetryService.trackNewConnection(
+    void this._telemetryService.trackNewConnection(
       newDataService.client.client,
       connectionModel,
       connectionType
@@ -323,7 +323,7 @@ export default class ConnectionController {
         connectionId,
         connectionInfoAsString
       );
-      this._storageController.storeNewConnection(newLoadedConnection);
+      void this._storageController.storeNewConnection(newLoadedConnection);
     }
 
     return this.connect(connectionId, connectionModel, connectionType);
@@ -412,7 +412,7 @@ export default class ConnectionController {
     }
 
     log.info('Successfully connected');
-    vscode.window.showInformationMessage('MongoDB connection successful.');
+    void vscode.window.showInformationMessage('MongoDB connection successful.');
 
     this._activeDataService = newDataService;
     this._activeConnectionModel = connectionModel;
@@ -449,7 +449,7 @@ export default class ConnectionController {
           : savedConnectionModel
       );
     } catch (error) {
-      vscode.window.showErrorMessage(`Unable to load connection: ${error}`);
+      void vscode.window.showErrorMessage(`Unable to load connection: ${error}`);
 
       return false;
     }
@@ -463,7 +463,7 @@ export default class ConnectionController {
 
       return connectResult.successfullyConnected;
     } catch (error) {
-      vscode.window.showErrorMessage(error.message);
+      void vscode.window.showErrorMessage(error.message);
 
       return false;
     }
@@ -476,7 +476,7 @@ export default class ConnectionController {
     );
 
     if (!this._activeDataService) {
-      vscode.window.showErrorMessage(
+      void vscode.window.showErrorMessage(
         'Unable to disconnect: no active connection.'
       );
 
@@ -502,10 +502,10 @@ export default class ConnectionController {
 
     try {
       await _disconnect();
-      vscode.window.showInformationMessage('MongoDB disconnected.');
+      void vscode.window.showInformationMessage('MongoDB disconnected.');
     } catch (error) {
       // Show an error, however we still reset the active connection to free up the extension.
-      vscode.window.showErrorMessage(
+      void vscode.window.showErrorMessage(
         'An error occured while disconnecting from the current connection.'
       );
     }
@@ -533,7 +533,7 @@ export default class ConnectionController {
   async removeMongoDBConnection(connectionId: string): Promise<boolean> {
     if (!this._connections[connectionId]) {
       // No active connection(s) to remove.
-      vscode.window.showErrorMessage('Connection does not exist.');
+      void vscode.window.showErrorMessage('Connection does not exist.');
 
       return false;
     }
@@ -559,7 +559,7 @@ export default class ConnectionController {
 
     await this.removeSavedConnection(connectionId);
 
-    vscode.window.showInformationMessage('MongoDB connection removed.');
+    void vscode.window.showInformationMessage('MongoDB connection removed.');
 
     return true;
   }
@@ -571,7 +571,7 @@ export default class ConnectionController {
 
     if (connectionIds.length === 0) {
       // No active connection(s) to remove.
-      vscode.window.showErrorMessage('No connections to remove.');
+      void vscode.window.showErrorMessage('No connections to remove.');
 
       return false;
     }

--- a/src/editors/collectionDocumentsProvider.ts
+++ b/src/editors/collectionDocumentsProvider.ts
@@ -45,7 +45,7 @@ implements vscode.TextDocumentContentProvider {
     const operationId = uriParams.get(OPERATION_ID_URI_IDENTIFIER);
 
     if (!operationId) {
-      vscode.window.showErrorMessage(
+      void vscode.window.showErrorMessage(
         'Unable to list documents: invalid operation'
       );
 
@@ -58,7 +58,7 @@ implements vscode.TextDocumentContentProvider {
     // Ensure we're still connected to the correct connection.
     if (connectionId !== this._connectionController.getActiveConnectionId()) {
       operation.isCurrentlyFetchingMoreDocuments = false;
-      vscode.window.showErrorMessage(
+      void vscode.window.showErrorMessage(
         `Unable to list documents: no longer connected to ${connectionId}`
       );
 
@@ -74,7 +74,7 @@ implements vscode.TextDocumentContentProvider {
     if (dataservice === null) {
       const errorMessage = `Unable to list documents: no longer connected to ${connectionId}`;
 
-      vscode.window.showErrorMessage(errorMessage);
+      void vscode.window.showErrorMessage(errorMessage);
 
       throw new Error(errorMessage);
     }
@@ -108,7 +108,7 @@ implements vscode.TextDocumentContentProvider {
       const printableError = error as { message: string };
       const errorMessage = `Unable to list documents: ${printableError.message}`;
 
-      vscode.window.showErrorMessage(errorMessage);
+      void vscode.window.showErrorMessage(errorMessage);
 
       throw Error(errorMessage);
     }

--- a/src/editors/editorsController.ts
+++ b/src/editors/editorsController.ts
@@ -121,7 +121,7 @@ export default class EditorsController {
       )) as EJSON.SerializableTypes;
 
       if (mdbDocument === null) {
-        vscode.window.showErrorMessage(`
+        void vscode.window.showErrorMessage(`
           Unable to open mongodb document: document ${JSON.stringify(data.documentId)} not found
         `);
 
@@ -148,7 +148,7 @@ export default class EditorsController {
     } catch (error) {
       const printableError = error as { message: string };
 
-      vscode.window.showErrorMessage(printableError.message);
+      void vscode.window.showErrorMessage(printableError.message);
 
       return false;
     }
@@ -196,9 +196,9 @@ export default class EditorsController {
       });
 
       // Save document changes to active editor.
-      activeEditor?.document.save();
+      await activeEditor?.document.save();
 
-      vscode.window.showInformationMessage(
+      void vscode.window.showInformationMessage(
         `The document was saved successfully to '${namespace}'`
       );
 
@@ -206,7 +206,7 @@ export default class EditorsController {
     } catch (error) {
       const printableError = error as { message: string };
 
-      vscode.window.showErrorMessage(printableError.message);
+      void vscode.window.showErrorMessage(printableError.message);
 
       return false;
     }
@@ -251,7 +251,7 @@ export default class EditorsController {
     } catch (error) {
       const printableError = error as { message: string };
 
-      vscode.window.showErrorMessage(
+      void vscode.window.showErrorMessage(
         `Unable to open documents: ${printableError.message}`
       );
 
@@ -272,7 +272,7 @@ export default class EditorsController {
       this._collectionDocumentsOperationsStore.operations[operationId]
         .isCurrentlyFetchingMoreDocuments
     ) {
-      vscode.window.showErrorMessage(
+      void vscode.window.showErrorMessage(
         'Already fetching more documents...'
       );
 
@@ -281,7 +281,7 @@ export default class EditorsController {
 
     // Ensure we're still connected to the correct connection.
     if (connectionId !== this._connectionController.getActiveConnectionId()) {
-      vscode.window.showErrorMessage(
+      void vscode.window.showErrorMessage(
         `Unable to view more documents: no longer connected to ${connectionId}`
       );
 

--- a/src/editors/playgroundController.ts
+++ b/src/editors/playgroundController.ts
@@ -99,14 +99,7 @@ export default class PlaygroundController {
     this._connectionController.addEventListener(
       DataServiceEventTypes.ACTIVE_CONNECTION_CHANGED,
       () => {
-        this._disconnectFromServiceProvider();
-      }
-    );
-
-    this._connectionController.addEventListener(
-      DataServiceEventTypes.ACTIVE_CONNECTION_CHANGED,
-      () => {
-        this._connectToServiceProvider();
+        void this._connectToServiceProvider();
       }
     );
 
@@ -140,7 +133,7 @@ export default class PlaygroundController {
             .map((selection) => this._getSelectedText(selection))
             .join('\n');
 
-          this._showCodeLensForSelection(
+          void this._showCodeLensForSelection(
             sortedSelections,
             changeEvent.textEditor
           );
@@ -173,7 +166,7 @@ export default class PlaygroundController {
       lastSelection.end.line === editor.document.lineCount - 1 &&
       lastSelectedLineContent.trim().length > 0
     ) {
-      editor.edit(edit => {
+      void editor.edit(edit => {
         edit.insert(
           new vscode.Position(lastSelection.end.line + 1, 0),
           '\n'
@@ -188,10 +181,6 @@ export default class PlaygroundController {
         lastSelectedLineNumber + codeLensLineOffset, 0
       )
     );
-  }
-
-  _disconnectFromServiceProvider(): void {
-    this._languageServerController.disconnectFromServiceProvider();
   }
 
   async _connectToServiceProvider(): Promise<void> {
@@ -246,7 +235,7 @@ export default class PlaygroundController {
     } catch (error) {
       const printableError = error as { message: string };
 
-      vscode.window.showErrorMessage(
+      void vscode.window.showErrorMessage(
         `Unable to create a playground: ${printableError.message}`
       );
 
@@ -323,7 +312,7 @@ export default class PlaygroundController {
     } catch (error) {
       const printableError = error as { message: string };
 
-      vscode.window.showErrorMessage(
+      void vscode.window.showErrorMessage(
         `Unable to create a playground: ${printableError.message}`
       );
 
@@ -455,7 +444,7 @@ export default class PlaygroundController {
     } catch (error) {
       const printableError = error as { message: string };
 
-      vscode.window.showErrorMessage(
+      void vscode.window.showErrorMessage(
         `Unable to open a result document: ${printableError.message}`
       );
     }
@@ -467,7 +456,7 @@ export default class PlaygroundController {
       .get('confirmRunAll');
 
     if (!this._connectionController.isCurrentlyConnected()) {
-      vscode.window.showErrorMessage(
+      void vscode.window.showErrorMessage(
         'Please connect to a database before running a playground.'
       );
 
@@ -508,7 +497,8 @@ export default class PlaygroundController {
 
     this._playgroundResult = evaluateResponse.result;
 
-    await this._explorerController.refresh();
+    this._explorerController.refresh();
+
     await this._openPlaygroundResult();
 
     return true;
@@ -519,7 +509,7 @@ export default class PlaygroundController {
       !this._activeTextEditor ||
       this._activeTextEditor.document.languageId !== 'mongodb'
     ) {
-      vscode.window.showErrorMessage(
+      void vscode.window.showErrorMessage(
         "Please open a '.mongodb' playground file before running it."
       );
 
@@ -533,7 +523,7 @@ export default class PlaygroundController {
       !Array.isArray(selections) ||
       (selections.length === 1 && this._getSelectedText(selections[0]) === '')
     ) {
-      vscode.window.showInformationMessage(
+      void vscode.window.showInformationMessage(
         'Please select one or more lines in the playground.'
       );
 
@@ -551,7 +541,7 @@ export default class PlaygroundController {
       !this._activeTextEditor ||
       this._activeTextEditor.document.languageId !== 'mongodb'
     ) {
-      vscode.window.showErrorMessage(
+      void vscode.window.showErrorMessage(
         "Please open a '.mongodb' playground file before running it."
       );
 
@@ -569,7 +559,7 @@ export default class PlaygroundController {
       !this._activeTextEditor ||
       this._activeTextEditor.document.languageId !== 'mongodb'
     ) {
-      vscode.window.showErrorMessage(
+      void vscode.window.showErrorMessage(
         "Please open a '.mongodb' playground file before running it."
       );
 
@@ -603,7 +593,7 @@ export default class PlaygroundController {
     } catch (error) {
       const printableError = error as { message: string };
 
-      vscode.window.showErrorMessage(
+      void vscode.window.showErrorMessage(
         `Unable to open a playground: ${printableError.message}`
       );
 

--- a/src/explorer/collectionTreeItem.ts
+++ b/src/explorer/collectionTreeItem.ts
@@ -388,9 +388,10 @@ export default class CollectionTreeItem extends vscode.TreeItem
         `${this.databaseName}.${collectionName}`,
         (err: Error | null, successfullyDroppedCollection = false) => {
           if (err) {
-            vscode.window.showErrorMessage(
+            void vscode.window.showErrorMessage(
               `Drop collection failed: ${err.message}`
             );
+
             return resolve(false);
           }
 

--- a/src/explorer/connectionTreeItem.ts
+++ b/src/explorer/connectionTreeItem.ts
@@ -249,7 +249,8 @@ export default class ConnectionTreeItem extends vscode.TreeItem
           () => resolve(true),
           (err) => {
             this.isExpanded = false;
-            vscode.window.showErrorMessage(err);
+            void vscode.window.showErrorMessage(err);
+
             return resolve(false);
           }
         );

--- a/src/explorer/databaseTreeItem.ts
+++ b/src/explorer/databaseTreeItem.ts
@@ -227,7 +227,7 @@ export default class DatabaseTreeItem extends vscode.TreeItem
         databaseName,
         (err: Error | null, successfullyDroppedDatabase = false) => {
           if (err) {
-            vscode.window.showErrorMessage(
+            void vscode.window.showErrorMessage(
               `Drop database failed: ${err.message}`
             );
             return resolve(false);

--- a/src/explorer/documentListTreeItem.ts
+++ b/src/explorer/documentListTreeItem.ts
@@ -160,7 +160,7 @@ export default class DocumentListTreeItem extends vscode.TreeItem
         },
         (err: Error, documents: []) => {
           if (err) {
-            vscode.window.showErrorMessage(`Unable to list documents: ${err}`);
+            void vscode.window.showErrorMessage(`Unable to list documents: ${err}`);
             return reject(err);
           }
 

--- a/src/explorer/explorerController.ts
+++ b/src/explorer/explorerController.ts
@@ -59,12 +59,12 @@ export default class ExplorerController {
     }
   }
 
-  refresh(): Promise<boolean> {
+  refresh(): boolean {
     if (this._treeController) {
       return this._treeController.refresh();
     }
 
-    return Promise.reject(new Error('No tree to refresh.'));
+    throw new Error('No tree to refresh.');
   }
 
   // Exposed for testing.

--- a/src/explorer/explorerTreeController.ts
+++ b/src/explorer/explorerTreeController.ts
@@ -38,7 +38,7 @@ implements vscode.TreeDataProvider<vscode.TreeItem> {
     this._connectionController.removeEventListener(
       DataServiceEventTypes.CONNECTIONS_DID_CHANGE,
       () => {
-        void this.refresh();
+        this.refresh();
       }
     );
   }

--- a/src/explorer/explorerTreeController.ts
+++ b/src/explorer/explorerTreeController.ts
@@ -27,7 +27,7 @@ implements vscode.TreeDataProvider<vscode.TreeItem> {
     this._connectionController.addEventListener(
       DataServiceEventTypes.CONNECTIONS_DID_CHANGE,
       () => {
-        this.refresh();
+        void this.refresh();
       }
     );
 
@@ -38,7 +38,7 @@ implements vscode.TreeDataProvider<vscode.TreeItem> {
     this._connectionController.removeEventListener(
       DataServiceEventTypes.CONNECTIONS_DID_CHANGE,
       () => {
-        this.refresh();
+        void this.refresh();
       }
     );
   }
@@ -124,10 +124,10 @@ implements vscode.TreeDataProvider<vscode.TreeItem> {
   _onDidChangeTreeData: vscode.EventEmitter<any>;
   readonly onDidChangeTreeData: vscode.Event<any>;
 
-  public refresh = (): Promise<boolean> => {
+  refresh = (): boolean => {
     this._onDidChangeTreeData.fire(null);
 
-    return Promise.resolve(true);
+    return true;
   };
 
   onTreeItemUpdate(): void {

--- a/src/explorer/explorerTreeController.ts
+++ b/src/explorer/explorerTreeController.ts
@@ -27,7 +27,7 @@ implements vscode.TreeDataProvider<vscode.TreeItem> {
     this._connectionController.addEventListener(
       DataServiceEventTypes.CONNECTIONS_DID_CHANGE,
       () => {
-        void this.refresh();
+        this.refresh();
       }
     );
 

--- a/src/explorer/schemaTreeItem.ts
+++ b/src/explorer/schemaTreeItem.ts
@@ -212,7 +212,7 @@ export default class SchemaTreeItem extends vscode.TreeItem
     this.cacheIsUpToDate = true;
 
     if (!schema || !schema.fields || schema.fields.length < 1) {
-      vscode.window.showInformationMessage(
+      void vscode.window.showInformationMessage(
         'No documents were found when attempting to parse schema.'
       );
       this.childrenCache = {};

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,7 +24,7 @@ let mdbExtension: MDBExtensionController;
 
 // Called when our extension is activated.
 // See "activationEvents" in `package.json` for the events that cause activation.
-export function activate(context: vscode.ExtensionContext): void {
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
   log.info('activate extension called');
 
   ext.context = context;
@@ -38,7 +38,7 @@ export function activate(context: vscode.ExtensionContext): void {
   mdbExtension = new MDBExtensionController(context, {
     shouldTrackTelemetry: true
   });
-  mdbExtension.activate();
+  await mdbExtension.activate();
 
   // Add our extension to a list of disposables for when we are deactivated.
   context.subscriptions.push(mdbExtension);
@@ -47,8 +47,8 @@ export function activate(context: vscode.ExtensionContext): void {
 }
 
 // Called when our extension is deactivated.
-export function deactivate(): void {
+export async function deactivate(): Promise<void> {
   if (mdbExtension) {
-    mdbExtension.deactivate();
+    await mdbExtension.deactivate();
   }
 }

--- a/src/language/languageServerController.ts
+++ b/src/language/languageServerController.ts
@@ -124,11 +124,11 @@ export default class LanguageServerController {
     );
 
     this._client.onNotification(ServerCommands.SHOW_INFO_MESSAGE, (messsage) => {
-      vscode.window.showInformationMessage(messsage);
+      void vscode.window.showInformationMessage(messsage);
     });
 
     this._client.onNotification(ServerCommands.SHOW_ERROR_MESSAGE, (messsage) => {
-      vscode.window.showErrorMessage(messsage);
+      void vscode.window.showErrorMessage(messsage);
     });
   }
 
@@ -138,7 +138,7 @@ export default class LanguageServerController {
     }
 
     // Stop the language server
-    this._client.stop();
+    void this._client.stop();
   }
 
   async executeAll(

--- a/src/language/mongoDBService.ts
+++ b/src/language/mongoDBService.ts
@@ -211,7 +211,7 @@ export default class MongoDBService {
             );
           }
 
-          worker.terminate().then(() => {
+          void worker.terminate().then(() => {
             resolve(result);
           });
         });
@@ -283,7 +283,7 @@ export default class MongoDBService {
           );
         }
 
-        worker.terminate().then(() => {
+        void worker.terminate().then(() => {
           this._connection.console.log(`MONGOSH found ${result.length} databases`);
           this._updateCurrentSessionDatabases(result);
         });
@@ -327,7 +327,7 @@ export default class MongoDBService {
             );
           }
 
-          worker.terminate().then(() => {
+          void worker.terminate().then(() => {
             this._connection.console.log(
               `MONGOSH found ${result.length} collections`
             );
@@ -381,7 +381,7 @@ export default class MongoDBService {
             this._connection.console.log(`SCHEMA error: ${util.inspect(error)}`);
           }
 
-          worker.terminate().then(() => {
+          void worker.terminate().then(() => {
             this._connection.console.log(`SCHEMA found ${result.length} fields`);
             this._updateCurrentSessionFields(namespace, result);
 

--- a/src/language/server.ts
+++ b/src/language/server.ts
@@ -68,7 +68,7 @@ connection.onInitialize((params: InitializeParams) => {
 connection.onInitialized(() => {
   if (hasConfigurationCapability) {
     // Register for all configuration changes.
-    connection.client.register(
+    void connection.client.register(
       DidChangeConfigurationNotification.type,
       undefined
     );

--- a/src/language/worker.ts
+++ b/src/language/worker.ts
@@ -173,7 +173,7 @@ const getListCollections = async (
   }
 };
 
-const handleMessageFromParentPort = async(message: string) => {
+const handleMessageFromParentPort = async(message: string): Promise<void> => {
   if (message === ServerCommands.EXECUTE_ALL_FROM_PLAYGROUND) {
     parentPort?.postMessage(
       await executeAll(
@@ -219,6 +219,6 @@ const handleMessageFromParentPort = async(message: string) => {
 parentPort?.once(
   'message',
   (message: string): void => {
-    handleMessageFromParentPort(message);
+    void handleMessageFromParentPort(message);
   }
 );

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -539,8 +539,8 @@ export default class MDBExtensionController implements vscode.Disposable {
     }
   }
 
-  dispose(): void {
-    void this.deactivate();
+  async dispose(): Promise<void> {
+    await this.deactivate();
   }
 
   async deactivate(): Promise<void> {

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -133,7 +133,7 @@ export default class MDBExtensionController implements vscode.Disposable {
 
     this.registerCommands();
 
-    await this.showOverviewPageIfRecentlyInstalled();
+    this.showOverviewPageIfRecentlyInstalled();
   }
 
   registerCommands = (): void => {
@@ -518,7 +518,7 @@ export default class MDBExtensionController implements vscode.Disposable {
     );
   }
 
-  async showOverviewPageIfRecentlyInstalled(): Promise<void> {
+  showOverviewPageIfRecentlyInstalled(): void {
     const hasBeenShownViewAlready = !!this._storageController.get(
       StorageVariables.GLOBAL_HAS_BEEN_SHOWN_INITIAL_VIEW
     );
@@ -532,7 +532,7 @@ export default class MDBExtensionController implements vscode.Disposable {
         );
       }
 
-      await this._storageController.update(
+      void this._storageController.update(
         StorageVariables.GLOBAL_HAS_BEEN_SHOWN_INITIAL_VIEW,
         true
       );

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -122,16 +122,18 @@ export default class MDBExtensionController implements vscode.Disposable {
     this._editorsController.registerProviders();
   }
 
-  activate(): void {
+  async activate(): Promise<void> {
     this._explorerController.activateConnectionsTreeView();
     this._helpExplorer.activateHelpTreeView(this._telemetryService);
     this._playgroundsExplorer.activatePlaygroundsTreeView();
-    this._connectionController.loadSavedConnections();
     this._telemetryService.activateSegmentAnalytics();
-    this._languageServerController.startLanguageServer();
+
+    await this._connectionController.loadSavedConnections();
+    await this._languageServerController.startLanguageServer();
 
     this.registerCommands();
-    this.showOverviewPageIfRecentlyInstalled();
+
+    await this.showOverviewPageIfRecentlyInstalled();
   }
 
   registerCommands = (): void => {
@@ -277,7 +279,7 @@ export default class MDBExtensionController implements vscode.Disposable {
         );
 
         await vscode.env.clipboard.writeText(connectionString);
-        vscode.window.showInformationMessage('Copied to clipboard.');
+        void vscode.window.showInformationMessage('Copied to clipboard.');
 
         return true;
       }
@@ -297,7 +299,7 @@ export default class MDBExtensionController implements vscode.Disposable {
       EXTENSION_COMMANDS.MDB_ADD_DATABASE,
       async (element: ConnectionTreeItem): Promise<boolean> => {
         if (!element) {
-          vscode.window.showErrorMessage(
+          void vscode.window.showErrorMessage(
             'Please wait for the connection to finish loading before adding a database.'
           );
 
@@ -308,7 +310,7 @@ export default class MDBExtensionController implements vscode.Disposable {
           element.connectionId !==
           this._connectionController.getActiveConnectionId()
         ) {
-          vscode.window.showErrorMessage(
+          void vscode.window.showErrorMessage(
             'Please connect to this connection before adding a database.'
           );
 
@@ -316,7 +318,7 @@ export default class MDBExtensionController implements vscode.Disposable {
         }
 
         if (this._connectionController.isDisconnecting()) {
-          vscode.window.showErrorMessage(
+          void vscode.window.showErrorMessage(
             'Unable to add database: currently disconnecting.'
           );
 
@@ -324,7 +326,7 @@ export default class MDBExtensionController implements vscode.Disposable {
         }
 
         if (this._connectionController.isConnecting()) {
-          vscode.window.showErrorMessage(
+          void vscode.window.showErrorMessage(
             'Unable to add database: currently connecting.'
           );
 
@@ -339,7 +341,7 @@ export default class MDBExtensionController implements vscode.Disposable {
       EXTENSION_COMMANDS.MDB_COPY_DATABASE_NAME,
       async (element: DatabaseTreeItem) => {
         await vscode.env.clipboard.writeText(element.databaseName);
-        vscode.window.showInformationMessage('Copied to clipboard.');
+        void vscode.window.showInformationMessage('Copied to clipboard.');
 
         return true;
       }
@@ -350,7 +352,7 @@ export default class MDBExtensionController implements vscode.Disposable {
         const successfullyDroppedDatabase = await element.onDropDatabaseClicked();
 
         if (successfullyDroppedDatabase) {
-          vscode.window.showInformationMessage(
+          void vscode.window.showInformationMessage(
             'Database successfully dropped.'
           );
 
@@ -366,15 +368,16 @@ export default class MDBExtensionController implements vscode.Disposable {
       EXTENSION_COMMANDS.MDB_REFRESH_DATABASE,
       (databaseTreeItem: DatabaseTreeItem): Promise<boolean> => {
         databaseTreeItem.resetCache();
+        this._explorerController.refresh();
 
-        return this._explorerController.refresh();
+        return Promise.resolve(true);
       }
     );
     this.registerCommand(
       EXTENSION_COMMANDS.MDB_ADD_COLLECTION,
       async (element: DatabaseTreeItem): Promise<boolean> => {
         if (this._connectionController.isDisconnecting()) {
-          vscode.window.showErrorMessage(
+          void vscode.window.showErrorMessage(
             'Unable to add collection: currently disconnecting.'
           );
 
@@ -389,7 +392,7 @@ export default class MDBExtensionController implements vscode.Disposable {
       EXTENSION_COMMANDS.MDB_COPY_COLLECTION_NAME,
       async (element: CollectionTreeItem): Promise<boolean> => {
         await vscode.env.clipboard.writeText(element.collectionName);
-        vscode.window.showInformationMessage('Copied to clipboard.');
+        void vscode.window.showInformationMessage('Copied to clipboard.');
 
         return true;
       }
@@ -400,7 +403,7 @@ export default class MDBExtensionController implements vscode.Disposable {
         const successfullyDroppedCollection = await element.onDropCollectionClicked();
 
         if (successfullyDroppedCollection) {
-          vscode.window.showInformationMessage(
+          void vscode.window.showInformationMessage(
             'Collection successfully dropped.'
           );
 
@@ -426,8 +429,9 @@ export default class MDBExtensionController implements vscode.Disposable {
       EXTENSION_COMMANDS.MDB_REFRESH_COLLECTION,
       (collectionTreeItem: CollectionTreeItem): Promise<boolean> => {
         collectionTreeItem.resetCache();
+        this._explorerController.refresh();
 
-        return this._explorerController.refresh();
+        return Promise.resolve(true);
       }
     );
     this.registerCommand(
@@ -452,25 +456,27 @@ export default class MDBExtensionController implements vscode.Disposable {
     );
     this.registerCommand(
       EXTENSION_COMMANDS.MDB_REFRESH_DOCUMENT_LIST,
-      (documentsListTreeItem: DocumentListTreeItem): Promise<boolean> => {
-        documentsListTreeItem.resetCache();
+      async (documentsListTreeItem: DocumentListTreeItem): Promise<boolean> => {
+        await documentsListTreeItem.resetCache();
+        this._explorerController.refresh();
 
-        return this._explorerController.refresh();
+        return Promise.resolve(true);
       }
     );
     this.registerCommand(
       EXTENSION_COMMANDS.MDB_REFRESH_SCHEMA,
       (schemaTreeItem: SchemaTreeItem): Promise<boolean> => {
         schemaTreeItem.resetCache();
+        this._explorerController.refresh();
 
-        return this._explorerController.refresh();
+        return Promise.resolve(true);
       }
     );
     this.registerCommand(
       EXTENSION_COMMANDS.MDB_COPY_SCHEMA_FIELD_NAME,
       async (fieldTreeItem: FieldTreeItem): Promise<boolean> => {
         await vscode.env.clipboard.writeText(fieldTreeItem.getFieldName());
-        vscode.window.showInformationMessage('Copied to clipboard.');
+        void vscode.window.showInformationMessage('Copied to clipboard.');
 
         return true;
       }
@@ -479,8 +485,9 @@ export default class MDBExtensionController implements vscode.Disposable {
       EXTENSION_COMMANDS.MDB_REFRESH_INDEXES,
       (indexListTreeItem: IndexListTreeItem): Promise<boolean> => {
         indexListTreeItem.resetCache();
+        this._explorerController.refresh();
 
-        return this._explorerController.refresh();
+        return Promise.resolve(true);
       }
     );
     this.registerCommand(
@@ -511,7 +518,7 @@ export default class MDBExtensionController implements vscode.Disposable {
     );
   }
 
-  showOverviewPageIfRecentlyInstalled(): void {
+  async showOverviewPageIfRecentlyInstalled(): Promise<void> {
     const hasBeenShownViewAlready = !!this._storageController.get(
       StorageVariables.GLOBAL_HAS_BEEN_SHOWN_INITIAL_VIEW
     );
@@ -520,12 +527,12 @@ export default class MDBExtensionController implements vscode.Disposable {
     // user yet, and they have no saved connections.
     if (!hasBeenShownViewAlready) {
       if (!this._storageController.hasSavedConnections()) {
-        vscode.commands.executeCommand(
+        void vscode.commands.executeCommand(
           EXTENSION_COMMANDS.MDB_OPEN_OVERVIEW_PAGE
         );
       }
 
-      this._storageController.update(
+      await this._storageController.update(
         StorageVariables.GLOBAL_HAS_BEEN_SHOWN_INITIAL_VIEW,
         true
       );
@@ -533,11 +540,12 @@ export default class MDBExtensionController implements vscode.Disposable {
   }
 
   dispose(): void {
-    this.deactivate();
+    void this.deactivate();
   }
 
-  deactivate(): void {
-    this._connectionController.disconnect();
+  async deactivate(): Promise<void> {
+    await this._connectionController.disconnect();
+
     this._explorerController.deactivate();
     this._helpExplorer.deactivate();
     this._playgroundsExplorer.deactivate();

--- a/src/storage/storageController.ts
+++ b/src/storage/storageController.ts
@@ -58,11 +58,11 @@ export default class StorageController {
     storageScope?: StorageScope
   ): Thenable<void> {
     if (storageScope === StorageScope.WORKSPACE) {
-      this._workspaceState.update(variableName, value);
+      void this._workspaceState.update(variableName, value);
       return Promise.resolve();
     }
 
-    this._globalState.update(variableName, value);
+    void this._globalState.update(variableName, value);
     return Promise.resolve();
   }
 
@@ -74,7 +74,7 @@ export default class StorageController {
     }
 
     globalUserId = uuidv4();
-    this.update(StorageVariables.GLOBAL_USER_ID, globalUserId);
+    void this.update(StorageVariables.GLOBAL_USER_ID, globalUserId);
 
     return globalUserId;
   }
@@ -154,7 +154,7 @@ export default class StorageController {
       const storeOnWorkspace = 'Save the connection on this workspace';
       const storeGlobally = 'Save the connection globally on vscode';
       // Prompt the user where they want to save the new connection.
-      vscode.window
+      void vscode.window
         .showQuickPick(
           [
             storeOnWorkspace,
@@ -191,7 +191,7 @@ export default class StorageController {
     );
     if (globalStoredConnections && globalStoredConnections[connectionId]) {
       delete globalStoredConnections[connectionId];
-      this.update(
+      void this.update(
         StorageVariables.GLOBAL_SAVED_CONNECTIONS,
         globalStoredConnections
       );
@@ -206,7 +206,7 @@ export default class StorageController {
       workspaceStoredConnections[connectionId]
     ) {
       delete workspaceStoredConnections[connectionId];
-      this.update(
+      void this.update(
         StorageVariables.WORKSPACE_SAVED_CONNECTIONS,
         workspaceStoredConnections,
         StorageScope.WORKSPACE

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -33,4 +33,4 @@ async function main(): Promise<any> {
   }
 }
 
-main();
+void main();

--- a/src/test/suite/commands/launchMongoShell.test.ts
+++ b/src/test/suite/commands/launchMongoShell.test.ts
@@ -7,7 +7,7 @@ import launchMongoShell from '../../../commands/launchMongoShell';
 import { mdbTestExtension } from '../stubbableMdbExtension';
 
 suite('Commands Test Suite', () => {
-  vscode.window.showInformationMessage('Starting tests...');
+  void vscode.window.showInformationMessage('Starting tests...');
 
   const mockConnectionController =
     mdbTestExtension.testExtensionController._connectionController;

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -868,7 +868,7 @@ suite('Connection Controller Test Suite', function () {
 
   suite('connecting to a new connection when already connecting', () => {
     test('connects to the new connection', async () => {
-      testConnectionController.addNewConnectionStringAndConnect(
+      void testConnectionController.addNewConnectionStringAndConnect(
         testDatabaseURI2WithTimeout
       );
 
@@ -927,7 +927,7 @@ suite('Connection Controller Test Suite', function () {
 
       for (let i = 0; i < 5; i++) {
         const id = `${i}`;
-        testConnectionController.connectWithConnectionId(id);
+        void testConnectionController.connectWithConnectionId(id);
       }
 
       // Ensure the connections complete.
@@ -945,8 +945,8 @@ suite('Connection Controller Test Suite', function () {
     );
 
     try {
-      testConnectionController.disconnect();
-      testConnectionController.disconnect();
+      void testConnectionController.disconnect();
+      void testConnectionController.disconnect();
     } catch (err) {
       assert(
         false,
@@ -972,7 +972,7 @@ suite('Connection Controller Test Suite', function () {
       storageLocation: StorageScope.NONE
     };
 
-    testConnectionController.connectWithConnectionId(connectionId);
+    void testConnectionController.connectWithConnectionId(connectionId);
 
     // Ensure the connection starts but doesn't time out yet.
     await sleep(250);
@@ -1007,7 +1007,7 @@ suite('Connection Controller Test Suite', function () {
       })
     );
 
-    testConnectionController.connectWithConnectionId(connectionId);
+    void testConnectionController.connectWithConnectionId(connectionId);
 
     // Ensure the connection attempt has started.
     await sleep(10);

--- a/src/test/suite/editors/collectionDocumentsProvider.test.ts
+++ b/src/test/suite/editors/collectionDocumentsProvider.test.ts
@@ -190,7 +190,7 @@ suite('Collection Documents Provider Test Suite', () => {
       `scheme:Results: filename.json?namespace=vostok.mercury&operationId=${operationId}`
     );
 
-    testCollectionViewProvider.provideTextDocumentContent(uri).then(() => {
+    void testCollectionViewProvider.provideTextDocumentContent(uri).then(() => {
       assert(
         testQueryStore.operations[operationId].hasMoreDocumentsToShow === false,
         'Expected not to have more documents to show.'

--- a/src/test/suite/explorer/databaseTreeItem.test.ts
+++ b/src/test/suite/explorer/databaseTreeItem.test.ts
@@ -66,7 +66,7 @@ suite('DatabaseTreeItem Test Suite', () => {
       {}
     );
 
-    testDatabaseTreeItem.onDidExpand();
+    void testDatabaseTreeItem.onDidExpand();
 
     const collections = await testDatabaseTreeItem.getChildren();
     assert(
@@ -213,13 +213,13 @@ suite('DatabaseTreeItem Test Suite', () => {
         'Expected collection tree item not to be expanded on default.'
       );
 
-      collectionTreeItems[0].onDidExpand();
+      void collectionTreeItems[0].onDidExpand();
       const schemaTreeItem = collectionTreeItems[0].getSchemaChild();
       if (!schemaTreeItem) {
         assert(false, 'No schema tree item found on collection.');
         return;
       }
-      schemaTreeItem.onDidExpand();
+      void schemaTreeItem.onDidExpand();
       schemaTreeItem.onShowMoreClicked();
 
       const fields: any[] = await schemaTreeItem.getChildren();
@@ -235,7 +235,7 @@ suite('DatabaseTreeItem Test Suite', () => {
         'Expected the subdocument field to be in the schema cache.'
       );
       // Expand the subdocument.
-      schemaTreeItem.childrenCache.testerObject.onDidExpand();
+      void schemaTreeItem.childrenCache.testerObject.onDidExpand();
 
       testDatabaseTreeItem.onDidCollapse();
       const postCollapseCollectionTreeItems = await testDatabaseTreeItem
@@ -245,7 +245,7 @@ suite('DatabaseTreeItem Test Suite', () => {
         `Expected the database tree to return no children when collapsed, found ${collectionTreeItems.length}`
       );
 
-      testDatabaseTreeItem.onDidExpand();
+      void testDatabaseTreeItem.onDidExpand();
       const newCollectionTreeItems = await testDatabaseTreeItem
         .getChildren();
       dataService.disconnect(() => {});

--- a/src/test/suite/explorer/fieldTreeItem.test.ts
+++ b/src/test/suite/explorer/fieldTreeItem.test.ts
@@ -138,7 +138,7 @@ suite('FieldTreeItem Test Suite', function () {
     });
 
     test('field name is pulled from the name of a field', (done) => {
-      seedDataAndCreateDataService('pie', [
+      void seedDataAndCreateDataService('pie', [
         {
           _id: 1,
           blueberryPie: 'yes'
@@ -178,7 +178,7 @@ suite('FieldTreeItem Test Suite', function () {
     });
 
     test('it shows dropdowns for nested subdocuments', (done) => {
-      seedDataAndCreateDataService('gryffindor', [
+      void seedDataAndCreateDataService('gryffindor', [
         {
           _id: 1,
           alwaysDocument: {
@@ -209,9 +209,9 @@ suite('FieldTreeItem Test Suite', function () {
           {}
         );
 
-        testSchemaTreeItem.onDidExpand();
+        void testSchemaTreeItem.onDidExpand();
 
-        testSchemaTreeItem.getChildren().then((schemaFields) => {
+        void testSchemaTreeItem.getChildren().then((schemaFields) => {
           dataService.disconnect(() => {});
           assert(
             schemaFields.length === 2,
@@ -252,7 +252,7 @@ suite('FieldTreeItem Test Suite', function () {
     });
 
     test('it shows dropdowns for arrays', (done) => {
-      seedDataAndCreateDataService('gryffindor', [
+      void seedDataAndCreateDataService('gryffindor', [
         {
           _id: 1,
           testingArray: ['okay', 'nice']
@@ -273,7 +273,7 @@ suite('FieldTreeItem Test Suite', function () {
           {}
         );
 
-        testSchemaTreeItem.onDidExpand();
+        void testSchemaTreeItem.onDidExpand();
 
         testSchemaTreeItem.getChildren().then((schemaFields) => {
           dataService.disconnect(() => {});
@@ -302,7 +302,7 @@ suite('FieldTreeItem Test Suite', function () {
     });
 
     test('it shows dropdowns and fields for document fields in arrays', (done) => {
-      seedDataAndCreateDataService('beach', [
+      void seedDataAndCreateDataService('beach', [
         {
           _id: 1,
           testingArray: [
@@ -333,9 +333,9 @@ suite('FieldTreeItem Test Suite', function () {
           {}
         );
 
-        testSchemaTreeItem.onDidExpand();
+        void testSchemaTreeItem.onDidExpand();
 
-        testSchemaTreeItem.getChildren().then((schemaFields) => {
+        void testSchemaTreeItem.getChildren().then((schemaFields) => {
           dataService.disconnect(() => {});
 
           schemaFields[1].getChildren().then((nestedSubDocuments) => {

--- a/src/test/suite/explorer/helpExplorer.test.ts
+++ b/src/test/suite/explorer/helpExplorer.test.ts
@@ -65,7 +65,7 @@ suite('Help Explorer Test Suite', function () {
     sinon.replace(vscode.commands, 'executeCommand', stubExecuteCommand);
     const helpTreeItems = await testHelpExplorer._treeController.getChildren();
     const atlasHelpItem = helpTreeItems[1];
-    testHelpExplorer._treeController.onClickHelpItem(
+    void testHelpExplorer._treeController.onClickHelpItem(
       atlasHelpItem,
       mdbTestExtension.testExtensionController._telemetryService
     );
@@ -93,7 +93,7 @@ suite('Help Explorer Test Suite', function () {
     sinon.replace(linkHelper, 'openLink', stubExecuteCommand);
     const helpTreeItems = await testHelpExplorer._treeController.getChildren();
     const atlasHelpItem = helpTreeItems[5];
-    testHelpExplorer._treeController.onClickHelpItem(
+    void testHelpExplorer._treeController.onClickHelpItem(
       atlasHelpItem,
       mdbTestExtension.testExtensionController._telemetryService
     );
@@ -118,7 +118,7 @@ suite('Help Explorer Test Suite', function () {
     sinon.replace(vscode.commands, 'executeCommand', sinon.fake());
     const helpTreeItems = await testHelpExplorer._treeController.getChildren();
     const atlasHelpItem = helpTreeItems[5];
-    testHelpExplorer._treeController.onClickHelpItem(
+    void testHelpExplorer._treeController.onClickHelpItem(
       atlasHelpItem,
       mdbTestExtension.testExtensionController._telemetryService
     );

--- a/src/test/suite/explorer/schemaTreeItem.test.ts
+++ b/src/test/suite/explorer/schemaTreeItem.test.ts
@@ -233,7 +233,7 @@ suite('SchemaTreeItem Test Suite', function () {
     });
 
     test('when not expanded it has not yet pulled the schema', (done) => {
-      seedDataAndCreateDataService('favoritePiesIWantToEatRightNow', [
+      void seedDataAndCreateDataService('favoritePiesIWantToEatRightNow', [
         {
           _id: 10,
           someField: 'applePie'
@@ -265,7 +265,7 @@ suite('SchemaTreeItem Test Suite', function () {
     });
 
     test('when expanded shows the fields of a schema', (done) => {
-      seedDataAndCreateDataService('favoritePiesIWantToEatRightNow', [
+      void seedDataAndCreateDataService('favoritePiesIWantToEatRightNow', [
         {
           _id: 1,
           nameOfTastyPie: 'applePie'
@@ -282,7 +282,7 @@ suite('SchemaTreeItem Test Suite', function () {
           {}
         );
 
-        testSchemaTreeItem.onDidExpand();
+        void testSchemaTreeItem.onDidExpand();
 
         testSchemaTreeItem
           .getChildren()
@@ -306,7 +306,7 @@ suite('SchemaTreeItem Test Suite', function () {
     });
 
     test('it only shows a dropdown for fields which are always documents - and not for polymorphic', (done) => {
-      seedDataAndCreateDataService('favoritePiesIWantToEatRightNow', [
+      void seedDataAndCreateDataService('favoritePiesIWantToEatRightNow', [
         {
           _id: 1,
           alwaysDocument: {
@@ -335,7 +335,7 @@ suite('SchemaTreeItem Test Suite', function () {
           {}
         );
 
-        testSchemaTreeItem.onDidExpand();
+        void testSchemaTreeItem.onDidExpand();
 
         testSchemaTreeItem
           .getChildren()

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -5,7 +5,7 @@ import EXTENSION_COMMANDS from '../../commands';
 const { contributes } = require('../../../package.json');
 
 suite('Extension Test Suite', () => {
-  vscode.window.showInformationMessage('Starting tests...');
+  void vscode.window.showInformationMessage('Starting tests...');
 
   test('there should be 3 views registered in the package.json', () => {
     assert(contributes.views.mongoDB.length === 3);

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -42,7 +42,7 @@ export function run(): Promise<void> {
           mdbTestExtension.testExtensionContext,
           { shouldTrackTelemetry: false }
         );
-        mdbTestExtension.testExtensionController.activate();
+        void mdbTestExtension.testExtensionController.activate();
 
         // We avoid using the user's credential store when running tests
         // in order to ensure we're not polluting the credential store
@@ -51,7 +51,7 @@ export function run(): Promise<void> {
         ext.keytarModule = new KeytarStub();
 
         // Disable the dialogue for prompting the user where to store the connection.
-        vscode.workspace
+        void vscode.workspace
           .getConfiguration('mdb.connectionSaving')
           .update('hideOptionToChooseWhereToSaveNewConnections', true)
           .then(() => {

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -8,7 +8,7 @@ import KeytarStub from './keytarStub';
 import { TestExtensionContext } from './stubs';
 import { mdbTestExtension } from './stubbableMdbExtension';
 
-export function run(): Promise<void> {
+export async function run(): Promise<void> {
   const reporterOptions = {
     spec: '-',
     'mocha-junit-reporter': path.join(__dirname, './test-results.xml')
@@ -24,6 +24,15 @@ export function run(): Promise<void> {
 
   const testsRoot = path.join(__dirname, '..');
 
+  // Activate the extension.
+  mdbTestExtension.testExtensionContext = new TestExtensionContext();
+  mdbTestExtension.testExtensionController = new MDBExtensionController(
+    mdbTestExtension.testExtensionContext,
+    { shouldTrackTelemetry: false }
+  );
+
+  await mdbTestExtension.testExtensionController.activate();
+
   return new Promise((c, e) => {
     glob(
       '**/**.test.js',
@@ -35,14 +44,6 @@ export function run(): Promise<void> {
         if (err) {
           return e(err);
         }
-
-        // Activate the extension.
-        mdbTestExtension.testExtensionContext = new TestExtensionContext();
-        mdbTestExtension.testExtensionController = new MDBExtensionController(
-          mdbTestExtension.testExtensionContext,
-          { shouldTrackTelemetry: false }
-        );
-        void mdbTestExtension.testExtensionController.activate();
 
         // We avoid using the user's credential store when running tests
         // in order to ensure we're not polluting the credential store

--- a/src/test/suite/mdbExtensionController.test.ts
+++ b/src/test/suite/mdbExtensionController.test.ts
@@ -973,7 +973,7 @@ suite('MDBExtensionController Test Suite', function () {
     const testConnectionController =
       mdbTestExtension.testExtensionController._connectionController;
 
-    testConnectionController
+    void testConnectionController
       .addNewConnectionStringAndConnect(testDatabaseURI)
       .then(() => {
         const testCollectionTreeItem = new CollectionTreeItem(
@@ -1098,7 +1098,7 @@ suite('MDBExtensionController Test Suite', function () {
     const testConnectionController =
       mdbTestExtension.testExtensionController._connectionController;
 
-    testConnectionController
+    void testConnectionController
       .addNewConnectionStringAndConnect(testDatabaseURI)
       .then(() => {
         const testDatabaseTreeItem = new DatabaseTreeItem(
@@ -1730,7 +1730,7 @@ suite('MDBExtensionController Test Suite', function () {
           mockStorageControllerUpdate
         );
 
-        mdbTestExtension.testExtensionController.showOverviewPageIfRecentlyInstalled();
+        void mdbTestExtension.testExtensionController.showOverviewPageIfRecentlyInstalled();
       });
 
       afterEach(() => {
@@ -1795,7 +1795,7 @@ suite('MDBExtensionController Test Suite', function () {
           mockStorageControllerUpdate
         );
 
-        mdbTestExtension.testExtensionController.showOverviewPageIfRecentlyInstalled();
+        void mdbTestExtension.testExtensionController.showOverviewPageIfRecentlyInstalled();
       });
 
       test('they are not shown the overview page', () => {
@@ -1834,7 +1834,7 @@ suite('MDBExtensionController Test Suite', function () {
         mockVSCodeExecuteCommand
       );
 
-      mdbTestExtension.testExtensionController.showOverviewPageIfRecentlyInstalled();
+      void mdbTestExtension.testExtensionController.showOverviewPageIfRecentlyInstalled();
     });
 
     test('they are not shown the overview page', () => {

--- a/src/test/suite/storage/storageController.test.ts
+++ b/src/test/suite/storage/storageController.test.ts
@@ -40,7 +40,7 @@ suite('Storage Controller Test Suite', () => {
     );
   });
 
-  test('addNewConnectionToGlobalStore adds the connection to preexisting connections on the global store', async () => {
+  test('addNewConnectionToGlobalStore adds the connection to preexisting connections on the global store', () => {
     const testExtensionContext = new TestExtensionContext();
     testExtensionContext._globalState = {
       [StorageVariables.GLOBAL_SAVED_CONNECTIONS]: {
@@ -52,7 +52,7 @@ suite('Storage Controller Test Suite', () => {
       }
     };
     const testStorageController = new StorageController(testExtensionContext);
-    await testStorageController.saveConnectionToGlobalStore({
+    void testStorageController.saveConnectionToGlobalStore({
       id: 'new_conn',
       name: 'saved2',
       storageLocation: StorageScope.NONE
@@ -81,7 +81,7 @@ suite('Storage Controller Test Suite', () => {
     assert(testStorageController.hasSavedConnections());
   });
 
-  test('addNewConnectionToWorkspaceStore adds the connection to preexisting connections on the workspace store', async () => {
+  test('addNewConnectionToWorkspaceStore adds the connection to preexisting connections on the workspace store', () => {
     const testExtensionContext = new TestExtensionContext();
     testExtensionContext._workspaceState = {
       [StorageVariables.WORKSPACE_SAVED_CONNECTIONS]: {
@@ -92,7 +92,7 @@ suite('Storage Controller Test Suite', () => {
       }
     };
     const testStorageController = new StorageController(testExtensionContext);
-    await testStorageController.saveConnectionToWorkspaceStore({
+    void testStorageController.saveConnectionToWorkspaceStore({
       id: 'new_conn',
       name: 'saved2',
       storageLocation: StorageScope.NONE

--- a/src/test/suite/storage/storageController.test.ts
+++ b/src/test/suite/storage/storageController.test.ts
@@ -40,7 +40,7 @@ suite('Storage Controller Test Suite', () => {
     );
   });
 
-  test('addNewConnectionToGlobalStore adds the connection to preexisting connections on the global store', () => {
+  test('addNewConnectionToGlobalStore adds the connection to preexisting connections on the global store', async () => {
     const testExtensionContext = new TestExtensionContext();
     testExtensionContext._globalState = {
       [StorageVariables.GLOBAL_SAVED_CONNECTIONS]: {
@@ -52,7 +52,7 @@ suite('Storage Controller Test Suite', () => {
       }
     };
     const testStorageController = new StorageController(testExtensionContext);
-    testStorageController.saveConnectionToGlobalStore({
+    await testStorageController.saveConnectionToGlobalStore({
       id: 'new_conn',
       name: 'saved2',
       storageLocation: StorageScope.NONE
@@ -81,7 +81,7 @@ suite('Storage Controller Test Suite', () => {
     assert(testStorageController.hasSavedConnections());
   });
 
-  test('addNewConnectionToWorkspaceStore adds the connection to preexisting connections on the workspace store', () => {
+  test('addNewConnectionToWorkspaceStore adds the connection to preexisting connections on the workspace store', async () => {
     const testExtensionContext = new TestExtensionContext();
     testExtensionContext._workspaceState = {
       [StorageVariables.WORKSPACE_SAVED_CONNECTIONS]: {
@@ -92,7 +92,7 @@ suite('Storage Controller Test Suite', () => {
       }
     };
     const testStorageController = new StorageController(testExtensionContext);
-    testStorageController.saveConnectionToWorkspaceStore({
+    await testStorageController.saveConnectionToWorkspaceStore({
       id: 'new_conn',
       name: 'saved2',
       storageLocation: StorageScope.NONE

--- a/src/test/suite/utils/linkHelper.test.ts
+++ b/src/test/suite/utils/linkHelper.test.ts
@@ -10,7 +10,7 @@ suite('Open Link Test Suite', () => {
   test('the helper server is instantiated correctly', () => {
     const stubServer: any = { on: sinon.spy(), listen: sinon.spy() };
     const stubCreateServer: any = sinon.stub(http, 'createServer').returns(stubServer);
-    openLink('https://mongodb.com', 4321);
+    void openLink('https://mongodb.com', 4321);
     expect(stubServer.on.calledWith('connection')).to.be.true;
     expect(stubServer.listen.calledWith(4321)).to.be.true;
     stubCreateServer.restore();
@@ -24,7 +24,7 @@ suite('Open Link Test Suite', () => {
     const stubCreateStubInstance: any = sinon.createStubInstance(http.Server, stubServer);
     const stubCreateServer: any = sinon.stub(http, 'createServer').returns(stubCreateStubInstance);
     const stubExecuteCommand: any = sinon.stub(vscode.commands, 'executeCommand').resolves();
-    openLink('https://mongodb.com', 4321);
+    void openLink('https://mongodb.com', 4321);
     expect(stubExecuteCommand.firstCall.args[0]).to.equal('vscode.open');
     expect(stubExecuteCommand.firstCall.args[1].authority).to.equal(vscode.Uri.parse('http://localhost:4321').authority);
     stubExecuteCommand.restore();
@@ -39,7 +39,7 @@ suite('Open Link Test Suite', () => {
     const stubCreateStubInstance: any = sinon.createStubInstance(http.Server, stubServer);
     const stubCreateServer: any = sinon.stub(http, 'createServer').returns(stubCreateStubInstance);
     const stubExecuteCommand: any = sinon.stub(vscode.commands, 'executeCommand').resolves();
-    openLink('https://monkey.mongodb.com', 4321);
+    void openLink('https://monkey.mongodb.com', 4321);
     expect(stubExecuteCommand.firstCall.args[0]).to.equal('vscode.open');
     expect(stubExecuteCommand.firstCall.args[1].authority).to.equal(vscode.Uri.parse('http://localhost:4321').authority);
     stubExecuteCommand.restore();

--- a/src/test/suite/views/webviewController.test.ts
+++ b/src/test/suite/views/webviewController.test.ts
@@ -48,7 +48,7 @@ suite('Webview Test Suite', () => {
       mdbTestExtension.testExtensionController._telemetryService
     );
 
-    testWebviewController.openWebview(mdbTestExtension.testExtensionContext);
+    void testWebviewController.openWebview(mdbTestExtension.testExtensionContext);
 
     assert(fakeVSCodeCreateWebviewPanel.called);
     assert(fakeWebview.html !== '');
@@ -118,7 +118,7 @@ suite('Webview Test Suite', () => {
     let messageReceived;
     const fakeWebview = {
       html: '',
-      postMessage: (): void => {
+      postMessage: async (): Promise<void> => {
         assert(testConnectionController.isCurrentlyConnected());
         assert(
           testConnectionController.getActiveConnectionName() ===
@@ -128,7 +128,7 @@ suite('Webview Test Suite', () => {
           testConnectionController.getActiveConnectionModel()?.port === 27018
         );
 
-        testConnectionController.disconnect();
+        await testConnectionController.disconnect();
         done();
       },
       onDidReceiveMessage: (callback): void => {
@@ -153,7 +153,7 @@ suite('Webview Test Suite', () => {
       testTelemetryService
     );
 
-    testWebviewController.openWebview(mdbTestExtension.testExtensionContext);
+    void testWebviewController.openWebview(mdbTestExtension.testExtensionContext);
 
     assert(
       messageReceivedSet,
@@ -193,7 +193,7 @@ suite('Webview Test Suite', () => {
     let messageReceived;
     const fakeWebview = {
       html: '',
-      postMessage: (message): void => {
+      postMessage: async (message): Promise<void> => {
         assert(message.connectionSuccess);
         const expectedMessage = 'Successfully connected to localhost:27018.';
         assert(
@@ -201,7 +201,7 @@ suite('Webview Test Suite', () => {
           `Expected connection message "${message.connectionMessage}" to equal ${expectedMessage}`
         );
 
-        testConnectionController.disconnect();
+        await testConnectionController.disconnect();
         done();
       },
       onDidReceiveMessage: (callback): void => {
@@ -226,7 +226,7 @@ suite('Webview Test Suite', () => {
       testTelemetryService
     );
 
-    testWebviewController.openWebview(mdbTestExtension.testExtensionContext);
+    void testWebviewController.openWebview(mdbTestExtension.testExtensionContext);
 
     assert(
       messageReceivedSet,
@@ -265,11 +265,11 @@ suite('Webview Test Suite', () => {
     let messageReceived;
     const fakeWebview = {
       html: '',
-      postMessage: (message): void => {
+      postMessage: async (message): Promise<void> => {
         assert(!message.connectionSuccess);
         assert(message.connectionMessage.includes('Unable to load connection'));
 
-        testConnectionController.disconnect();
+        await testConnectionController.disconnect();
         done();
       },
       onDidReceiveMessage: (callback): void => {
@@ -293,7 +293,7 @@ suite('Webview Test Suite', () => {
       testTelemetryService
     );
 
-    testWebviewController.openWebview(mdbTestExtension.testExtensionContext);
+    void testWebviewController.openWebview(mdbTestExtension.testExtensionContext);
 
     // Mock a connection call.
     messageReceived({
@@ -320,7 +320,7 @@ suite('Webview Test Suite', () => {
     let messageReceived;
     const fakeWebview = {
       html: '',
-      postMessage: (message): void => {
+      postMessage: async (message): Promise<void> => {
         assert(!message.connectionSuccess);
         const expectedMessage = 'connection attempt overriden';
         assert(
@@ -328,7 +328,7 @@ suite('Webview Test Suite', () => {
           `Expected connection message "${message.connectionMessage}" to equal ${expectedMessage}`
         );
 
-        testConnectionController.disconnect();
+        await testConnectionController.disconnect();
         done();
       },
       onDidReceiveMessage: (callback): void => {
@@ -352,7 +352,7 @@ suite('Webview Test Suite', () => {
       testTelemetryService
     );
 
-    testWebviewController.openWebview(mdbTestExtension.testExtensionContext);
+    void testWebviewController.openWebview(mdbTestExtension.testExtensionContext);
 
     // Mock a connection call.
     messageReceived({
@@ -369,7 +369,7 @@ suite('Webview Test Suite', () => {
     setTimeout(() => {
       // Once the previous request has started, issue a successful connect
       // attempt to override the previous.
-      testConnectionController.addNewConnectionStringAndConnect(
+      void testConnectionController.addNewConnectionStringAndConnect(
         TEST_DATABASE_URI
       );
     }, 5);
@@ -394,11 +394,11 @@ suite('Webview Test Suite', () => {
     let messageReceived;
     const fakeWebview = {
       html: '',
-      postMessage: (): void => {
+      postMessage: async (): Promise<void> => {
         assert(fakeVSCodeOpenDialog.called);
         assert(fakeVSCodeOpenDialog.firstCall.args[0].canSelectFiles);
 
-        testConnectionController.disconnect();
+        await testConnectionController.disconnect();
         done();
       },
       onDidReceiveMessage: (callback): void => {
@@ -424,7 +424,7 @@ suite('Webview Test Suite', () => {
       testTelemetryService
     );
 
-    testWebviewController.openWebview(mdbTestExtension.testExtensionContext);
+    void testWebviewController.openWebview(mdbTestExtension.testExtensionContext);
 
     // Mock a connection call.
     messageReceived({
@@ -448,11 +448,11 @@ suite('Webview Test Suite', () => {
     let messageReceived;
     const fakeWebview = {
       html: '',
-      postMessage: (message): void => {
+      postMessage: async (message): Promise<void> => {
         assert(message.action === 'file_action');
         assert(message.files[0] === path.resolve('somefilepath/test.text'));
 
-        testConnectionController.disconnect();
+        await testConnectionController.disconnect();
         done();
       },
       onDidReceiveMessage: (callback): void => {
@@ -484,7 +484,7 @@ suite('Webview Test Suite', () => {
       testTelemetryService
     );
 
-    testWebviewController.openWebview(mdbTestExtension.testExtensionContext);
+    void testWebviewController.openWebview(mdbTestExtension.testExtensionContext);
 
     messageReceived({
       command: MESSAGE_TYPES.OPEN_FILE_PICKER,
@@ -532,7 +532,7 @@ suite('Webview Test Suite', () => {
       testTelemetryService
     );
 
-    testWebviewController.openWebview(mdbTestExtension.testExtensionContext);
+    void testWebviewController.openWebview(mdbTestExtension.testExtensionContext);
 
     messageReceived({
       command: MESSAGE_TYPES.OPEN_CONNECTION_STRING_INPUT
@@ -591,7 +591,7 @@ suite('Webview Test Suite', () => {
       testTelemetryService
     );
 
-    testWebviewController.openWebview(mdbTestExtension.testExtensionContext);
+    void testWebviewController.openWebview(mdbTestExtension.testExtensionContext);
 
     // Mock a connection status request call.
     messageReceived({
@@ -614,11 +614,11 @@ suite('Webview Test Suite', () => {
     let messageReceived;
     const fakeWebview = {
       html: '',
-      postMessage: (message): void => {
+      postMessage: async (message): Promise<void> => {
         assert(message.command === 'CONNECTION_STATUS_MESSAGE');
         assert(message.connectionStatus === 'CONNECTED');
         assert(message.activeConnectionName === 'localhost:27018');
-        testConnectionController.disconnect();
+        await testConnectionController.disconnect();
 
         done();
       },
@@ -643,9 +643,9 @@ suite('Webview Test Suite', () => {
       testTelemetryService
     );
 
-    testWebviewController.openWebview(mdbTestExtension.testExtensionContext);
+    void testWebviewController.openWebview(mdbTestExtension.testExtensionContext);
 
-    testConnectionController
+    void testConnectionController
       .addNewConnectionStringAndConnect(TEST_DATABASE_URI)
       .then(() => {
         // Mock a connection status request call.
@@ -700,7 +700,7 @@ suite('Webview Test Suite', () => {
       testTelemetryService
     );
 
-    testWebviewController.openWebview(mdbTestExtension.testExtensionContext);
+    void testWebviewController.openWebview(mdbTestExtension.testExtensionContext);
 
     await testConnectionController.addNewConnectionStringAndConnect(
       TEST_DATABASE_URI
@@ -717,7 +717,7 @@ suite('Webview Test Suite', () => {
         testConnectionController.getActiveConnectionId()
     );
 
-    testConnectionController.disconnect();
+    await testConnectionController.disconnect();
   });
 
   suite('with a rendered webview', () => {

--- a/src/utils/linkHelper.ts
+++ b/src/utils/linkHelper.ts
@@ -43,7 +43,7 @@ export const openLink = (url: string, serverPort = 3211): Promise<Server> => new
   });
 
   server.listen(serverPort, () => {
-    vscode.commands.executeCommand(
+    void vscode.commands.executeCommand(
       'vscode.open',
       vscode.Uri.parse(`http://localhost:${serverPort}`)
     );

--- a/src/views/webviewController.ts
+++ b/src/views/webviewController.ts
@@ -96,7 +96,7 @@ export default class WebviewController {
 
       try {
         // The webview may have been closed in which case this will throw.
-        panel.webview.postMessage({
+        void panel.webview.postMessage({
           command: MESSAGE_TYPES.CONNECT_RESULT,
           connectionAttemptId,
           connectionSuccess: successfullyConnected,
@@ -108,9 +108,9 @@ export default class WebviewController {
         log.error('Unable to send connection result to webview:', err);
       }
     } catch (error) {
-      vscode.window.showErrorMessage(`Unable to load connection: ${error}`);
+      void vscode.window.showErrorMessage(`Unable to load connection: ${error}`);
 
-      panel.webview.postMessage({
+      void panel.webview.postMessage({
         command: MESSAGE_TYPES.CONNECT_RESULT,
         connectionAttemptId,
         connectionSuccess: false,
@@ -127,7 +127,7 @@ export default class WebviewController {
       ...openFileOptions,
       canSelectMany: message.multi
     });
-    panel.webview.postMessage({
+    void panel.webview.postMessage({
       command: MESSAGE_TYPES.FILE_PICKER_RESULTS,
       action: message.action,
       files: (files && files.length > 0)
@@ -149,12 +149,12 @@ export default class WebviewController {
         );
         return;
       case MESSAGE_TYPES.CREATE_NEW_PLAYGROUND:
-        vscode.commands.executeCommand(
+        void vscode.commands.executeCommand(
           EXTENSION_COMMANDS.MDB_CREATE_PLAYGROUND_FROM_OVERVIEW_PAGE
         );
         return;
       case MESSAGE_TYPES.GET_CONNECTION_STATUS:
-        panel.webview.postMessage({
+        void panel.webview.postMessage({
           command: MESSAGE_TYPES.CONNECTION_STATUS_MESSAGE,
           connectionStatus: this._connectionController.getConnectionStatus(),
           activeConnectionName: this._connectionController.getActiveConnectionName()
@@ -164,7 +164,7 @@ export default class WebviewController {
         await this.handleWebviewOpenFilePickerRequest(message, panel);
         return;
       case MESSAGE_TYPES.OPEN_CONNECTION_STRING_INPUT:
-        vscode.commands.executeCommand(EXTENSION_COMMANDS.MDB_CONNECT_WITH_URI);
+        void vscode.commands.executeCommand(EXTENSION_COMMANDS.MDB_CONNECT_WITH_URI);
 
         return;
 
@@ -189,7 +189,7 @@ export default class WebviewController {
 
       case MESSAGE_TYPES.RENAME_ACTIVE_CONNECTION:
         if (this._connectionController.isCurrentlyConnected()) {
-          this._connectionController.renameConnection(
+          void this._connectionController.renameConnection(
             this._connectionController.getActiveConnectionId() as string
           );
         }


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
Moving toward async/await instead of using promises, it would be nice to have a tool that ensures proper call of async functions that do or do not expect awaiting the result. For example, forgetting `await` before `connect()` would definitely cause the connectivity issue. But we do not want to await telemetry events or other processes that could happen parallel to the main flow.

This PR adds `no-floating-promises` aslant rule that complains when await keyword is missing before async function call. If the function doesn't have to wait for a result, the void keyword should be used instead. It makes code safer and easier to read because you explicitly can see the expected behaviour.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
