### PR TITLE
fix(connect-form): fix wsl file path resolving VSCODE-284

### DIFF
--- a/src/test/suite/views/webviewController.test.ts
+++ b/src/test/suite/views/webviewController.test.ts
@@ -449,11 +449,19 @@ suite('Webview Test Suite', () => {
     const fakeWebview = {
       html: '',
       postMessage: async (message): Promise<void> => {
-        assert(message.action === 'file_action');
-        assert(message.files[0] === path.resolve('somefilepath/test.text'));
+        try {
+          assert.strictEqual(message.action, 'file_action');
+          assert.strictEqual(
+            message.files[0],
+            '/somefilepath/test.text'
+          );
+
+          done();
+        } catch (e) {
+          done(e);
+        }
 
         await testConnectionController.disconnect();
-        done();
       },
       onDidReceiveMessage: (callback): void => {
         messageReceived = callback;

--- a/src/views/webviewController.ts
+++ b/src/views/webviewController.ts
@@ -131,7 +131,7 @@ export default class WebviewController {
       command: MESSAGE_TYPES.FILE_PICKER_RESULTS,
       action: message.action,
       files: (files && files.length > 0)
-        ? files.map((file) => path.resolve(file.path.substr(1)))
+        ? files.map((file) => file.path)
         : undefined
     });
   };


### PR DESCRIPTION
VSCODE-284

Fixes opening files on wsl. Remove the resolving of the file path, since it's resolved later. Not sure why we were doing it, looks like something I introduced lol. Maybe it was needed for the connection model & driver at the time.

Tested manually on wsl & mac w/ a tls file.


https://user-images.githubusercontent.com/1791149/131749631-8c5e905b-5591-4bef-9c5e-5452b01bbf6f.mp4





