### PR TITLE
fix(connect-form): Update file path resolve to use fsPath instead of path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "debug": "^4.3.2",
         "dotenv": "^8.2.0",
         "micromatch": "^4.0.4",
-        "mongodb": "^4.1.0",
+        "mongodb": "^4.1.2",
         "mongodb-cloud-info": "^1.1.2",
         "mongodb-connection-model": "^21.5.4",
         "mongodb-data-service": "^21.5.4",
@@ -4317,9 +4317,9 @@
       }
     },
     "node_modules/bson": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.4.1.tgz",
-      "integrity": "sha512-Uu4OCZa0jouQJCKOk1EmmyqtdWAP5HVLru4lQxTwzJzxT+sJ13lVpEZU/MATDxtHiekWMAL84oQY3Xn1LpJVSg==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.5.2.tgz",
+      "integrity": "sha512-8CEMJpwc7qlQtrn2rney38jQSEeMar847lz0LyitwRmVknAW8iHXrzW4fTjHfyWm0E3sukyD/zppdH+QU1QefA==",
       "dependencies": {
         "buffer": "^5.6.0"
       },
@@ -15867,19 +15867,19 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.1.0.tgz",
-      "integrity": "sha512-Gx9U9MsFWgJ3E0v4oHAdWvYTGBznNYPCkhmD/3i/kPTY/URnPfHD5/6VoKUFrdgQTK3icFiM9976hVbqCRBO9Q==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.1.2.tgz",
+      "integrity": "sha512-pHCKDoOy1h6mVurziJmXmTMPatYWOx8pbnyFgSgshja9Y36Q+caHUzTDY6rrIy9HCSrjnbXmx3pCtvNZHmR8xg==",
       "dependencies": {
-        "bson": "^4.4.0",
-        "denque": "^1.5.0",
-        "mongodb-connection-string-url": "^1.0.1"
+        "bson": "^4.5.2",
+        "denque": "^2.0.1",
+        "mongodb-connection-string-url": "^2.0.0"
       },
       "engines": {
         "node": ">=12.9.0"
       },
       "optionalDependencies": {
-        "saslprep": "^1.0.0"
+        "saslprep": "^1.0.3"
       }
     },
     "node_modules/mongodb-ace-autocompleter": {
@@ -17123,6 +17123,35 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mongodb/node_modules/denque": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.0.1.tgz",
+      "integrity": "sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ==",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/mongodb/node_modules/mongodb-connection-string-url": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.1.0.tgz",
+      "integrity": "sha512-Qf9Zw7KGiRljWvMrrUFDdVqo46KIEiDuCzvEN97rh/PcKzk2bd6n9KuzEwBwW9xo5glwx69y1mI6s+jFUD/aIQ==",
+      "dependencies": {
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^9.1.0"
+      }
+    },
+    "node_modules/mongodb/node_modules/whatwg-url": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-9.1.0.tgz",
+      "integrity": "sha512-CQ0UcrPHyomtlOCot1TL77WyMIm/bCwrJ2D6AOKGwEczU9EpyoqAokfqrf/MioU9kHcMsmJZcg1egXix2KYEsA==",
+      "dependencies": {
+        "tr46": "^2.1.0",
+        "webidl-conversions": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/mongodb3": {
@@ -27921,9 +27950,9 @@
       }
     },
     "bson": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.4.1.tgz",
-      "integrity": "sha512-Uu4OCZa0jouQJCKOk1EmmyqtdWAP5HVLru4lQxTwzJzxT+sJ13lVpEZU/MATDxtHiekWMAL84oQY3Xn1LpJVSg==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.5.2.tgz",
+      "integrity": "sha512-8CEMJpwc7qlQtrn2rney38jQSEeMar847lz0LyitwRmVknAW8iHXrzW4fTjHfyWm0E3sukyD/zppdH+QU1QefA==",
       "requires": {
         "buffer": "^5.6.0"
       }
@@ -37644,14 +37673,39 @@
       "optional": true
     },
     "mongodb": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.1.0.tgz",
-      "integrity": "sha512-Gx9U9MsFWgJ3E0v4oHAdWvYTGBznNYPCkhmD/3i/kPTY/URnPfHD5/6VoKUFrdgQTK3icFiM9976hVbqCRBO9Q==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.1.2.tgz",
+      "integrity": "sha512-pHCKDoOy1h6mVurziJmXmTMPatYWOx8pbnyFgSgshja9Y36Q+caHUzTDY6rrIy9HCSrjnbXmx3pCtvNZHmR8xg==",
       "requires": {
-        "bson": "^4.4.0",
-        "denque": "^1.5.0",
-        "mongodb-connection-string-url": "^1.0.1",
-        "saslprep": "^1.0.0"
+        "bson": "^4.5.2",
+        "denque": "^2.0.1",
+        "mongodb-connection-string-url": "^2.0.0",
+        "saslprep": "^1.0.3"
+      },
+      "dependencies": {
+        "denque": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/denque/-/denque-2.0.1.tgz",
+          "integrity": "sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ=="
+        },
+        "mongodb-connection-string-url": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.1.0.tgz",
+          "integrity": "sha512-Qf9Zw7KGiRljWvMrrUFDdVqo46KIEiDuCzvEN97rh/PcKzk2bd6n9KuzEwBwW9xo5glwx69y1mI6s+jFUD/aIQ==",
+          "requires": {
+            "@types/whatwg-url": "^8.2.1",
+            "whatwg-url": "^9.1.0"
+          }
+        },
+        "whatwg-url": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-9.1.0.tgz",
+          "integrity": "sha512-CQ0UcrPHyomtlOCot1TL77WyMIm/bCwrJ2D6AOKGwEczU9EpyoqAokfqrf/MioU9kHcMsmJZcg1egXix2KYEsA==",
+          "requires": {
+            "tr46": "^2.1.0",
+            "webidl-conversions": "^6.1.0"
+          }
+        }
       }
     },
     "mongodb-ace-autocompleter": {

--- a/package.json
+++ b/package.json
@@ -879,7 +879,7 @@
     "debug": "^4.3.2",
     "dotenv": "^8.2.0",
     "micromatch": "^4.0.4",
-    "mongodb": "^4.1.0",
+    "mongodb": "^4.1.2",
     "mongodb-cloud-info": "^1.1.2",
     "mongodb-connection-model": "^21.5.4",
     "mongodb-data-service": "^21.5.4",

--- a/src/test/suite/views/webviewController.test.ts
+++ b/src/test/suite/views/webviewController.test.ts
@@ -480,7 +480,7 @@ suite('Webview Test Suite', () => {
 
     const fakeVSCodeOpenDialog = sinon.fake.resolves([
       {
-        path: '/somefilepath/test.text'
+        fsPath: '/somefilepath/test.text'
       }
     ]);
 

--- a/src/views/webviewController.ts
+++ b/src/views/webviewController.ts
@@ -131,7 +131,7 @@ export default class WebviewController {
       command: MESSAGE_TYPES.FILE_PICKER_RESULTS,
       action: message.action,
       files: (files && files.length > 0)
-        ? files.map((file) => file.path)
+        ? files.map((file) => file.fsPath)
         : undefined
     });
   };


### PR DESCRIPTION
We were using `path` instead of `fsPath` which was resolving incorrectly on windows.

Tested manually w/ window, ubuntu, and mac connecting w/ x509 pem file.
Would be nice to find a way to test this dialog resolving using the different systems in our ci.

https://code.visualstudio.com/api/references/vscode-api#Uri
