### PR TITLE
deps: bump mongodb driver patch version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "debug": "^4.3.2",
         "dotenv": "^8.2.0",
         "micromatch": "^4.0.4",
-        "mongodb": "^4.1.2",
+        "mongodb": "^4.1.3",
         "mongodb-cloud-info": "^1.1.2",
         "mongodb-connection-model": "^21.5.4",
         "mongodb-data-service": "^21.5.4",
@@ -15867,9 +15867,9 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.1.2.tgz",
-      "integrity": "sha512-pHCKDoOy1h6mVurziJmXmTMPatYWOx8pbnyFgSgshja9Y36Q+caHUzTDY6rrIy9HCSrjnbXmx3pCtvNZHmR8xg==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.1.3.tgz",
+      "integrity": "sha512-lHvTqODBiSpuqjpCj48DOyYWS6Iq6ElJNUiH9HWdQtONyOfjgsKzJULipWduMGsSzaNO4nFi/kmlMFCLvjox/Q==",
       "dependencies": {
         "bson": "^4.5.2",
         "denque": "^2.0.1",
@@ -37673,9 +37673,9 @@
       "optional": true
     },
     "mongodb": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.1.2.tgz",
-      "integrity": "sha512-pHCKDoOy1h6mVurziJmXmTMPatYWOx8pbnyFgSgshja9Y36Q+caHUzTDY6rrIy9HCSrjnbXmx3pCtvNZHmR8xg==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.1.3.tgz",
+      "integrity": "sha512-lHvTqODBiSpuqjpCj48DOyYWS6Iq6ElJNUiH9HWdQtONyOfjgsKzJULipWduMGsSzaNO4nFi/kmlMFCLvjox/Q==",
       "requires": {
         "bson": "^4.5.2",
         "denque": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -879,7 +879,7 @@
     "debug": "^4.3.2",
     "dotenv": "^8.2.0",
     "micromatch": "^4.0.4",
-    "mongodb": "^4.1.2",
+    "mongodb": "^4.1.3",
     "mongodb-cloud-info": "^1.1.2",
     "mongodb-connection-model": "^21.5.4",
     "mongodb-data-service": "^21.5.4",


### PR DESCRIPTION
Looks like our our local install dep listing is a bit strict on patch version and throws an error when it's not up to date. 
Bumps mongodb node driver version to fix https://github.com/mongodb-js/vscode/issues/353