### PR TITLE
build: try to bump mongodb-ace-autocompleter version

### DIFF
--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -45,13 +45,6 @@ jobs:
       - name: Install npm@7
         run: npm install -g npm@7
 
-      - name: Patch node gyp on Windows
-        if: ${{ runner.os == 'Windows' }}
-        shell: powershell
-        run: |
-          npm install --global node-gyp
-          npm prefix -g | % {npm config set node_gyp "$_\node_modules\node-gyp\bin\node-gyp.js"}
-
       - name: Install Dependencies
         run: npm ci
 
@@ -64,13 +57,6 @@ jobs:
       - name: Run Tests
         run: npm run test
         shell: bash
-
-      - name: Unset global node gyp on Windows
-        if: ${{ runner.os == 'Windows' }}
-        shell: powershell
-        run: |
-          npm config delete node_gyp
-          npm uninstall --global node-gyp
 
       - name: Prepare build for release
         shell: bash

--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           # Version Spec of the version to use.  Examples: 12.x, 10.15.1, >=10.15.0
-          node-version: 14.17.3
+          node-version: ^14.17.3
 
       - name: Install npm@7
         run: npm install -g npm@7

--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -65,6 +65,13 @@ jobs:
         run: npm run test
         shell: bash
 
+      - name: Unset global node gyp on Windows
+        if: ${{ runner.os == 'Windows' }}
+        shell: powershell
+        run: |
+          npm config delete node_gyp
+          npm uninstall --global node-gyp
+
       - name: Prepare build for release
         shell: bash
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -43,7 +43,14 @@ jobs:
           node-version: ^14.17.3
 
       - name: Install npm@7
-        run: npm install -g npm@7
+        run: npm install -g npm@7.19.1
+
+      - name: Patch node gyp on Windows
+        if: ${{ runner.os == 'Windows' }}
+        shell: powershell
+        run: |
+          npm install --global node-gyp
+          npm prefix -g | % {npm config set node_gyp "$_\node_modules\node-gyp\bin\node-gyp.js"}
 
       - name: Install Dependencies
         run: npm ci
@@ -57,6 +64,13 @@ jobs:
       - name: Run Tests
         run: npm run test
         shell: bash
+
+      - name: Unset global node gyp on Windows
+        if: ${{ runner.os == 'Windows' }}
+        shell: powershell
+        run: |
+          npm config delete node_gyp
+          npm uninstall --global node-gyp
 
       - name: Prepare build for release
         shell: bash

--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -43,12 +43,14 @@ jobs:
           node-version: ^14.17.3
 
       - name: Install npm@7
-        run: npm install -g npm@7.19.1
+        run: npm install -g npm@7
 
       - name: Patch node gyp on Windows
         if: ${{ runner.os == 'Windows' }}
         shell: powershell
         run: |
+          npm config delete node_gyp
+          npm uninstall --global node-gyp
           npm install --global node-gyp
           npm prefix -g | % {npm config set node_gyp "$_\node_modules\node-gyp\bin\node-gyp.js"}
 
@@ -64,13 +66,6 @@ jobs:
       - name: Run Tests
         run: npm run test
         shell: bash
-
-      - name: Unset global node gyp on Windows
-        if: ${{ runner.os == 'Windows' }}
-        shell: powershell
-        run: |
-          npm config delete node_gyp
-          npm uninstall --global node-gyp
 
       - name: Prepare build for release
         shell: bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,7 @@
         "mocha": "^8.4.0",
         "mocha-junit-reporter": "^2.0.2",
         "mocha-multi": "^1.1.5",
-        "mongodb-ace-autocompleter": "^0.9.0",
+        "mongodb-ace-autocompleter": "^0.8.0",
         "mongodb-build-info": "^1.2.0",
         "mongodb-runner": "^4.8.3",
         "node-loader": "^0.6.0",
@@ -1581,14 +1581,6 @@
       },
       "engines": {
         "node": ">=12.4.0"
-      }
-    },
-    "node_modules/@mongosh/autocomplete/node_modules/mongodb-ace-autocompleter": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.8.0.tgz",
-      "integrity": "sha512-I86NDpg6YDbZ2thoouClzlv8e0obZJI7urvFWE0B4cB2LdNVAYMAD5WnGnNOl8ySpNHrWDK/ESCRAPW4LeDAZQ==",
-      "dependencies": {
-        "semver": "^7.3.5"
       }
     },
     "node_modules/@mongosh/browser-runtime-core": {
@@ -16085,10 +16077,9 @@
       }
     },
     "node_modules/mongodb-ace-autocompleter": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.9.0.tgz",
-      "integrity": "sha512-vgbTBR+pcbAgXP/Ck/Jp7CH6kmU1IGt901n+ES8f5WMt8sibNor0sJaZohhsdld9aL0Wqaloya6OBoKodsYbKA==",
-      "dev": true,
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.8.0.tgz",
+      "integrity": "sha512-I86NDpg6YDbZ2thoouClzlv8e0obZJI7urvFWE0B4cB2LdNVAYMAD5WnGnNOl8ySpNHrWDK/ESCRAPW4LeDAZQ==",
       "dependencies": {
         "semver": "^7.3.5"
       }
@@ -25885,16 +25876,6 @@
         "@mongosh/shell-api": "1.1.4",
         "mongodb-ace-autocompleter": "^0.8.0",
         "semver": "^7.3.2"
-      },
-      "dependencies": {
-        "mongodb-ace-autocompleter": {
-          "version": "0.8.0",
-          "resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.8.0.tgz",
-          "integrity": "sha512-I86NDpg6YDbZ2thoouClzlv8e0obZJI7urvFWE0B4cB2LdNVAYMAD5WnGnNOl8ySpNHrWDK/ESCRAPW4LeDAZQ==",
-          "requires": {
-            "semver": "^7.3.5"
-          }
-        }
       }
     },
     "@mongosh/browser-runtime-core": {
@@ -38135,10 +38116,9 @@
       }
     },
     "mongodb-ace-autocompleter": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.9.0.tgz",
-      "integrity": "sha512-vgbTBR+pcbAgXP/Ck/Jp7CH6kmU1IGt901n+ES8f5WMt8sibNor0sJaZohhsdld9aL0Wqaloya6OBoKodsYbKA==",
-      "dev": true,
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.8.0.tgz",
+      "integrity": "sha512-I86NDpg6YDbZ2thoouClzlv8e0obZJI7urvFWE0B4cB2LdNVAYMAD5WnGnNOl8ySpNHrWDK/ESCRAPW4LeDAZQ==",
       "requires": {
         "semver": "^7.3.5"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,7 @@
         "mocha": "^8.4.0",
         "mocha-junit-reporter": "^2.0.2",
         "mocha-multi": "^1.1.5",
-        "mongodb-ace-autocompleter": "^0.8.0",
+        "mongodb-ace-autocompleter": "^0.10.0",
         "mongodb-build-info": "^1.2.0",
         "mongodb-runner": "^4.8.3",
         "node-loader": "^0.6.0",
@@ -1581,6 +1581,14 @@
       },
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@mongosh/autocomplete/node_modules/mongodb-ace-autocompleter": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.8.0.tgz",
+      "integrity": "sha512-I86NDpg6YDbZ2thoouClzlv8e0obZJI7urvFWE0B4cB2LdNVAYMAD5WnGnNOl8ySpNHrWDK/ESCRAPW4LeDAZQ==",
+      "dependencies": {
+        "semver": "^7.3.5"
       }
     },
     "node_modules/@mongosh/browser-runtime-core": {
@@ -16077,9 +16085,10 @@
       }
     },
     "node_modules/mongodb-ace-autocompleter": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.8.0.tgz",
-      "integrity": "sha512-I86NDpg6YDbZ2thoouClzlv8e0obZJI7urvFWE0B4cB2LdNVAYMAD5WnGnNOl8ySpNHrWDK/ESCRAPW4LeDAZQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.10.0.tgz",
+      "integrity": "sha512-dDC9ZtPtRYPInxJ1Pw54HF5Jnyz15zVM1tpGOMpk0tPyTqVrWAngfn9CjrxuGDGAguLqv6WhDOYwnlx15Hx+UQ==",
+      "dev": true,
       "dependencies": {
         "semver": "^7.3.5"
       }
@@ -25876,6 +25885,16 @@
         "@mongosh/shell-api": "1.1.4",
         "mongodb-ace-autocompleter": "^0.8.0",
         "semver": "^7.3.2"
+      },
+      "dependencies": {
+        "mongodb-ace-autocompleter": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.8.0.tgz",
+          "integrity": "sha512-I86NDpg6YDbZ2thoouClzlv8e0obZJI7urvFWE0B4cB2LdNVAYMAD5WnGnNOl8ySpNHrWDK/ESCRAPW4LeDAZQ==",
+          "requires": {
+            "semver": "^7.3.5"
+          }
+        }
       }
     },
     "@mongosh/browser-runtime-core": {
@@ -38116,9 +38135,10 @@
       }
     },
     "mongodb-ace-autocompleter": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.8.0.tgz",
-      "integrity": "sha512-I86NDpg6YDbZ2thoouClzlv8e0obZJI7urvFWE0B4cB2LdNVAYMAD5WnGnNOl8ySpNHrWDK/ESCRAPW4LeDAZQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.10.0.tgz",
+      "integrity": "sha512-dDC9ZtPtRYPInxJ1Pw54HF5Jnyz15zVM1tpGOMpk0tPyTqVrWAngfn9CjrxuGDGAguLqv6WhDOYwnlx15Hx+UQ==",
+      "dev": true,
       "requires": {
         "semver": "^7.3.5"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,7 @@
         "mocha": "^8.4.0",
         "mocha-junit-reporter": "^2.0.2",
         "mocha-multi": "^1.1.5",
-        "mongodb-ace-autocompleter": "^0.10.0",
+        "mongodb-ace-autocompleter": "^0.9.0",
         "mongodb-build-info": "^1.2.0",
         "mongodb-runner": "^4.8.3",
         "node-loader": "^0.6.0",
@@ -16085,9 +16085,9 @@
       }
     },
     "node_modules/mongodb-ace-autocompleter": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.10.0.tgz",
-      "integrity": "sha512-dDC9ZtPtRYPInxJ1Pw54HF5Jnyz15zVM1tpGOMpk0tPyTqVrWAngfn9CjrxuGDGAguLqv6WhDOYwnlx15Hx+UQ==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.9.0.tgz",
+      "integrity": "sha512-vgbTBR+pcbAgXP/Ck/Jp7CH6kmU1IGt901n+ES8f5WMt8sibNor0sJaZohhsdld9aL0Wqaloya6OBoKodsYbKA==",
       "dev": true,
       "dependencies": {
         "semver": "^7.3.5"
@@ -38135,9 +38135,9 @@
       }
     },
     "mongodb-ace-autocompleter": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.10.0.tgz",
-      "integrity": "sha512-dDC9ZtPtRYPInxJ1Pw54HF5Jnyz15zVM1tpGOMpk0tPyTqVrWAngfn9CjrxuGDGAguLqv6WhDOYwnlx15Hx+UQ==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.9.0.tgz",
+      "integrity": "sha512-vgbTBR+pcbAgXP/Ck/Jp7CH6kmU1IGt901n+ES8f5WMt8sibNor0sJaZohhsdld9aL0Wqaloya6OBoKodsYbKA==",
       "dev": true,
       "requires": {
         "semver": "^7.3.5"

--- a/package.json
+++ b/package.json
@@ -990,7 +990,7 @@
     "mocha": "^8.4.0",
     "mocha-junit-reporter": "^2.0.2",
     "mocha-multi": "^1.1.5",
-    "mongodb-ace-autocompleter": "^0.9.0",
+    "mongodb-ace-autocompleter": "^0.8.0",
     "mongodb-build-info": "^1.2.0",
     "mongodb-runner": "^4.8.3",
     "node-loader": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -990,7 +990,7 @@
     "mocha": "^8.4.0",
     "mocha-junit-reporter": "^2.0.2",
     "mocha-multi": "^1.1.5",
-    "mongodb-ace-autocompleter": "^0.10.0",
+    "mongodb-ace-autocompleter": "^0.9.0",
     "mongodb-build-info": "^1.2.0",
     "mongodb-runner": "^4.8.3",
     "node-loader": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -990,7 +990,7 @@
     "mocha": "^8.4.0",
     "mocha-junit-reporter": "^2.0.2",
     "mocha-multi": "^1.1.5",
-    "mongodb-ace-autocompleter": "^0.8.0",
+    "mongodb-ace-autocompleter": "^0.10.0",
     "mongodb-build-info": "^1.2.0",
     "mongodb-runner": "^4.8.3",
     "node-loader": "^0.6.0",


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. VSCODE-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
Tried the same thing to verify that CI behaves identically: https://github.com/mongodb-js/vscode/pull/378

Since each time we install the latest npm version we need to remember to unset global installed node-gyp: https://github.com/nodejs/node-gyp/blob/master/docs/Force-npm-to-use-global-node-gyp.md

The patch for node-gyp on Windows was added here: https://github.com/mongodb-js/vscode/pull/318

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
