### PR TITLE
chore: infer MongoClientOptions type instead of importing it

### DIFF
--- a/src/language/worker.ts
+++ b/src/language/worker.ts
@@ -1,5 +1,4 @@
 import { CliServiceProvider } from '@mongosh/service-provider-server';
-import type { MongoClientOptions } from '@mongosh/service-provider-server';
 import { CompletionItemKind } from 'vscode-languageserver/node';
 import { EJSON, Document } from 'bson';
 import { ElectronRuntime } from '@mongosh/browser-runtime-electron';
@@ -7,6 +6,9 @@ import parseSchema = require('mongodb-schema');
 import { parentPort, workerData } from 'worker_threads';
 import { PlaygroundResult, PlaygroundDebug, ShellExecuteAllResult } from '../types/playgroundType';
 import { ServerCommands } from './serverCommands';
+
+// MongoClientOptions is the second argument of CliServiceProvider.connect(connectionStr, options)
+type MongoClientOptions = NonNullable<Parameters<(typeof CliServiceProvider)['connect']>[1]>;
 
 interface EvaluationResult {
   printable: any;


### PR DESCRIPTION
Rather than importing it, define it in a slightly more reliable way
by referring to the second argument of `CliServiceProvider.connect()`.

For example, this also enables usage of `tlsUseSystemCA`, which is
included in `DevtoolsConnectOptions` (which is now the actual type
accepted by `CliServiceProvider.connect()`) but not in the driver's
`MongoClientOptions`.

This is for fixing integration with https://github.com/mongodb-js/mongosh/pull/1241.

<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. VSCODE-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
