### PR TITLE
feat: add command to generate objectid

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ If you use Terraform to manage your infrastructure, MongoDB for VS Code helps yo
 - `mdb.connectionSaving.hideOptionToChooseWhereToSaveNewConnections`: When a connection is added, a prompt is shown that let's the user decide where the new connection should be saved. When this setting is checked, the prompt is not shown and the default connection saving location setting is used.
 - `mdb.connectionSaving.defaultConnectionSavingLocation`: When the setting that hides the option to choose where to save new connections is checked, this setting sets if and where new connections are saved.
 - `mdb.useDefaultTemplateForPlayground`: Choose whether to use the default template for playground files or to start with an empty playground editor.
+- `mdb.uniqueObjectIdPerCursor`: The default behavior is to generate a single ObjectId and insert it on all cursors. Set to true to generate a unique ObjectId per cursor instead.
 - `mdb.sendTelemetry`: Opt-in and opt-out for diagnostic and telemetry collection.
 
 ![Settings](resources/screenshots/settings.png)

--- a/package.json
+++ b/package.json
@@ -76,6 +76,8 @@
     "onCommand:mdb.removeConnection",
     "onCommand:mdb.openMongoDBShell",
     "onCommand:mdb.saveMongoDBDocument",
+    "onCommand:mdb.insertObjectIdToEditor",
+    "onCommand:mdb.generateObjectIdToClipboard",
     "onView:mongoDB",
     "onView:mongoDBConnectionExplorer",
     "onView:mongoDBPlaygroundsExplorer",
@@ -393,6 +395,14 @@
           "light": "images/light/plus-circle.svg",
           "dark": "images/dark/plus-circle.svg"
         }
+      },
+      {
+        "command": "mdb.insertObjectIdToEditor",
+        "title": "MongoDB: Insert ObjectId to Editor"
+      },
+      {
+        "command": "mdb.generateObjectIdToClipboard",
+        "title": "MongoDB: Generate ObjectId to Clipboard"
       }
     ],
     "menus": {
@@ -896,6 +906,11 @@
           "type": "boolean",
           "default": true,
           "description": "Use default template for playground files."
+        },
+        "mdb.uniqueObjectIdPerCursor": {
+          "type": "boolean",
+          "default": false,
+          "description": "The default behavior is to generate a single ObjectId and insert it on all cursors. Set to true to generate a unique ObjectId per cursor instead."
         }
       }
     }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -57,7 +57,9 @@ enum EXTENSION_COMMANDS {
   MDB_REFRESH_SCHEMA = 'mdb.refreshSchema',
   MDB_COPY_SCHEMA_FIELD_NAME = 'mdb.copySchemaFieldName',
   MDB_REFRESH_INDEXES = 'mdb.refreshIndexes',
-  MDB_CREATE_INDEX_TREE_VIEW = 'mdb.createIndexFromTreeView'
+  MDB_CREATE_INDEX_TREE_VIEW = 'mdb.createIndexFromTreeView',
+  MDB_INSERT_OBJECTID_TO_EDITOR = 'mdb.insertObjectIdToEditor',
+  MDB_GENERATE_OBJECTID_TO_CLIPBOARD = 'mdb.generateObjectIdToClipboard'
 }
 
 export default EXTENSION_COMMANDS;

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -37,6 +37,7 @@ import TelemetryService from './telemetry/telemetryService';
 import PlaygroundsTreeItem from './explorer/playgroundsTreeItem';
 import PlaygroundResultProvider from './editors/playgroundResultProvider';
 import WebviewController from './views/webviewController';
+import { createIdFactory, generateId } from './utils/objectIdHelper';
 
 const log = createLogger('commands');
 
@@ -539,6 +540,37 @@ export default class MDBExtensionController implements vscode.Disposable {
       EXTENSION_COMMANDS.MDB_OPEN_PLAYGROUND_FROM_TREE_VIEW,
       (playgroundsTreeItem: PlaygroundsTreeItem) =>
         this._playgroundController.openPlayground(playgroundsTreeItem.filePath)
+    );
+    this.registerCommand(
+      EXTENSION_COMMANDS.MDB_INSERT_OBJECTID_TO_EDITOR,
+      async (): Promise<boolean> => {
+        const editor = vscode.window.activeTextEditor;
+
+        if (!editor) {
+          void vscode.window.showInformationMessage('No active editor to insert to.');
+          return false;
+        }
+
+        const objectIdFactory = createIdFactory();
+
+        await editor.edit((editBuilder) => {
+          const { selections } = editor;
+
+          for (const selection of selections) {
+            editBuilder.replace(selection, objectIdFactory().toHexString());
+          }
+        });
+        return true;
+      }
+    );
+    this.registerCommand(
+      EXTENSION_COMMANDS.MDB_GENERATE_OBJECTID_TO_CLIPBOARD,
+      async (): Promise<boolean> => {
+        await vscode.env.clipboard.writeText(generateId().toHexString());
+        void vscode.window.showInformationMessage('Copied to clipboard.');
+
+        return true;
+      }
     );
   }
 

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -50,6 +50,8 @@ suite('Extension Test Suite', () => {
       'mdb.copySchemaFieldName',
       'mdb.refreshIndexes',
       'mdb.createIndexFromTreeView',
+      'mdb.insertObjectIdToEditor',
+      'mdb.generateObjectIdToClipboard',
 
       // Editor commands.
       'mdb.codeLens.showMoreDocumentsClicked',
@@ -57,11 +59,11 @@ suite('Extension Test Suite', () => {
       ...Object.values(EXTENSION_COMMANDS)
     ];
 
-    for (let i = 0; i < expectedCommands.length; i++) {
-      assert.notEqual(
-        registeredCommands.indexOf(expectedCommands[i]),
+    for (const expectedCommand of expectedCommands) {
+      assert.notStrictEqual(
+        registeredCommands.indexOf(expectedCommand),
         -1,
-        `command ${expectedCommands[i]} not registered and was expected`
+        `command ${expectedCommand} not registered and was expected`
       );
     }
   });

--- a/src/test/suite/utils/objectIdHelper.test.ts
+++ b/src/test/suite/utils/objectIdHelper.test.ts
@@ -1,0 +1,41 @@
+import vscode from 'vscode';
+import { expect } from 'chai';
+
+import { createIdFactory, generateId } from '../../../utils/objectIdHelper';
+
+const CONFIG_SECTION = 'mdb';
+const CONFIG_NAME = 'uniqueObjectIdPerCursor';
+
+suite('ObjectId Test Suite', () => {
+  test('succesfully creates an ObjectId', () => {
+    expect(() => generateId()).not.to.throw();
+  });
+
+  test('should generate the same ObjectId when config is false', async () => {
+    await vscode.workspace
+      .getConfiguration(CONFIG_SECTION)
+      .update(CONFIG_NAME, false);
+
+    const idFactory = createIdFactory();
+    const ids = [
+      idFactory(),
+      idFactory()
+    ];
+
+    expect(ids[0]).to.equal(ids[1]);
+  });
+
+  test('should generate unique ObjectIds when config is true', async () => {
+    await vscode.workspace
+      .getConfiguration(CONFIG_SECTION)
+      .update(CONFIG_NAME, true);
+
+    const idFactory = createIdFactory();
+    const ids = [
+      idFactory(),
+      idFactory()
+    ];
+
+    expect(ids[0]).to.not.equal(ids[1]);
+  });
+});

--- a/src/utils/objectIdHelper.ts
+++ b/src/utils/objectIdHelper.ts
@@ -1,0 +1,19 @@
+import * as vscode from 'vscode';
+import { ObjectId } from 'bson';
+
+export function createIdFactory(): () => ObjectId {
+  const uniqueObjectIdPerCursor = vscode.workspace
+    .getConfiguration('mdb')
+    .get('uniqueObjectIdPerCursor', false);
+
+  if (uniqueObjectIdPerCursor) {
+    return () => new ObjectId();
+  }
+
+  const staticObjectId = new ObjectId();
+  return () => staticObjectId;
+}
+
+export function generateId(): ObjectId {
+  return new ObjectId();
+}


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. VSCODE-1111: updates ace editor width in agg pipeline view -->
## Related
* Closes https://github.com/mongodb-js/vscode/issues/415

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
Adds 2 commands and 1 configuration setting.

`mdb.insertObjectIdToEditor` - Generates an ObjectId and inserts it to the editor.

`mdb.generateObjectIdToClipboard` - Generates an ObjectId and saves it to the clipboard.

`mdb.uniqueObjectIdPerCursor` - If we should use the same or unique ObjectId when `mdb.insertObjectIdToEditor` is called with multiple cursors/selections.

<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Not really a problem, but I'd just find it pretty convenient if I could generate and insert ObjectIds into the editor through a command.

This is usually while creating fixtures for testing or sharing examples of models.

<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)

![Peek 2022-05-24 22-31](https://user-images.githubusercontent.com/22801583/170136058-f4275c1d-263a-4a2c-aca4-e26e71112009.gif)