### PR TITLE
feat: support getCollection for names and shell methods

### DIFF
--- a/src/language/visitor.ts
+++ b/src/language/visitor.ts
@@ -233,7 +233,7 @@ export class Visitor {
   }
 
   _checkIsObjectKey(node: babel.types.ObjectExpression): void {
-    this._state.isObjectKey = !!node.properties.find(
+    this._state.isObjectKey ||= !!node.properties.find(
       (item: any) => !!(item.key.name && item.key.name.includes(PLACEHOLDER))
     );
   }


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. VSCODE-1111: updates ace editor width in agg pipeline view -->

Currently this implementation is unpolished, but it works fine in my local install.

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
Parsed out calls to `getCollection` so that they will also be given completion. Also, detect when the collection is being typed out as a string so that completion works properly. 
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist

I'll do these if the feature is desired.

- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context

The default "Search For Documents" option on a collection creates a playground document with `db.getCollection('collection_name')`, but the language service only provides completion when accessing the collection like `db.collection_name`.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
I'm not sure about the names of the props in the `CompletionState`, so some feedback there would be appreciated.

The tests to filter on the correct AST node generate high complexity in the eslint complexity check, so I did a bit of refactoring. Methods could be cleaned up in general. Not sure how far i should go, or the style i should use in appeasing eslint there.

The commits could also be split up a bit more. Let me know if you want that.

In the longer term, I'd suggest moving towards using, or at least supporting a typescript plugin, but that's out of scope for this simpler change. I'd also like editor suggestions for query parameters, but that might be more maintainable in typescript definitions. At least, I'll create a feature request for it. I saw that there's definitions for those completions in `mongodb-ace-autocompleter`, but the operators dont have the same links to documentation that the aggregation pipeline stages do.

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
