### PR TITLE
fix(help-explorer): remove extra data provider tree register VSCODE-343

### DIFF
--- a/src/explorer/helpExplorer.ts
+++ b/src/explorer/helpExplorer.ts
@@ -23,10 +23,6 @@ export default class HelpExplorer {
         this._treeView,
         telemetryService
       );
-      vscode.window.registerTreeDataProvider(
-        'mongoDBHelpExplorer',
-        this._treeController
-      );
     }
   }
 


### PR DESCRIPTION
VSCODE-343
Doesn't need to be in release notes as the bug wasn't released. Looks like we added an extra `registerTreeDataProvider` to the help tree although it is already registered in the previous lines when we pass the `treeDataProvider` to `createTreeView`. This resulted in it not handling the tree selections (no link clicks). 
https://github.com/mongodb-js/vscode/pull/437/files#diff-9bc69eef7e7b5c6202fdac33a5f439e7ca8be35d80a56724d4b49b3e6c7f38f6R26

More on tree data providers: https://code.visualstudio.com/api/extension-guides/tree-view#registering-the-treedataprovider