### PR TITLE
feat(tree-explorer): Add open and copy document tree view context menu items VSCODE-348

### DIFF
--- a/package.json
+++ b/package.json
@@ -404,6 +404,14 @@
       {
         "command": "mdb.generateObjectIdToClipboard",
         "title": "MongoDB: Generate ObjectId to Clipboard"
+      },
+      {
+        "command": "mdb.openMongoDBDocumentFromTree",
+        "title": "Open Document"
+      },
+      {
+        "command": "mdb.copyDocumentContentsFromTreeView",
+        "title": "Copy Document"
       }
     ],
     "menus": {
@@ -590,6 +598,16 @@
         {
           "command": "mdb.createIndexFromTreeView",
           "when": "view == mongoDBConnectionExplorer && viewItem == indexListTreeItem"
+        },
+        {
+          "command": "mdb.openMongoDBDocumentFromTree",
+          "when": "view == mongoDBConnectionExplorer && viewItem == documentTreeItem",
+          "group": "1@1"
+        },
+        {
+          "command": "mdb.copyDocumentContentsFromTreeView",
+          "when": "view == mongoDBConnectionExplorer && viewItem == documentTreeItem",
+          "group": "2@1"
         }
       ],
       "editor/title": [
@@ -754,6 +772,14 @@
         },
         {
           "command": "mdb.copySchemaFieldName",
+          "when": "false"
+        },
+        {
+          "command": "mdb.openMongoDBDocumentFromTree",
+          "when": "false"
+        },
+        {
+          "command": "mdb.copyDocumentContentsFromTreeView",
           "when": "false"
         }
       ]

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -60,6 +60,7 @@ enum EXTENSION_COMMANDS {
   MDB_CREATE_INDEX_TREE_VIEW = 'mdb.createIndexFromTreeView',
   MDB_INSERT_OBJECTID_TO_EDITOR = 'mdb.insertObjectIdToEditor',
   MDB_GENERATE_OBJECTID_TO_CLIPBOARD = 'mdb.generateObjectIdToClipboard',
+  MDB_COPY_DOCUMENT_CONTENTS_FROM_TREE_VIEW = 'mdb.copyDocumentContentsFromTreeView',
 }
 
 export default EXTENSION_COMMANDS;

--- a/src/editors/editorsController.ts
+++ b/src/editors/editorsController.ts
@@ -124,7 +124,6 @@ export default class EditorsController {
     this._documentIdStore = new DocumentIdStore();
     this._mongoDBDocumentService = new MongoDBDocumentService(
       this._context,
-      this._documentIdStore,
       this._connectionController,
       this._statusView,
       this._telemetryService

--- a/src/editors/mongoDBDocumentService.ts
+++ b/src/editors/mongoDBDocumentService.ts
@@ -4,7 +4,6 @@ import { EJSON, Document } from 'bson';
 
 import ConnectionController from '../connectionController';
 import { createLogger } from '../logging';
-import DocumentIdStore from './documentIdStore';
 import { DocumentSource } from '../documentSource';
 import type { EditDocumentInfo } from '../types/editDocumentInfoType';
 import formatError from '../utils/formatError';
@@ -21,20 +20,17 @@ export const VIEW_DOCUMENT_SCHEME = 'VIEW_DOCUMENT_SCHEME';
 
 export default class MongoDBDocumentService {
   _context: vscode.ExtensionContext;
-  _documentIdStore: DocumentIdStore;
   _connectionController: ConnectionController;
   _statusView: StatusView;
   _telemetryService: TelemetryService;
 
   constructor(
     context: vscode.ExtensionContext,
-    documentIdStore: DocumentIdStore,
     connectionController: ConnectionController,
     statusView: StatusView,
     telemetryService: TelemetryService
   ) {
     this._context = context;
-    this._documentIdStore = documentIdStore;
     this._connectionController = connectionController;
     this._statusView = statusView;
     this._telemetryService = telemetryService;

--- a/src/explorer/documentListTreeItem.ts
+++ b/src/explorer/documentListTreeItem.ts
@@ -7,6 +7,7 @@ import DocumentTreeItem from './documentTreeItem';
 import formatError from '../utils/formatError';
 import { getImagesPath } from '../extensionConstants';
 import TreeItemParent from './treeItemParentInterface';
+import type { DataService } from 'mongodb-data-service';
 
 const path = require('path');
 const log = createLogger('tree view document list');
@@ -104,7 +105,7 @@ export default class DocumentListTreeItem
   namespace: string;
   type: CollectionTypes;
 
-  private _dataService: any;
+  private _dataService: DataService;
 
   isExpanded: boolean;
 
@@ -112,7 +113,7 @@ export default class DocumentListTreeItem
     collectionName: string,
     databaseName: string,
     type: CollectionTypes,
-    dataService: any,
+    dataService: DataService,
     isExpanded: boolean,
     maxDocumentsToShow: number,
     cachedDocumentCount: number | null,
@@ -173,7 +174,8 @@ export default class DocumentListTreeItem
           new DocumentTreeItem(
             (pastTreeItem as DocumentTreeItem).document,
             this.namespace,
-            index
+            index,
+            this._dataService
           )
         );
       });
@@ -217,7 +219,12 @@ export default class DocumentListTreeItem
     if (documents) {
       documents.forEach((document, index) => {
         this._childrenCache.push(
-          new DocumentTreeItem(document, this.namespace, index)
+          new DocumentTreeItem(
+            document,
+            this.namespace,
+            index,
+            this._dataService
+          )
         );
       });
     }

--- a/src/explorer/documentTreeItem.ts
+++ b/src/explorer/documentTreeItem.ts
@@ -1,5 +1,9 @@
 import { EJSON } from 'bson';
 import * as vscode from 'vscode';
+import type { Document } from 'mongodb';
+import type { DataService } from 'mongodb-data-service';
+import { promisify } from 'util';
+import formatError from '../utils/formatError';
 
 export const DOCUMENT_ITEM = 'documentTreeItem';
 
@@ -10,10 +14,16 @@ export default class DocumentTreeItem
   contextValue = DOCUMENT_ITEM;
 
   namespace: string;
-  document: any;
+  dataService: DataService;
+  document: Document;
   documentId: EJSON.SerializableTypes;
 
-  constructor(document: any, namespace: string, documentIndexInTree: number) {
+  constructor(
+    document: Document,
+    namespace: string,
+    documentIndexInTree: number,
+    dataService: DataService
+  ) {
     // A document can not have a `_id` when it is in a view. In this instance
     // we just show the document's index in the tree.
     super(
@@ -27,6 +37,7 @@ export default class DocumentTreeItem
       ? JSON.stringify(document._id)
       : `Document ${documentIndexInTree + 1}`;
 
+    this.dataService = dataService;
     this.document = document;
     this.documentId = document._id;
     this.namespace = namespace;
@@ -40,5 +51,24 @@ export default class DocumentTreeItem
 
   getChildren(): Thenable<DocumentTreeItem[]> {
     return Promise.resolve([]);
+  }
+
+  async getStringifiedEJSONDocumentContents(): Promise<string> {
+    try {
+      const find = promisify(this.dataService.find.bind(this.dataService));
+      const documents = await find(
+        this.namespace,
+        { _id: this.documentId },
+        { limit: 1 }
+      );
+
+      if (!documents || documents.length === 0) {
+        throw new Error('document not found');
+      }
+
+      return EJSON.stringify(documents[0], undefined, 2);
+    } catch (error) {
+      throw new Error(formatError(error).message);
+    }
   }
 }

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -551,6 +551,17 @@ export default class MDBExtensionController implements vscode.Disposable {
         this._playgroundController.openPlayground(playgroundsTreeItem.filePath)
     );
     this.registerCommand(
+      EXTENSION_COMMANDS.MDB_COPY_DOCUMENT_CONTENTS_FROM_TREE_VIEW,
+      async (documentTreeItem: DocumentTreeItem): Promise<boolean> => {
+        const documentContents =
+          await documentTreeItem.getStringifiedEJSONDocumentContents();
+        await vscode.env.clipboard.writeText(documentContents);
+        void vscode.window.showInformationMessage('Copied to clipboard.');
+
+        return true;
+      }
+    );
+    this.registerCommand(
       EXTENSION_COMMANDS.MDB_INSERT_OBJECTID_TO_EDITOR,
       async (): Promise<boolean> => {
         const editor = vscode.window.activeTextEditor;

--- a/src/test/suite/editors/mongoDBDocumentService.test.ts
+++ b/src/test/suite/editors/mongoDBDocumentService.test.ts
@@ -5,7 +5,6 @@ import { EJSON } from 'bson';
 import sinon from 'sinon';
 
 import ConnectionController from '../../../connectionController';
-import DocumentIdStore from '../../../editors/documentIdStore';
 import { DocumentSource } from '../../../documentSource';
 import formatError from '../../../utils/formatError';
 import MongoDBDocumentService from '../../../editors/mongoDBDocumentService';
@@ -18,7 +17,6 @@ import { TestExtensionContext } from '../stubs';
 const expect = chai.expect;
 
 suite('MongoDB Document Service Test Suite', () => {
-  const testDocumentIdStore = new DocumentIdStore();
   const mockExtensionContext = new TestExtensionContext();
   const testStorageController = new StorageController(mockExtensionContext);
   const testStatusView = new StatusView(mockExtensionContext);
@@ -33,7 +31,6 @@ suite('MongoDB Document Service Test Suite', () => {
   );
   const testMongoDBDocumentService = new MongoDBDocumentService(
     mockExtensionContext,
-    testDocumentIdStore,
     testConnectionController,
     testStatusView,
     testTelemetryService

--- a/src/test/suite/explorer/documentListTreeItem.test.ts
+++ b/src/test/suite/explorer/documentListTreeItem.test.ts
@@ -1,5 +1,7 @@
 import * as vscode from 'vscode';
+import { before } from 'mocha';
 import assert from 'assert';
+import type { DataService } from 'mongodb-data-service';
 
 const { contributes } = require('../../../../package.json');
 
@@ -12,13 +14,19 @@ import DocumentListTreeItem, {
 import { DataServiceStub, mockDocuments } from '../stubs';
 
 suite('DocumentListTreeItem Test Suite', () => {
+  let dataServiceMock: DataService;
+
+  before(() => {
+    dataServiceMock = new DataServiceStub() as any as DataService;
+  });
+
   test('its context value should be in the package json', () => {
     let documentListRegisteredCommandInPackageJson = false;
     const testDocumentListTreeItem = new DocumentListTreeItem(
       'collectionName',
       'databaseName',
       CollectionTypes.collection,
-      'not_real_dataservice',
+      dataServiceMock,
       false,
       MAX_DOCUMENTS_VISIBLE,
       null,
@@ -44,7 +52,7 @@ suite('DocumentListTreeItem Test Suite', () => {
       'collectionName',
       'databaseName',
       CollectionTypes.collection,
-      'not_real_dataservice',
+      'not_real_dataservice' as any as DataService,
       false,
       MAX_DOCUMENTS_VISIBLE,
       null,
@@ -75,7 +83,7 @@ suite('DocumentListTreeItem Test Suite', () => {
         'mock_collection_name',
         'mock_db_name',
         CollectionTypes.collection,
-        new DataServiceStub(),
+        dataServiceMock,
         false,
         MAX_DOCUMENTS_VISIBLE,
         null,
@@ -96,7 +104,7 @@ suite('DocumentListTreeItem Test Suite', () => {
         'mock_collection_name',
         'mock_db_name',
         CollectionTypes.collection,
-        new DataServiceStub(),
+        dataServiceMock,
         false,
         MAX_DOCUMENTS_VISIBLE,
         null,
@@ -119,7 +127,7 @@ suite('DocumentListTreeItem Test Suite', () => {
       'mock_collection_name',
       'mock_db_name',
       CollectionTypes.view,
-      new DataServiceStub(),
+      dataServiceMock,
       false,
       MAX_DOCUMENTS_VISIBLE,
       null,
@@ -139,7 +147,7 @@ suite('DocumentListTreeItem Test Suite', () => {
       'mock_collection_name_1',
       'mock_db_name',
       CollectionTypes.collection,
-      new DataServiceStub(),
+      dataServiceMock,
       false,
       MAX_DOCUMENTS_VISIBLE,
       25,
@@ -166,7 +174,7 @@ suite('DocumentListTreeItem Test Suite', () => {
       'mock_collection_name_2',
       'mock_db_name',
       CollectionTypes.collection,
-      new DataServiceStub(),
+      dataServiceMock,
       false,
       MAX_DOCUMENTS_VISIBLE,
       25,
@@ -193,7 +201,7 @@ suite('DocumentListTreeItem Test Suite', () => {
       'mock_collection_name_3',
       'mock_db_name',
       CollectionTypes.collection,
-      new DataServiceStub(),
+      dataServiceMock,
       false,
       MAX_DOCUMENTS_VISIBLE,
       25,
@@ -225,7 +233,7 @@ suite('DocumentListTreeItem Test Suite', () => {
       'mock_collection_name_4',
       'mock_db_name',
       CollectionTypes.collection,
-      new DataServiceStub(),
+      dataServiceMock,
       false,
       MAX_DOCUMENTS_VISIBLE,
       25,
@@ -258,7 +266,7 @@ suite('DocumentListTreeItem Test Suite', () => {
       'mock_collection_name_1',
       'mock_db_name',
       CollectionTypes.collection,
-      new DataServiceStub(),
+      dataServiceMock,
       false,
       MAX_DOCUMENTS_VISIBLE,
       maxDocs,
@@ -275,7 +283,7 @@ suite('DocumentListTreeItem Test Suite', () => {
       'mock_collection_name_4',
       'mock_db_name',
       CollectionTypes.collection,
-      new DataServiceStub(),
+      dataServiceMock,
       false,
       MAX_DOCUMENTS_VISIBLE,
       maxDocs,
@@ -300,7 +308,7 @@ suite('DocumentListTreeItem Test Suite', () => {
       'mock_collection_name_4',
       'mock_db_name',
       CollectionTypes.view,
-      new DataServiceStub(),
+      dataServiceMock,
       false,
       MAX_DOCUMENTS_VISIBLE,
       null,
@@ -319,7 +327,7 @@ suite('DocumentListTreeItem Test Suite', () => {
       'mock_collection_name_4',
       'mock_db_name',
       CollectionTypes.collection,
-      new DataServiceStub(),
+      dataServiceMock,
       false,
       MAX_DOCUMENTS_VISIBLE,
       null,
@@ -340,7 +348,7 @@ suite('DocumentListTreeItem Test Suite', () => {
       'mock_collection_name_4',
       'mock_db_name',
       CollectionTypes.collection,
-      new DataServiceStub(),
+      dataServiceMock,
       false,
       MAX_DOCUMENTS_VISIBLE,
       25,
@@ -357,7 +365,7 @@ suite('DocumentListTreeItem Test Suite', () => {
       'mock_collection_name_4',
       'mock_db_name',
       CollectionTypes.collection,
-      new DataServiceStub(),
+      dataServiceMock,
       false,
       MAX_DOCUMENTS_VISIBLE,
       2200000,

--- a/src/test/suite/explorer/documentTreeItem.test.ts
+++ b/src/test/suite/explorer/documentTreeItem.test.ts
@@ -1,6 +1,10 @@
 import assert from 'assert';
+import type { DataService } from 'mongodb-data-service';
 
 import DocumentTreeItem from '../../../explorer/documentTreeItem';
+import { DataServiceStub } from '../stubs';
+
+const mockDataService = new DataServiceStub() as any as DataService;
 
 suite('DocumentTreeItem Test Suite', () => {
   test('it makes the document _id the label of the document tree item', function () {
@@ -11,7 +15,8 @@ suite('DocumentTreeItem Test Suite', () => {
     const testCollectionTreeItem = new DocumentTreeItem(
       mockDocument,
       'namespace',
-      1
+      1,
+      {} as any
     );
 
     const documentTreeItemLabel = testCollectionTreeItem.label;
@@ -34,7 +39,8 @@ suite('DocumentTreeItem Test Suite', () => {
     const testCollectionTreeItem = new DocumentTreeItem(
       mockDocument,
       'namespace',
-      1
+      1,
+      mockDataService
     );
 
     const documentTreeItemLabel = testCollectionTreeItem.label;
@@ -54,7 +60,8 @@ suite('DocumentTreeItem Test Suite', () => {
     const testCollectionTreeItem = new DocumentTreeItem(
       mockDocument,
       'namespace',
-      1
+      1,
+      mockDataService
     );
 
     const documentTreeItemLabel = testCollectionTreeItem.label;

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -52,6 +52,9 @@ suite('Extension Test Suite', () => {
       'mdb.createIndexFromTreeView',
       'mdb.insertObjectIdToEditor',
       'mdb.generateObjectIdToClipboard',
+      'mdb.openMongoDBDocumentFromTree',
+      'mdb.openMongoDBDocumentFromCodeLens',
+      'mdb.copyDocumentContentsFromTreeView',
 
       // Editor commands.
       'mdb.codeLens.showMoreDocumentsClicked',

--- a/src/test/suite/mdbExtensionController.test.ts
+++ b/src/test/suite/mdbExtensionController.test.ts
@@ -237,7 +237,7 @@ suite('MDBExtensionController Test Suite', function () {
       .then(done, done);
   });
 
-  test('mdb.copyConnectionString command should try to copy the driver url to the vscode env clipboard', async () => {
+  test('mdb.copyConnectionString command should try to copy the driver url to the vscode env clipboard', (done) => {
     const mockTreeItem = new ConnectionTreeItem(
       'craving_for_pancakes_with_maple_syrup',
       vscode.TreeItemCollapsibleState.None,
@@ -260,22 +260,22 @@ suite('MDBExtensionController Test Suite', function () {
       mockStubUri
     );
 
-    await vscode.commands.executeCommand(
-      'mdb.copyConnectionString',
-      mockTreeItem
-    );
-
-    assert(
-      mockCopyToClipboard.called,
-      'Expected "writeText" to be called on "vscode.env.clipboard".'
-    );
-    assert(
-      mockCopyToClipboard.firstArg === 'weStubThisUri',
-      `Expected the clipboard to be sent the uri string "weStubThisUri", found ${mockCopyToClipboard.firstArg}.`
-    );
+    vscode.commands
+      .executeCommand('mdb.copyConnectionString', mockTreeItem)
+      .then(() => {
+        assert(
+          mockCopyToClipboard.called,
+          'Expected "writeText" to be called on "vscode.env.clipboard".'
+        );
+        assert(
+          mockCopyToClipboard.firstArg === 'weStubThisUri',
+          `Expected the clipboard to be sent the uri string "weStubThisUri", found ${mockCopyToClipboard.firstArg}.`
+        );
+      })
+      .then(done, done);
   });
 
-  test('mdb.copyDatabaseName command should try to copy the database name to the vscode env clipboard', async () => {
+  test('mdb.copyDatabaseName command should try to copy the database name to the vscode env clipboard', (done) => {
     const mockTreeItem = new DatabaseTreeItem(
       'isClubMateTheBestDrinkEver',
       {},
@@ -290,18 +290,22 @@ suite('MDBExtensionController Test Suite', function () {
       readText: sinon.fake() as any,
     }));
 
-    await vscode.commands.executeCommand('mdb.copyDatabaseName', mockTreeItem);
-    assert(
-      mockCopyToClipboard.called,
-      'Expected "writeText" to be called on "vscode.env.clipboard".'
-    );
-    assert(
-      mockCopyToClipboard.firstArg === 'isClubMateTheBestDrinkEver',
-      `Expected the clipboard to be sent the uri string "isClubMateTheBestDrinkEver", found ${mockCopyToClipboard.firstArg}.`
-    );
+    vscode.commands
+      .executeCommand('mdb.copyDatabaseName', mockTreeItem)
+      .then(() => {
+        assert(
+          mockCopyToClipboard.called,
+          'Expected "writeText" to be called on "vscode.env.clipboard".'
+        );
+        assert(
+          mockCopyToClipboard.firstArg === 'isClubMateTheBestDrinkEver',
+          `Expected the clipboard to be sent the uri string "isClubMateTheBestDrinkEver", found ${mockCopyToClipboard.firstArg}.`
+        );
+      })
+      .then(done, done);
   });
 
-  test('mdb.copyCollectionName command should try to copy the collection name to the vscode env clipboard', async () => {
+  test('mdb.copyCollectionName command should try to copy the collection name to the vscode env clipboard', (done) => {
     const mockTreeItem = new CollectionTreeItem(
       {
         name: 'waterBuffalo',
@@ -320,18 +324,19 @@ suite('MDBExtensionController Test Suite', function () {
       readText: sinon.fake() as any,
     }));
 
-    await vscode.commands.executeCommand(
-      'mdb.copyCollectionName',
-      mockTreeItem
-    );
-    assert(
-      mockCopyToClipboard.called,
-      'Expected "writeText" to be called on "vscode.env.clipboard".'
-    );
-    assert(
-      mockCopyToClipboard.firstArg === 'waterBuffalo',
-      `Expected the clipboard to be sent the uri string "waterBuffalo", found ${mockCopyToClipboard.firstArg}.`
-    );
+    vscode.commands
+      .executeCommand('mdb.copyCollectionName', mockTreeItem)
+      .then(() => {
+        assert(
+          mockCopyToClipboard.called,
+          'Expected "writeText" to be called on "vscode.env.clipboard".'
+        );
+        assert(
+          mockCopyToClipboard.firstArg === 'waterBuffalo',
+          `Expected the clipboard to be sent the uri string "waterBuffalo", found ${mockCopyToClipboard.firstArg}.`
+        );
+      })
+      .then(done, done);
   });
 
   test('mdb.copySchemaFieldName command should try to copy the field name to the vscode env clipboard', async () => {
@@ -401,7 +406,7 @@ suite('MDBExtensionController Test Suite', function () {
       .then(done, done);
   });
 
-  test('mdb.refreshCollection command should reset the expanded state of its children and call to refresh the explorer controller', async () => {
+  test('mdb.refreshCollection command should reset the expanded state of its children and call to refresh the explorer controller', (done) => {
     const mockTreeItem = new CollectionTreeItem(
       {
         name: 'iSawACatThatLookedLikeALionToday',
@@ -427,15 +432,19 @@ suite('MDBExtensionController Test Suite', function () {
       mockExplorerControllerRefresh
     );
 
-    await vscode.commands.executeCommand('mdb.refreshCollection', mockTreeItem);
-    assert(
-      mockTreeItem.getSchemaChild().isExpanded === false,
-      'Expected collection tree item child to be reset to not expanded.'
-    );
-    assert(
-      mockExplorerControllerRefresh.called === true,
-      'Expected explorer controller refresh to be called.'
-    );
+    vscode.commands
+      .executeCommand('mdb.refreshCollection', mockTreeItem)
+      .then(() => {
+        assert(
+          mockTreeItem.getSchemaChild().isExpanded === false,
+          'Expected collection tree item child to be reset to not expanded.'
+        );
+        assert(
+          mockExplorerControllerRefresh.called === true,
+          'Expected explorer controller refresh to be called.'
+        );
+      })
+      .then(done, done);
   });
 
   test('mdb.refreshDocumentList command should update the document count and call to refresh the explorer controller', async () => {
@@ -795,7 +804,7 @@ suite('MDBExtensionController Test Suite', function () {
 
   // https://code.visualstudio.com/api/references/contribution-points#Sorting-of-groups
 
-  test('mdb.dropCollection calls dataservice to drop the collection after inputting the collection name', async () => {
+  test('mdb.dropCollection calls dataservice to drop the collection after inputting the collection name', (done) => {
     let calledNamespace = '';
     const testCollectionTreeItem = new CollectionTreeItem(
       { name: 'testColName', type: CollectionTypes.collection },
@@ -815,12 +824,13 @@ suite('MDBExtensionController Test Suite', function () {
     mockInputBoxResolves.onCall(0).resolves('testColName');
     sinon.replace(vscode.window, 'showInputBox', mockInputBoxResolves);
 
-    const successfullyDropped = await vscode.commands.executeCommand(
-      'mdb.dropCollection',
-      testCollectionTreeItem
-    );
-    assert(successfullyDropped);
-    assert(calledNamespace === 'testDbName.testColName');
+    vscode.commands
+      .executeCommand('mdb.dropCollection', testCollectionTreeItem)
+      .then((successfullyDropped) => {
+        assert(successfullyDropped);
+        assert(calledNamespace === 'testDbName.testColName');
+      })
+      .then(done, done);
   });
 
   test('mdb.dropCollection fails when a collection doesnt exist', (done) => {
@@ -1499,7 +1509,7 @@ suite('MDBExtensionController Test Suite', function () {
     );
   });
 
-  test('mdb.runSelectedPlaygroundBlocks command should call runSelectedPlaygroundBlocks on the playground controller', async () => {
+  test('mdb.runSelectedPlaygroundBlocks command should call runSelectedPlaygroundBlocks on the playground controller', (done) => {
     const mockRunSelectedPlaygroundBlocks: any = sinon.fake();
     sinon.replace(
       mdbTestExtension.testExtensionController._playgroundController,
@@ -1507,14 +1517,18 @@ suite('MDBExtensionController Test Suite', function () {
       mockRunSelectedPlaygroundBlocks
     );
 
-    await vscode.commands.executeCommand('mdb.runSelectedPlaygroundBlocks');
-    assert(
-      mockRunSelectedPlaygroundBlocks.called,
-      'Expected "runSelectedPlaygroundBlocks" to be called on the playground controller.'
-    );
+    vscode.commands
+      .executeCommand('mdb.runSelectedPlaygroundBlocks')
+      .then(() => {
+        assert(
+          mockRunSelectedPlaygroundBlocks.called,
+          'Expected "runSelectedPlaygroundBlocks" to be called on the playground controller.'
+        );
+      })
+      .then(done, done);
   });
 
-  test('mdb.runAllPlaygroundBlocks command should call runAllPlaygroundBlocks on the playground controller', async () => {
+  test('mdb.runAllPlaygroundBlocks command should call runAllPlaygroundBlocks on the playground controller', (done) => {
     const mockRunAllPlaygroundBlocks: any = sinon.fake();
     sinon.replace(
       mdbTestExtension.testExtensionController._playgroundController,
@@ -1522,14 +1536,18 @@ suite('MDBExtensionController Test Suite', function () {
       mockRunAllPlaygroundBlocks
     );
 
-    await vscode.commands.executeCommand('mdb.runAllPlaygroundBlocks');
-    assert(
-      mockRunAllPlaygroundBlocks.called,
-      'Expected "runAllPlaygroundBlocks" to be called on the playground controller.'
-    );
+    vscode.commands
+      .executeCommand('mdb.runAllPlaygroundBlocks')
+      .then(() => {
+        assert(
+          mockRunAllPlaygroundBlocks.called,
+          'Expected "runAllPlaygroundBlocks" to be called on the playground controller.'
+        );
+      })
+      .then(done, done);
   });
 
-  test('mdb.changeActiveConnection command should call changeActiveConnection on the playground controller', async () => {
+  test('mdb.changeActiveConnection command should call changeActiveConnection on the playground controller', (done) => {
     const mockChangeActiveConnection: any = sinon.fake();
     sinon.replace(
       mdbTestExtension.testExtensionController._connectionController,
@@ -1537,14 +1555,18 @@ suite('MDBExtensionController Test Suite', function () {
       mockChangeActiveConnection
     );
 
-    await vscode.commands.executeCommand('mdb.changeActiveConnection');
-    assert(
-      mockChangeActiveConnection.called,
-      'Expected "changeActiveConnection" to be called on the playground controller.'
-    );
+    vscode.commands
+      .executeCommand('mdb.changeActiveConnection')
+      .then(() => {
+        assert(
+          mockChangeActiveConnection.called,
+          'Expected "changeActiveConnection" to be called on the playground controller.'
+        );
+      })
+      .then(done, done);
   });
 
-  test('mdb.refreshPlaygrounds command should call refreshPlaygrounds on the playgrounds explorer controller', async () => {
+  test('mdb.refreshPlaygrounds command should call refreshPlaygrounds on the playgrounds explorer controller', (done) => {
     const mockRefreshPlaygrounds: any = sinon.fake();
     sinon.replace(
       mdbTestExtension.testExtensionController._playgroundsExplorer,
@@ -1552,11 +1574,67 @@ suite('MDBExtensionController Test Suite', function () {
       mockRefreshPlaygrounds
     );
 
-    await vscode.commands.executeCommand('mdb.refreshPlaygrounds');
-    assert(
-      mockRefreshPlaygrounds.called,
-      'Expected "refreshPlaygrounds" to be called on the playground controller.'
+    vscode.commands
+      .executeCommand('mdb.refreshPlaygrounds')
+      .then(() => {
+        assert(
+          mockRefreshPlaygrounds.called,
+          'Expected "refreshPlaygrounds" to be called on the playground controller.'
+        );
+      })
+      .then(done, done);
+  });
+
+  test("mdb.copyDocumentContentsFromTreeView should copy a document's content to the clipboard", async () => {
+    const mockDocument = {
+      _id: 'pancakes',
+      time: {
+        $time: '12345',
+      },
+    };
+
+    let namespaceUsed = '';
+
+    const mockDataService: DataService = {
+      find: (
+        namespace: string,
+        filter: object,
+        options: object,
+        callback: (error: Error | undefined, documents: object[]) => void
+      ) => {
+        namespaceUsed = namespace;
+        callback(undefined, [mockDocument]);
+      },
+    } as any;
+
+    const documentTreeItem = new DocumentTreeItem(
+      mockDocument,
+      'waffle.house',
+      0,
+      mockDataService
     );
+
+    const mockCopyToClipboard: any = sinon.fake();
+    sinon.replaceGetter(vscode.env, 'clipboard', () => ({
+      writeText: mockCopyToClipboard,
+      readText: sinon.fake() as any,
+    }));
+
+    await vscode.commands.executeCommand(
+      'mdb.copyDocumentContentsFromTreeView',
+      documentTreeItem
+    );
+    assert.strictEqual(mockCopyToClipboard.called, true);
+    assert.strictEqual(
+      mockCopyToClipboard.firstArg,
+      `{
+  "_id": "pancakes",
+  "time": {
+    "$time": "12345"
+  }
+}`
+    );
+    assert.strictEqual(namespaceUsed, 'waffle.house');
   });
 
   suite(
@@ -1622,58 +1700,6 @@ suite('MDBExtensionController Test Suite', function () {
       });
     }
   );
-
-  test("mdb.copyDocumentContentsFromTreeView should copy a document's content to the clipboard", async () => {
-    const mockDocument = {
-      _id: 'pancakes',
-      time: {
-        $time: '12345',
-      },
-    };
-
-    let namespaceUsed = '';
-
-    const mockDataService: DataService = {
-      find: (
-        namespace: string,
-        filter: object,
-        options: object,
-        callback: (error: Error | undefined, documents: object[]) => void
-      ) => {
-        namespaceUsed = namespace;
-        callback(undefined, [mockDocument]);
-      },
-    } as any;
-
-    const documentTreeItem = new DocumentTreeItem(
-      mockDocument,
-      'waffle.house',
-      0,
-      mockDataService
-    );
-
-    const mockCopyToClipboard: any = sinon.fake();
-    sinon.replaceGetter(vscode.env, 'clipboard', () => ({
-      writeText: mockCopyToClipboard,
-      readText: sinon.fake() as any,
-    }));
-
-    await vscode.commands.executeCommand(
-      'mdb.copyDocumentContentsFromTreeView',
-      documentTreeItem
-    );
-    assert.strictEqual(mockCopyToClipboard.called, true);
-    assert.strictEqual(
-      mockCopyToClipboard.firstArg,
-      `{
-  "_id": "pancakes",
-  "time": {
-    "$time": "12345"
-  }
-}`
-    );
-    assert.strictEqual(namespaceUsed, 'waffle.house');
-  });
 
   suite(
     'when a user hasnt been shown the initial overview page yet and they have connections saved',

--- a/src/test/suite/mdbExtensionController.test.ts
+++ b/src/test/suite/mdbExtensionController.test.ts
@@ -237,7 +237,7 @@ suite('MDBExtensionController Test Suite', function () {
       .then(done, done);
   });
 
-  test('mdb.copyConnectionString command should try to copy the driver url to the vscode env clipboard', (done) => {
+  test('mdb.copyConnectionString command should try to copy the driver url to the vscode env clipboard', async () => {
     const mockTreeItem = new ConnectionTreeItem(
       'craving_for_pancakes_with_maple_syrup',
       vscode.TreeItemCollapsibleState.None,
@@ -260,22 +260,22 @@ suite('MDBExtensionController Test Suite', function () {
       mockStubUri
     );
 
-    vscode.commands
-      .executeCommand('mdb.copyConnectionString', mockTreeItem)
-      .then(() => {
-        assert(
-          mockCopyToClipboard.called,
-          'Expected "writeText" to be called on "vscode.env.clipboard".'
-        );
-        assert(
-          mockCopyToClipboard.firstArg === 'weStubThisUri',
-          `Expected the clipboard to be sent the uri string "weStubThisUri", found ${mockCopyToClipboard.firstArg}.`
-        );
-      })
-      .then(done, done);
+    await vscode.commands.executeCommand(
+      'mdb.copyConnectionString',
+      mockTreeItem
+    );
+
+    assert(
+      mockCopyToClipboard.called,
+      'Expected "writeText" to be called on "vscode.env.clipboard".'
+    );
+    assert(
+      mockCopyToClipboard.firstArg === 'weStubThisUri',
+      `Expected the clipboard to be sent the uri string "weStubThisUri", found ${mockCopyToClipboard.firstArg}.`
+    );
   });
 
-  test('mdb.copyDatabaseName command should try to copy the database name to the vscode env clipboard', (done) => {
+  test('mdb.copyDatabaseName command should try to copy the database name to the vscode env clipboard', async () => {
     const mockTreeItem = new DatabaseTreeItem(
       'isClubMateTheBestDrinkEver',
       {},
@@ -290,22 +290,18 @@ suite('MDBExtensionController Test Suite', function () {
       readText: sinon.fake() as any,
     }));
 
-    vscode.commands
-      .executeCommand('mdb.copyDatabaseName', mockTreeItem)
-      .then(() => {
-        assert(
-          mockCopyToClipboard.called,
-          'Expected "writeText" to be called on "vscode.env.clipboard".'
-        );
-        assert(
-          mockCopyToClipboard.firstArg === 'isClubMateTheBestDrinkEver',
-          `Expected the clipboard to be sent the uri string "isClubMateTheBestDrinkEver", found ${mockCopyToClipboard.firstArg}.`
-        );
-      })
-      .then(done, done);
+    await vscode.commands.executeCommand('mdb.copyDatabaseName', mockTreeItem);
+    assert(
+      mockCopyToClipboard.called,
+      'Expected "writeText" to be called on "vscode.env.clipboard".'
+    );
+    assert(
+      mockCopyToClipboard.firstArg === 'isClubMateTheBestDrinkEver',
+      `Expected the clipboard to be sent the uri string "isClubMateTheBestDrinkEver", found ${mockCopyToClipboard.firstArg}.`
+    );
   });
 
-  test('mdb.copyCollectionName command should try to copy the collection name to the vscode env clipboard', (done) => {
+  test('mdb.copyCollectionName command should try to copy the collection name to the vscode env clipboard', async () => {
     const mockTreeItem = new CollectionTreeItem(
       {
         name: 'waterBuffalo',
@@ -324,19 +320,18 @@ suite('MDBExtensionController Test Suite', function () {
       readText: sinon.fake() as any,
     }));
 
-    vscode.commands
-      .executeCommand('mdb.copyCollectionName', mockTreeItem)
-      .then(() => {
-        assert(
-          mockCopyToClipboard.called,
-          'Expected "writeText" to be called on "vscode.env.clipboard".'
-        );
-        assert(
-          mockCopyToClipboard.firstArg === 'waterBuffalo',
-          `Expected the clipboard to be sent the uri string "waterBuffalo", found ${mockCopyToClipboard.firstArg}.`
-        );
-      })
-      .then(done, done);
+    await vscode.commands.executeCommand(
+      'mdb.copyCollectionName',
+      mockTreeItem
+    );
+    assert(
+      mockCopyToClipboard.called,
+      'Expected "writeText" to be called on "vscode.env.clipboard".'
+    );
+    assert(
+      mockCopyToClipboard.firstArg === 'waterBuffalo',
+      `Expected the clipboard to be sent the uri string "waterBuffalo", found ${mockCopyToClipboard.firstArg}.`
+    );
   });
 
   test('mdb.copySchemaFieldName command should try to copy the field name to the vscode env clipboard', async () => {
@@ -406,7 +401,7 @@ suite('MDBExtensionController Test Suite', function () {
       .then(done, done);
   });
 
-  test('mdb.refreshCollection command should reset the expanded state of its children and call to refresh the explorer controller', (done) => {
+  test('mdb.refreshCollection command should reset the expanded state of its children and call to refresh the explorer controller', async () => {
     const mockTreeItem = new CollectionTreeItem(
       {
         name: 'iSawACatThatLookedLikeALionToday',
@@ -432,19 +427,15 @@ suite('MDBExtensionController Test Suite', function () {
       mockExplorerControllerRefresh
     );
 
-    vscode.commands
-      .executeCommand('mdb.refreshCollection', mockTreeItem)
-      .then(() => {
-        assert(
-          mockTreeItem.getSchemaChild().isExpanded === false,
-          'Expected collection tree item child to be reset to not expanded.'
-        );
-        assert(
-          mockExplorerControllerRefresh.called === true,
-          'Expected explorer controller refresh to be called.'
-        );
-      })
-      .then(done, done);
+    await vscode.commands.executeCommand('mdb.refreshCollection', mockTreeItem);
+    assert(
+      mockTreeItem.getSchemaChild().isExpanded === false,
+      'Expected collection tree item child to be reset to not expanded.'
+    );
+    assert(
+      mockExplorerControllerRefresh.called === true,
+      'Expected explorer controller refresh to be called.'
+    );
   });
 
   test('mdb.refreshDocumentList command should update the document count and call to refresh the explorer controller', async () => {
@@ -804,7 +795,7 @@ suite('MDBExtensionController Test Suite', function () {
 
   // https://code.visualstudio.com/api/references/contribution-points#Sorting-of-groups
 
-  test('mdb.dropCollection calls dataservice to drop the collection after inputting the collection name', (done) => {
+  test('mdb.dropCollection calls dataservice to drop the collection after inputting the collection name', async () => {
     let calledNamespace = '';
     const testCollectionTreeItem = new CollectionTreeItem(
       { name: 'testColName', type: CollectionTypes.collection },
@@ -824,13 +815,12 @@ suite('MDBExtensionController Test Suite', function () {
     mockInputBoxResolves.onCall(0).resolves('testColName');
     sinon.replace(vscode.window, 'showInputBox', mockInputBoxResolves);
 
-    vscode.commands
-      .executeCommand('mdb.dropCollection', testCollectionTreeItem)
-      .then((successfullyDropped) => {
-        assert(successfullyDropped);
-        assert(calledNamespace === 'testDbName.testColName');
-      })
-      .then(done, done);
+    const successfullyDropped = await vscode.commands.executeCommand(
+      'mdb.dropCollection',
+      testCollectionTreeItem
+    );
+    assert(successfullyDropped);
+    assert(calledNamespace === 'testDbName.testColName');
   });
 
   test('mdb.dropCollection fails when a collection doesnt exist', (done) => {
@@ -1199,7 +1189,12 @@ suite('MDBExtensionController Test Suite', function () {
       mockGetActiveDataService
     );
 
-    const documentItem = new DocumentTreeItem(mockDocument, 'waffle.house', 0);
+    const documentItem = new DocumentTreeItem(
+      mockDocument,
+      'waffle.house',
+      0,
+      {} as any as DataService
+    );
 
     await vscode.commands.executeCommand(
       'mdb.openMongoDBDocumentFromTree',
@@ -1241,7 +1236,12 @@ suite('MDBExtensionController Test Suite', function () {
         $time: '12345',
       },
     };
-    const documentItem = new DocumentTreeItem(mockDocument, 'waffle.house', 0);
+    const documentItem = new DocumentTreeItem(
+      mockDocument,
+      'waffle.house',
+      0,
+      {} as any as DataService
+    );
 
     const mockFetchDocument: any = sinon.fake.resolves(null);
     sinon.replace(
@@ -1499,7 +1499,7 @@ suite('MDBExtensionController Test Suite', function () {
     );
   });
 
-  test('mdb.runSelectedPlaygroundBlocks command should call runSelectedPlaygroundBlocks on the playground controller', (done) => {
+  test('mdb.runSelectedPlaygroundBlocks command should call runSelectedPlaygroundBlocks on the playground controller', async () => {
     const mockRunSelectedPlaygroundBlocks: any = sinon.fake();
     sinon.replace(
       mdbTestExtension.testExtensionController._playgroundController,
@@ -1507,18 +1507,14 @@ suite('MDBExtensionController Test Suite', function () {
       mockRunSelectedPlaygroundBlocks
     );
 
-    vscode.commands
-      .executeCommand('mdb.runSelectedPlaygroundBlocks')
-      .then(() => {
-        assert(
-          mockRunSelectedPlaygroundBlocks.called,
-          'Expected "runSelectedPlaygroundBlocks" to be called on the playground controller.'
-        );
-      })
-      .then(done, done);
+    await vscode.commands.executeCommand('mdb.runSelectedPlaygroundBlocks');
+    assert(
+      mockRunSelectedPlaygroundBlocks.called,
+      'Expected "runSelectedPlaygroundBlocks" to be called on the playground controller.'
+    );
   });
 
-  test('mdb.runAllPlaygroundBlocks command should call runAllPlaygroundBlocks on the playground controller', (done) => {
+  test('mdb.runAllPlaygroundBlocks command should call runAllPlaygroundBlocks on the playground controller', async () => {
     const mockRunAllPlaygroundBlocks: any = sinon.fake();
     sinon.replace(
       mdbTestExtension.testExtensionController._playgroundController,
@@ -1526,18 +1522,14 @@ suite('MDBExtensionController Test Suite', function () {
       mockRunAllPlaygroundBlocks
     );
 
-    vscode.commands
-      .executeCommand('mdb.runAllPlaygroundBlocks')
-      .then(() => {
-        assert(
-          mockRunAllPlaygroundBlocks.called,
-          'Expected "runAllPlaygroundBlocks" to be called on the playground controller.'
-        );
-      })
-      .then(done, done);
+    await vscode.commands.executeCommand('mdb.runAllPlaygroundBlocks');
+    assert(
+      mockRunAllPlaygroundBlocks.called,
+      'Expected "runAllPlaygroundBlocks" to be called on the playground controller.'
+    );
   });
 
-  test('mdb.changeActiveConnection command should call changeActiveConnection on the playground controller', (done) => {
+  test('mdb.changeActiveConnection command should call changeActiveConnection on the playground controller', async () => {
     const mockChangeActiveConnection: any = sinon.fake();
     sinon.replace(
       mdbTestExtension.testExtensionController._connectionController,
@@ -1545,18 +1537,14 @@ suite('MDBExtensionController Test Suite', function () {
       mockChangeActiveConnection
     );
 
-    vscode.commands
-      .executeCommand('mdb.changeActiveConnection')
-      .then(() => {
-        assert(
-          mockChangeActiveConnection.called,
-          'Expected "changeActiveConnection" to be called on the playground controller.'
-        );
-      })
-      .then(done, done);
+    await vscode.commands.executeCommand('mdb.changeActiveConnection');
+    assert(
+      mockChangeActiveConnection.called,
+      'Expected "changeActiveConnection" to be called on the playground controller.'
+    );
   });
 
-  test('mdb.refreshPlaygrounds command should call refreshPlaygrounds on the playgrounds explorer controller', (done) => {
+  test('mdb.refreshPlaygrounds command should call refreshPlaygrounds on the playgrounds explorer controller', async () => {
     const mockRefreshPlaygrounds: any = sinon.fake();
     sinon.replace(
       mdbTestExtension.testExtensionController._playgroundsExplorer,
@@ -1564,15 +1552,11 @@ suite('MDBExtensionController Test Suite', function () {
       mockRefreshPlaygrounds
     );
 
-    vscode.commands
-      .executeCommand('mdb.refreshPlaygrounds')
-      .then(() => {
-        assert(
-          mockRefreshPlaygrounds.called,
-          'Expected "refreshPlaygrounds" to be called on the playground controller.'
-        );
-      })
-      .then(done, done);
+    await vscode.commands.executeCommand('mdb.refreshPlaygrounds');
+    assert(
+      mockRefreshPlaygrounds.called,
+      'Expected "refreshPlaygrounds" to be called on the playground controller.'
+    );
   });
 
   suite(
@@ -1638,6 +1622,58 @@ suite('MDBExtensionController Test Suite', function () {
       });
     }
   );
+
+  test("mdb.copyDocumentContentsFromTreeView should copy a document's content to the clipboard", async () => {
+    const mockDocument = {
+      _id: 'pancakes',
+      time: {
+        $time: '12345',
+      },
+    };
+
+    let namespaceUsed = '';
+
+    const mockDataService: DataService = {
+      find: (
+        namespace: string,
+        filter: object,
+        options: object,
+        callback: (error: Error | undefined, documents: object[]) => void
+      ) => {
+        namespaceUsed = namespace;
+        callback(undefined, [mockDocument]);
+      },
+    } as any;
+
+    const documentTreeItem = new DocumentTreeItem(
+      mockDocument,
+      'waffle.house',
+      0,
+      mockDataService
+    );
+
+    const mockCopyToClipboard: any = sinon.fake();
+    sinon.replaceGetter(vscode.env, 'clipboard', () => ({
+      writeText: mockCopyToClipboard,
+      readText: sinon.fake() as any,
+    }));
+
+    await vscode.commands.executeCommand(
+      'mdb.copyDocumentContentsFromTreeView',
+      documentTreeItem
+    );
+    assert.strictEqual(mockCopyToClipboard.called, true);
+    assert.strictEqual(
+      mockCopyToClipboard.firstArg,
+      `{
+  "_id": "pancakes",
+  "time": {
+    "$time": "12345"
+  }
+}`
+    );
+    assert.strictEqual(namespaceUsed, 'waffle.house');
+  });
 
   suite(
     'when a user hasnt been shown the initial overview page yet and they have connections saved',

--- a/src/test/suite/stubs.ts
+++ b/src/test/suite/stubs.ts
@@ -142,15 +142,13 @@ for (let i = 0; i < numberOfDocumentsToMock; i++) {
 
 class DataServiceStub {
   listDatabases(): Promise<any> {
-    return new Promise((resolve) => {
-      resolve(mockDatabaseNames.map((dbName) => ({ name: dbName })));
-    });
+    return Promise.resolve(
+      mockDatabaseNames.map((dbName) => ({ name: dbName }))
+    );
   }
 
   listCollections(databaseName: string): Promise<any> {
-    return new Promise((resolve) => {
-      resolve(mockDatabases[databaseName].collections);
-    });
+    return Promise.resolve(mockDatabases[databaseName].collections);
   }
 
   find(namespace: string, filter: any, options: any, callback: any): void {


### PR DESCRIPTION
VSCODE-348

Add `Open Document` and `Copy Document` document context menu actions (right click).


https://user-images.githubusercontent.com/1791149/197725480-868ca5dd-1092-4f6d-a512-e4826d96599b.mp4

