### PR TITLE
feat(tree-explorer): add delete document context menu item VSCODE-349

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ If you use Terraform to manage your infrastructure, MongoDB for VS Code helps yo
 - `mdb.show`: Show or hide the MongoDB view.
 - `mdb.defaultLimit`: The number of documents to fetch when viewing documents from a collection.
 - `mdb.confirmRunAll`: Show a confirmation message before running commands in a playground.
+- `mdb.confirmDeleteDocument`: Show a confirmation message before deleting a document in the tree view.
 - `mdb.excludeFromPlaygroundsSearch`: Exclude files and folders while searching for playground in the the current workspace.
 - `mdb.connectionSaving.hideOptionToChooseWhereToSaveNewConnections`: When a connection is added, a prompt is shown that let's the user decide where the new connection should be saved. When this setting is checked, the prompt is not shown and the default connection saving location setting is used.
 - `mdb.connectionSaving.defaultConnectionSavingLocation`: When the setting that hides the option to choose where to save new connections is checked, this setting sets if and where new connections are saved.

--- a/package.json
+++ b/package.json
@@ -412,6 +412,10 @@
       {
         "command": "mdb.copyDocumentContentsFromTreeView",
         "title": "Copy Document"
+      },
+      {
+        "command": "mdb.deleteDocumentFromTreeView",
+        "title": "Delete Document..."
       }
     ],
     "menus": {
@@ -608,6 +612,11 @@
           "command": "mdb.copyDocumentContentsFromTreeView",
           "when": "view == mongoDBConnectionExplorer && viewItem == documentTreeItem",
           "group": "2@1"
+        },
+        {
+          "command": "mdb.deleteDocumentFromTreeView",
+          "when": "view == mongoDBConnectionExplorer && viewItem == documentTreeItem",
+          "group": "3@1"
         }
       ],
       "editor/title": [
@@ -781,6 +790,10 @@
         {
           "command": "mdb.copyDocumentContentsFromTreeView",
           "when": "false"
+        },
+        {
+          "command": "mdb.deleteDocumentFromTreeView",
+          "when": "false"
         }
       ]
     },
@@ -903,6 +916,11 @@
           "type": "boolean",
           "default": true,
           "description": "Show a confirmation message before running commands in a playground."
+        },
+        "mdb.confirmDeleteDocument": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show a confirmation message before deleting a document from the tree view."
         },
         "mdb.sendTelemetry": {
           "type": "boolean",

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -61,6 +61,7 @@ enum EXTENSION_COMMANDS {
   MDB_INSERT_OBJECTID_TO_EDITOR = 'mdb.insertObjectIdToEditor',
   MDB_GENERATE_OBJECTID_TO_CLIPBOARD = 'mdb.generateObjectIdToClipboard',
   MDB_COPY_DOCUMENT_CONTENTS_FROM_TREE_VIEW = 'mdb.copyDocumentContentsFromTreeView',
+  MDB_DELETE_DOCUMENT_FROM_TREE_VIEW = 'mdb.deleteDocumentFromTreeView',
 }
 
 export default EXTENSION_COMMANDS;

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -819,7 +819,7 @@ export default class ConnectionController {
     return connectionString;
   }
 
-  getActiveDataService(): DataService | null {
+  getActiveDataService() {
     return this._activeDataService;
   }
 

--- a/src/explorer/documentListTreeItem.ts
+++ b/src/explorer/documentListTreeItem.ts
@@ -175,7 +175,8 @@ export default class DocumentListTreeItem
             (pastTreeItem as DocumentTreeItem).document,
             this.namespace,
             index,
-            this._dataService
+            this._dataService,
+            () => this.resetCache()
           )
         );
       });
@@ -223,7 +224,8 @@ export default class DocumentListTreeItem
             document,
             this.namespace,
             index,
-            this._dataService
+            this._dataService,
+            () => this.resetCache()
           )
         );
       });

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -562,6 +562,26 @@ export default class MDBExtensionController implements vscode.Disposable {
       }
     );
     this.registerCommand(
+      EXTENSION_COMMANDS.MDB_DELETE_DOCUMENT_FROM_TREE_VIEW,
+      async (documentTreeItem: DocumentTreeItem): Promise<boolean> => {
+        const successfullyDropped =
+          await documentTreeItem.onDeleteDocumentClicked();
+
+        if (successfullyDropped) {
+          void vscode.window.showInformationMessage(
+            'Document successfully deleted.'
+          );
+
+          // When we successfully drop a document, we need
+          // to update the explorer view.
+          this._explorerController.refresh();
+          // TODO ^^ Do we need to refresh the whole explorer controller.
+        }
+
+        return successfullyDropped;
+      }
+    );
+    this.registerCommand(
       EXTENSION_COMMANDS.MDB_INSERT_OBJECTID_TO_EDITOR,
       async (): Promise<boolean> => {
         const editor = vscode.window.activeTextEditor;

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -575,7 +575,6 @@ export default class MDBExtensionController implements vscode.Disposable {
           // When we successfully drop a document, we need
           // to update the explorer view.
           this._explorerController.refresh();
-          // TODO ^^ Do we need to refresh the whole explorer controller.
         }
 
         return successfullyDropped;

--- a/src/test/suite/explorer/documentTreeItem.test.ts
+++ b/src/test/suite/explorer/documentTreeItem.test.ts
@@ -16,7 +16,8 @@ suite('DocumentTreeItem Test Suite', () => {
       mockDocument,
       'namespace',
       1,
-      {} as any
+      {} as any,
+      () => Promise.resolve()
     );
 
     const documentTreeItemLabel = testCollectionTreeItem.label;
@@ -40,7 +41,8 @@ suite('DocumentTreeItem Test Suite', () => {
       mockDocument,
       'namespace',
       1,
-      mockDataService
+      mockDataService,
+      () => Promise.resolve()
     );
 
     const documentTreeItemLabel = testCollectionTreeItem.label;
@@ -61,7 +63,8 @@ suite('DocumentTreeItem Test Suite', () => {
       mockDocument,
       'namespace',
       1,
-      mockDataService
+      mockDataService,
+      () => Promise.resolve()
     );
 
     const documentTreeItemLabel = testCollectionTreeItem.label;

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -55,6 +55,7 @@ suite('Extension Test Suite', () => {
       'mdb.openMongoDBDocumentFromTree',
       'mdb.openMongoDBDocumentFromCodeLens',
       'mdb.copyDocumentContentsFromTreeView',
+      'mdb.deleteDocumentFromTreeView',
 
       // Editor commands.
       'mdb.codeLens.showMoreDocumentsClicked',


### PR DESCRIPTION
VSCODE-349

This adds a setting `confirmDeleteDocument` which defaults `true` to show a confirmation when deleting a document. Can add more tests if folks would like that.

https://user-images.githubusercontent.com/1791149/204882698-a93218c1-4933-4769-b38c-84c62715f501.mp4


