### PR TITLE
chore: improve disconnected action error messages

### DIFF
--- a/src/editors/collectionDocumentsProvider.ts
+++ b/src/editors/collectionDocumentsProvider.ts
@@ -60,12 +60,15 @@ export default class CollectionViewProvider
     // Ensure we're still connected to the correct connection.
     if (connectionId !== this._connectionController.getActiveConnectionId()) {
       operation.isCurrentlyFetchingMoreDocuments = false;
+      const oldConnectionName =
+        this._connectionController.getSavedConnectionName(connectionId || '') ||
+        'the connection';
       void vscode.window.showErrorMessage(
-        `Unable to list documents: no longer connected to ${connectionId}`
+        `Unable to list documents: no longer connected to ${oldConnectionName}`
       );
 
       throw new Error(
-        `Unable to list documents: no longer connected to ${connectionId}`
+        `Unable to list documents: no longer connected to ${oldConnectionName}`
       );
     }
 
@@ -74,7 +77,7 @@ export default class CollectionViewProvider
     const dataservice = this._connectionController.getActiveDataService();
 
     if (dataservice === null) {
-      const errorMessage = `Unable to list documents: no longer connected to ${connectionId}`;
+      const errorMessage = 'Unable to list documents: no longer connected';
 
       void vscode.window.showErrorMessage(errorMessage);
 

--- a/src/editors/collectionDocumentsProvider.ts
+++ b/src/editors/collectionDocumentsProvider.ts
@@ -62,7 +62,7 @@ export default class CollectionViewProvider
       operation.isCurrentlyFetchingMoreDocuments = false;
       const oldConnectionName =
         this._connectionController.getSavedConnectionName(connectionId || '') ||
-        'the connection';
+        'the database';
       void vscode.window.showErrorMessage(
         `Unable to list documents: no longer connected to ${oldConnectionName}`
       );

--- a/src/editors/editorsController.ts
+++ b/src/editors/editorsController.ts
@@ -309,8 +309,12 @@ export default class EditorsController {
 
     // Ensure we're still connected to the correct connection.
     if (connectionId !== this._connectionController.getActiveConnectionId()) {
+      const oldConnectionName =
+        this._connectionController.getSavedConnectionName(connectionId || '') ||
+        'the connection';
+
       void vscode.window.showErrorMessage(
-        `Unable to view more documents: no longer connected to ${connectionId}`
+        `Unable to view more documents: no longer connected to ${oldConnectionName}`
       );
 
       return Promise.resolve(false);

--- a/src/editors/editorsController.ts
+++ b/src/editors/editorsController.ts
@@ -311,7 +311,7 @@ export default class EditorsController {
     if (connectionId !== this._connectionController.getActiveConnectionId()) {
       const oldConnectionName =
         this._connectionController.getSavedConnectionName(connectionId || '') ||
-        'the connection';
+        'the database';
 
       void vscode.window.showErrorMessage(
         `Unable to view more documents: no longer connected to ${oldConnectionName}`

--- a/src/editors/mongoDBDocumentService.ts
+++ b/src/editors/mongoDBDocumentService.ts
@@ -114,7 +114,7 @@ export default class MongoDBDocumentService {
       this._connectionController.getActiveConnectionId();
     const connectionName = connectionId
       ? this._connectionController.getSavedConnectionName(connectionId)
-      : '';
+      : 'the database';
 
     if (activeConnectionId !== connectionId) {
       return this._fetchDocumentFailed(


### PR DESCRIPTION
Improves the error messages by showing the connection name in a few error messages that occur when the connection has changed, previously we were showing the connection id which doesn't mean much to a user. In the edge case where the old connection was removed and no longer exists we default to showing `the connection` as the name.

| before | after | 
| - | - |
| ![Screen Shot 2022-12-01 at 1 24 30 PM](https://user-images.githubusercontent.com/1791149/205131588-aea151aa-f767-4207-8b56-58ae96f13929.png) | ![Screen Shot 2022-12-01 at 1 26 34 PM](https://user-images.githubusercontent.com/1791149/205131610-7e114c1c-d71f-4a2d-ab15-d81915911f5a.png) |
