### PR TITLE
chore(playgrounds): avoid export to language code actions refresh when nothing to refresh

### DIFF
--- a/src/editors/playgroundController.ts
+++ b/src/editors/playgroundController.ts
@@ -161,27 +161,35 @@ export default class PlaygroundController {
 
     vscode.window.onDidChangeTextEditorSelection(
       async (changeEvent: vscode.TextEditorSelectionChangeEvent) => {
-        if (changeEvent?.textEditor?.document?.languageId === 'mongodb') {
-          // Sort lines selected as the may be mis-ordered from alt+click.
-          const sortedSelections = (
-            changeEvent.selections as Array<vscode.Selection>
-          ).sort((a, b) => (a.start.line > b.start.line ? 1 : -1));
-
-          this._selectedText = sortedSelections
-            .map((item) => this._getSelectedText(item))
-            .join('\n');
-
-          const mode =
-            await this._languageServerController.getExportToLanguageMode({
-              textFromEditor: this._getAllText(),
-              selection: sortedSelections[0],
-            });
-
-          this._codeActionProvider.refresh({
-            selection: sortedSelections[0],
-            mode,
-          });
+        if (changeEvent?.textEditor?.document?.languageId !== 'mongodb') {
+          return;
         }
+
+        // Sort lines selected as the may be mis-ordered from alt+click.
+        const sortedSelections = (
+          changeEvent.selections as Array<vscode.Selection>
+        ).sort((a, b) => (a.start.line > b.start.line ? 1 : -1));
+
+        const selectedText = sortedSelections
+          .map((item) => this._getSelectedText(item))
+          .join('\n');
+
+        if (selectedText === this._selectedText) {
+          return;
+        }
+
+        this._selectedText = selectedText;
+
+        const mode =
+          await this._languageServerController.getExportToLanguageMode({
+            textFromEditor: this._getAllText(),
+            selection: sortedSelections[0],
+          });
+
+        this._codeActionProvider.refresh({
+          selection: sortedSelections[0],
+          mode,
+        });
       }
     );
   }


### PR DESCRIPTION
Previously we were updating the code actions on each character type as that would fire the selection change. This pr makes it only update the code actions when the selection's content changes.