### PR TITLE
fix(playgrounds): handle out of memory playground worker VSCODE-269

### DIFF
--- a/playgrounds/out-of-memory-test.mongodb
+++ b/playgrounds/out-of-memory-test.mongodb
@@ -1,0 +1,22 @@
+/**
+ * This playground is used to test how the language server worker
+ * handles an out of memory error in mongosh's running of a playground. VSCODE-269
+ */
+
+use('test');
+
+const mockDataArray = [];
+for(let i = 0; i < 50000; i++) {
+  mockDataArray.push(Math.random() * 10000);
+}
+
+const docs = [];
+for(let i = 0; i < 10000000; i++) {
+  docs.push({
+    mockData: [...mockDataArray],
+    a: 'test 123',
+    b: Math.ceil(Math.random() * 10000)
+  });
+}
+
+console.log('Should not show this message as the process should have run out of memory in the loop above.');

--- a/src/editors/playgroundController.ts
+++ b/src/editors/playgroundController.ts
@@ -351,11 +351,7 @@ export default class PlaygroundController {
     } catch (err: any) {
       // We re-initialize the language server when we encounter an error.
       // This happens when the language server worker runs out of memory, can't be revitalized, and restarts.
-      if (
-        err?.message?.includes(
-          'Pending response rejected since connection got disposed'
-        )
-      ) {
+      if (err?.code === -32097) {
         void vscode.window.showErrorMessage(
           'An error occurred when running the playground. This can occur when the playground runner runs out of memory.'
         );

--- a/src/language/languageServerController.ts
+++ b/src/language/languageServerController.ts
@@ -89,10 +89,12 @@ export default class LanguageServerController {
 
   async startLanguageServer(): Promise<void> {
     // Push the disposable client to the context's subscriptions so that the
-    // client can be deactivated on extension deactivation
-    this._context.subscriptions.push(this._client);
+    // client can be deactivated on extension deactivation.
+    if (!this._context.subscriptions.includes(this._client)) {
+      this._context.subscriptions.push(this._client);
+    }
 
-    // Subscribe on notifications from the server when the client is ready
+    // Subscribe on notifications from the server when the client is ready.
     await this._client.sendRequest(
       ServerCommands.SET_EXTENSION_PATH,
       this._context.extensionPath

--- a/src/test/suite/editors/playgroundController.test.ts
+++ b/src/test/suite/editors/playgroundController.test.ts
@@ -407,11 +407,13 @@ suite('Playground Controller Test Suite', function () {
       });
 
       test('it shows an error message and restarts, and connects the language server when an error occurs in executeAll (out of memory can cause this)', async () => {
+        const mockConnectionDisposedError = new Error(
+          'Pending response rejected since connection got disposed'
+        );
+        (mockConnectionDisposedError as any).code = -32097;
         sinon
           .stub(mockLanguageServerController, 'executeAll')
-          .rejects(
-            new Error('Pending response rejected since connection got disposed')
-          );
+          .rejects(mockConnectionDisposedError);
 
         const stubStartLanguageServer = sinon
           .stub(mockLanguageServerController, 'startLanguageServer')
@@ -434,6 +436,7 @@ suite('Playground Controller Test Suite', function () {
           expect(err.message).to.equal(
             'Pending response rejected since connection got disposed'
           );
+          expect(err.code).to.equal(-32097);
         }
 
         expect(stubVSCodeErrorMessage.calledOnce).to.equal(true);

--- a/src/test/suite/explorer/playgroundsExplorer.test.ts
+++ b/src/test/suite/explorer/playgroundsExplorer.test.ts
@@ -54,21 +54,13 @@ suite('Playgrounds Controller Test Suite', function () {
     try {
       const children = await treeController.getPlaygrounds(rootUri);
 
-      assert.strictEqual(
-        Object.keys(children).length,
-        5,
-        `Tree playgrounds should have 5 child, found ${children.length}`
-      );
+      assert.strictEqual(Object.keys(children).length, 6);
 
       const playgrounds = Object.values(children).filter(
         (item: any) => item.label && item.label.split('.').pop() === 'mongodb'
       );
 
-      assert.strictEqual(
-        Object.keys(playgrounds).length,
-        5,
-        `Tree playgrounds should have 5 playgrounds with mongodb extension, found ${children.length}`
-      );
+      assert.strictEqual(Object.keys(playgrounds).length, 6);
     } catch (error) {
       assert(false, error as Error);
     }
@@ -92,10 +84,7 @@ suite('Playgrounds Controller Test Suite', function () {
       const treeController = new PlaygroundsTree();
       const children = await treeController.getPlaygrounds(rootUri);
 
-      assert(
-        Object.keys(children).length === 3,
-        `Tree playgrounds should have 3 child, found ${children.length}`
-      );
+      assert.strictEqual(Object.keys(children).length, 3);
     } catch (error) {
       assert(false, error as Error);
     }


### PR DESCRIPTION
VSCODE-269

This pr makes it so that when the playground worker running mongosh runs out of memory we re-initialize the language server so that subsequent playgrounds can be run. 
The pr adds a playground to the repository to be used for testing this functionality.

At first I was trying to catch an error the worker thread would throw but it seemed to happen at a higher level https://github.com/mongodb-js/vscode/blob/36cebd0f519e17d0c4533c04c05ad7e416a9f6a7/src/language/mongoDBService.ts#L151 I'm thinking the VSCode language server disposes any language servers that encounter an out of memory error and restarts them automatically. It throws a `Pending response rejected since connection got disposed` error which is what we look for.

![Screen Shot 2022-12-14 at 4 03 09 PM](https://user-images.githubusercontent.com/1791149/207744224-b5e1e91e-bf50-412a-aa08-07311cb28476.png)

