### PR TITLE
chore(playgrounds): add all types playground for type testing

### DIFF
--- a/playgrounds/all-field-types.mongodb
+++ b/playgrounds/all-field-types.mongodb
@@ -10,12 +10,12 @@ const doc = {
   array: [1, 2, 3], // Array, 4, array
   binData: new Binary(Buffer.from([1, 2, 3])), // Binary data, 5, binData
   // Undefined, 6, undefined (deprecated)
-  objectid: new ObjectId(), // ObjectId, 7, objectId
+  objectId: new ObjectId(), // ObjectId, 7, objectId
   boolean: true, // Boolean, 8, boolean
   date: new Date(), // Date, 9, date
   null: null, // Null, 10, null
   regex: new BSONRegExp('pattern', 'i'), // Regular Expression, 11, regex
-  dbref: new DBRef('namespace', new ObjectId()), // DBPointer, 12, dbPointer (deprecated)
+  dbPointer: new DBRef('namespace', new ObjectId()), // DBPointer, 12, dbPointer (deprecated)
   javascript: new Code('function() {}'), // JavaScript, 13, javascript
   symbol: new BSONSymbol('symbol'), // Symbol, 14, symbol (deprecated)
   // JavaScript code with scope 15 "javascriptWithScope" Deprecated in MongoDB 4.4.

--- a/playgrounds/all-field-types.mongodb
+++ b/playgrounds/all-field-types.mongodb
@@ -1,0 +1,42 @@
+const { Buffer } = require('node:buffer');
+
+use('test');
+
+// Create a document with all the BSON types.
+const doc = {
+  double: new Double(1.2), // Double, 1, double
+  string: 'Hello, world!', // String, 2, string
+  object: { key: 'value' }, // Object, 3, object
+  array: [1, 2, 3], // Array, 4, array
+  binData: new Binary(Buffer.from([1, 2, 3])), // Binary data, 5, binData
+  // Undefined, 6, undefined (deprecated)
+  objectid: new ObjectId(), // ObjectId, 7, objectId
+  boolean: true, // Boolean, 8, boolean
+  date: new Date(), // Date, 9, date
+  null: null, // Null, 10, null
+  regex: new BSONRegExp('pattern', 'i'), // Regular Expression, 11, regex
+  dbref: new DBRef('namespace', new ObjectId()), // DBPointer, 12, dbPointer (deprecated)
+  javascript: new Code('function() {}'), // JavaScript, 13, javascript
+  symbol: new BSONSymbol('symbol'), // Symbol, 14, symbol (deprecated)
+  // JavaScript code with scope 15 "javascriptWithScope" Deprecated in MongoDB 4.4.
+  int: new Int32(12345), // 32-bit integer, 16, "int"
+  timestamp: new Timestamp(), // Timestamp, 17, timestamp
+  long: new Long('123456789123456789'), // 64-bit integer, 18, long
+  decimal: new Decimal128(Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])), // Decimal128, 19, decimal
+  minKey: new MinKey(), // Min key, -1, minKey
+  maxKey: new MaxKey(), // Max key, 127, maxKey
+  binDataSubtypes: {
+    generic: new Binary(Buffer.from([1, 2, 3]), 0), // 0
+    functionData: new Binary('//8=', 1), // 1
+    binaryOld: new Binary('//8=', 2), // 2
+    uuidOld: new Binary('c//SZESzTGmQ6OfR38A11A==', 3), // 3
+    uuid: new UUID('AAAAAAAA-AAAA-4AAA-AAAA-AAAAAAAAAAAA'), // 4
+    md5: new Binary('c//SZESzTGmQ6OfR38A11A==', 5), // 5
+    encrypted: new Binary('c//SZESzTGmQ6OfR38A11A==', 6), // 6
+    compressedTimeSeries: new Binary('c//SZESzTGmQ6OfR38A11A==', 0), // 7
+    custom: new Binary('//8=', 128), // 128
+  }
+};
+
+// Insert the document into the `all_types` collection.
+db.all_types.insertOne(doc);

--- a/playgrounds/all-field-types.mongodb
+++ b/playgrounds/all-field-types.mongodb
@@ -15,16 +15,17 @@ const doc = {
   date: new Date(), // Date, 9, date
   null: null, // Null, 10, null
   regex: new BSONRegExp('pattern', 'i'), // Regular Expression, 11, regex
-  dbPointer: new DBRef('namespace', new ObjectId()), // DBPointer, 12, dbPointer (deprecated)
+  // DBPointer, 12, dbPointer (deprecated)
   javascript: new Code('function() {}'), // JavaScript, 13, javascript
   symbol: new BSONSymbol('symbol'), // Symbol, 14, symbol (deprecated)
-  // JavaScript code with scope 15 "javascriptWithScope" Deprecated in MongoDB 4.4.
+  javascriptWithScope: new Code('function() {}', { foo: 1, bar: 'a' }), // JavaScript code with scope 15 "javascriptWithScope" Deprecated in MongoDB 4.4.
   int: new Int32(12345), // 32-bit integer, 16, "int"
   timestamp: new Timestamp(), // Timestamp, 17, timestamp
   long: new Long('123456789123456789'), // 64-bit integer, 18, long
   decimal: new Decimal128(Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])), // Decimal128, 19, decimal
   minKey: new MinKey(), // Min key, -1, minKey
   maxKey: new MaxKey(), // Max key, 127, maxKey
+
   binDataSubtypes: {
     generic: new Binary(Buffer.from([1, 2, 3]), 0), // 0
     functionData: new Binary('//8=', 1), // 1
@@ -35,7 +36,9 @@ const doc = {
     encrypted: new Binary('c//SZESzTGmQ6OfR38A11A==', 6), // 6
     compressedTimeSeries: new Binary('c//SZESzTGmQ6OfR38A11A==', 0), // 7
     custom: new Binary('//8=', 128), // 128
-  }
+  },
+
+  dbRef: new DBRef('namespace', new ObjectId()), // not actually a separate type, just a convention
 };
 
 // Insert the document into the `all_types` collection.

--- a/src/test/suite/explorer/playgroundsExplorer.test.ts
+++ b/src/test/suite/explorer/playgroundsExplorer.test.ts
@@ -54,13 +54,13 @@ suite('Playgrounds Controller Test Suite', function () {
     try {
       const children = await treeController.getPlaygrounds(rootUri);
 
-      assert.strictEqual(Object.keys(children).length, 6);
+      assert.strictEqual(Object.keys(children).length, 7);
 
       const playgrounds = Object.values(children).filter(
         (item: any) => item.label && item.label.split('.').pop() === 'mongodb'
       );
 
-      assert.strictEqual(Object.keys(playgrounds).length, 6);
+      assert.strictEqual(Object.keys(playgrounds).length, 7);
     } catch (error) {
       assert(false, error as Error);
     }


### PR DESCRIPTION
Written by @lerouxb 
Figured this would be helpful for testing down the line so it makes sense to be in a code base.

Here's what the resulting document schema looks like in our view:
<img width="403" alt="Screen Shot 2023-01-04 at 11 33 17 AM" src="https://user-images.githubusercontent.com/1791149/210603814-f2a5b12e-1a5c-4eb9-9ffa-99f066f979f7.png">
