### PR TITLE
feat(tree-explorer): add insert document context menu action VSCODE-367

### DIFF
--- a/package.json
+++ b/package.json
@@ -378,6 +378,10 @@
         "title": "Refresh"
       },
       {
+        "command": "mdb.insertDocumentFromTreeView",
+        "title": "Insert a Document..."
+      },
+      {
         "command": "mdb.refreshSchema",
         "title": "Refresh"
       },
@@ -554,14 +558,19 @@
           "group": "1@2"
         },
         {
-          "command": "mdb.copyCollectionName",
+          "command": "mdb.insertDocumentFromTreeView",
           "when": "view == mongoDBConnectionExplorer && viewItem == collectionTreeItem",
           "group": "2@1"
         },
         {
-          "command": "mdb.dropCollection",
+          "command": "mdb.copyCollectionName",
           "when": "view == mongoDBConnectionExplorer && viewItem == collectionTreeItem",
           "group": "3@1"
+        },
+        {
+          "command": "mdb.dropCollection",
+          "when": "view == mongoDBConnectionExplorer && viewItem == collectionTreeItem",
+          "group": "4@1"
         },
         {
           "command": "mdb.searchForDocuments",
@@ -575,16 +584,23 @@
         },
         {
           "command": "mdb.viewCollectionDocuments",
-          "when": "view == mongoDBConnectionExplorer && viewItem == documentListTreeItem"
+          "when": "view == mongoDBConnectionExplorer && viewItem == documentListTreeItem",
+          "group": "1@1"
         },
         {
           "command": "mdb.refreshDocumentList",
-          "when": "view == mongoDBConnectionExplorer && viewItem == documentListTreeItem"
+          "when": "view == mongoDBConnectionExplorer && viewItem == documentListTreeItem",
+          "group": "1@2"
         },
         {
           "command": "mdb.searchForDocuments",
           "when": "view == mongoDBConnectionExplorer && viewItem == documentListTreeItem",
           "group": "2@1"
+        },
+        {
+          "command": "mdb.insertDocumentFromTreeView",
+          "when": "view == mongoDBConnectionExplorer && viewItem == collectionTreeItem",
+          "group": "3@1"
         },
         {
           "command": "mdb.refreshSchema",
@@ -758,6 +774,10 @@
         },
         {
           "command": "mdb.refreshDocumentList",
+          "when": "false"
+        },
+        {
+          "command": "mdb.insertDocumentFromTreeView",
           "when": "false"
         },
         {

--- a/package.json
+++ b/package.json
@@ -379,7 +379,7 @@
       },
       {
         "command": "mdb.insertDocumentFromTreeView",
-        "title": "Insert a Document..."
+        "title": "Insert Document..."
       },
       {
         "command": "mdb.refreshSchema",
@@ -558,12 +558,12 @@
           "group": "1@2"
         },
         {
-          "command": "mdb.insertDocumentFromTreeView",
+          "command": "mdb.copyCollectionName",
           "when": "view == mongoDBConnectionExplorer && viewItem == collectionTreeItem",
           "group": "2@1"
         },
         {
-          "command": "mdb.copyCollectionName",
+          "command": "mdb.insertDocumentFromTreeView",
           "when": "view == mongoDBConnectionExplorer && viewItem == collectionTreeItem",
           "group": "3@1"
         },
@@ -599,7 +599,7 @@
         },
         {
           "command": "mdb.insertDocumentFromTreeView",
-          "when": "view == mongoDBConnectionExplorer && viewItem == collectionTreeItem",
+          "when": "view == mongoDBConnectionExplorer && viewItem == documentListTreeItem",
           "group": "3@1"
         },
         {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -54,6 +54,7 @@ enum EXTENSION_COMMANDS {
   MDB_VIEW_COLLECTION_DOCUMENTS = 'mdb.viewCollectionDocuments',
   MDB_REFRESH_COLLECTION = 'mdb.refreshCollection',
   MDB_REFRESH_DOCUMENT_LIST = 'mdb.refreshDocumentList',
+  MDB_INSERT_DOCUMENT_FROM_TREE_VIEW = 'mdb.insertDocumentFromTreeView',
   MDB_REFRESH_SCHEMA = 'mdb.refreshSchema',
   MDB_COPY_SCHEMA_FIELD_NAME = 'mdb.copySchemaFieldName',
   MDB_REFRESH_INDEXES = 'mdb.refreshIndexes',

--- a/src/editors/playgroundController.ts
+++ b/src/editors/playgroundController.ts
@@ -19,6 +19,7 @@ import { LanguageServerController } from '../language';
 import playgroundCreateIndexTemplate from '../templates/playgroundCreateIndexTemplate';
 import playgroundCreateCollectionTemplate from '../templates/playgroundCreateCollectionTemplate';
 import playgroundCloneDocumentTemplate from '../templates/playgroundCloneDocumentTemplate';
+import playgroundInsertDocumentTemplate from '../templates/playgroundInsertDocumentTemplate';
 import {
   PlaygroundResult,
   ShellExecuteAllResult,
@@ -294,6 +295,17 @@ export default class PlaygroundController {
       .replace('CURRENT_DATABASE', databaseName)
       .replace('CURRENT_COLLECTION', collectionName)
       .replace('DOCUMENT_CONTENTS', documentContents);
+
+    return this._createPlaygroundFileWithContent(content);
+  }
+
+  createPlaygroundForInsertDocument(
+    databaseName: string,
+    collectionName: string
+  ): Promise<boolean> {
+    const content = playgroundInsertDocumentTemplate
+      .replace('CURRENT_DATABASE', databaseName)
+      .replace('CURRENT_COLLECTION', collectionName);
 
     return this._createPlaygroundFileWithContent(content);
   }

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -498,6 +498,17 @@ export default class MDBExtensionController implements vscode.Disposable {
       }
     );
     this.registerCommand(
+      EXTENSION_COMMANDS.MDB_INSERT_DOCUMENT_FROM_TREE_VIEW,
+      async (
+        documentsListTreeItem: DocumentListTreeItem | CollectionTreeItem
+      ): Promise<boolean> => {
+        return this._playgroundController.createPlaygroundForInsertDocument(
+          documentsListTreeItem.databaseName,
+          documentsListTreeItem.collectionName
+        );
+      }
+    );
+    this.registerCommand(
       EXTENSION_COMMANDS.MDB_REFRESH_SCHEMA,
       (schemaTreeItem: SchemaTreeItem): Promise<boolean> => {
         schemaTreeItem.resetCache();

--- a/src/templates/playgroundInsertDocumentTemplate.ts
+++ b/src/templates/playgroundInsertDocumentTemplate.ts
@@ -1,0 +1,13 @@
+const template = `// MongoDB Playground
+// Use Ctrl+Space inside a snippet or a string literal to trigger completions.
+
+// The current database to use.
+use('CURRENT_DATABASE');
+
+// Create a new document in the collection.
+db.getCollection('CURRENT_COLLECTION').insertOne({
+
+});
+`;
+
+export default template;

--- a/src/test/suite/mdbExtensionController.test.ts
+++ b/src/test/suite/mdbExtensionController.test.ts
@@ -1660,6 +1660,41 @@ suite('MDBExtensionController Test Suite', function () {
     assert.strictEqual(namespaceUsed, 'waffle.house');
   });
 
+  test('mdb.insertDocumentFromTreeView event should open a playground with an insert document template', async () => {
+    const collectionTreeItem = new CollectionTreeItem(
+      {
+        name: 'pineapple',
+        type: CollectionTypes.collection,
+      },
+      'plants',
+      {},
+      false,
+      false,
+      null
+    );
+
+    const mockCreatePlaygroundForInsertDocument = sinon.fake();
+    sinon.replace(
+      mdbTestExtension.testExtensionController._playgroundController,
+      'createPlaygroundForInsertDocument',
+      mockCreatePlaygroundForInsertDocument
+    );
+
+    await vscode.commands.executeCommand(
+      'mdb.insertDocumentFromTreeView',
+      collectionTreeItem
+    );
+    assert.strictEqual(mockCreatePlaygroundForInsertDocument.calledOnce, true);
+    assert.strictEqual(
+      mockCreatePlaygroundForInsertDocument.firstCall.args[0],
+      'plants'
+    );
+    assert.strictEqual(
+      mockCreatePlaygroundForInsertDocument.firstCall.args[1],
+      'pineapple'
+    );
+  });
+
   test('mdb.deleteDocumentFromTreeView should not delete a document when the confirmation is cancelled', async () => {
     const mockDocument = {
       _id: 'pancakes',


### PR DESCRIPTION
VSCODE-367
Adds an `Insert Document...` tree view context action to collections to shortcut adding a document.

| before | after |
| --- | --- |
| <img width="367" alt="Screen Shot 2023-01-31 at 11 51 26 PM" src="https://user-images.githubusercontent.com/1791149/215967692-736108b3-7a6b-4a36-b002-e789888edeea.png"> | <img width="368" alt="Screen Shot 2023-01-31 at 11 53 32 PM" src="https://user-images.githubusercontent.com/1791149/215967778-143fd318-46e6-4572-9cd8-dc3f82cd886a.png"> |
| <img width="427" alt="Screen Shot 2023-01-31 at 11 51 20 PM" src="https://user-images.githubusercontent.com/1791149/215967707-46568da0-8dc6-4122-9fc7-408d364e38b5.png"> | <img width="383" alt="Screen Shot 2023-01-31 at 11 53 26 PM" src="https://user-images.githubusercontent.com/1791149/215967795-6b1c3a55-300d-4456-8a09-71933a13a868.png"> |

