### PR TITLE
feat(playgrounds): update playground template VSCODE-337

### DIFF
--- a/src/templates/playgroundTemplate.ts
+++ b/src/templates/playgroundTemplate.ts
@@ -5,6 +5,8 @@ const template = `// MongoDB Playground
 // The result of the last command run in a playground is shown on the results panel.
 // By default the first 20 documents will be returned with a cursor.
 // Use 'console.log()' to print to the debug output.
+// For more documentation on playgrounds please refer to
+// https://www.mongodb.com/docs/mongodb-vscode/playgrounds/
 
 // Select the database to use.
 use('mongodbVSCodePlaygroundDB');
@@ -24,10 +26,10 @@ db.getCollection('sales').insertMany([
 // Run a find command to view items sold on April 4th, 2014.
 const salesOnApril4th = db.getCollection('sales').find({
   date: { $gte: new Date('2014-04-04'), $lt: new Date('2014-04-05') }
-}).toArray();
+}).count();
 
 // Print a message to the output window.
-console.log(\`\${salesOnApril4th.length} sales occurred in 2014.\`);
+console.log(\`\${salesOnApril4th} sales occurred in 2014.\`);
 
 // Here we run an aggregation and open a cursor to the results.
 // Use '.toArray()' to exhaust the cursor to return the whole result set.

--- a/src/templates/playgroundTemplate.ts
+++ b/src/templates/playgroundTemplate.ts
@@ -2,39 +2,42 @@ const template = `// MongoDB Playground
 // To disable this template go to Settings | MongoDB | Use Default Template For Playground.
 // Make sure you are connected to enable completions and to be able to run a playground.
 // Use Ctrl+Space inside a snippet or a string literal to trigger completions.
+// The result of the last command run in a playground is shown on the results panel.
+// By default the first 20 documents will be returned with a cursor.
+// Use 'console.log()' to print to the debug output.
 
 // Select the database to use.
 use('mongodbVSCodePlaygroundDB');
 
-// The drop() command destroys all data from a collection.
-// Make sure you run it against the correct database and collection.
-db.sales.drop();
-
 // Insert a few documents into the sales collection.
-db.sales.insertMany([
-  { '_id': 1, 'item': 'abc', 'price': 10, 'quantity': 2, 'date': new Date('2014-03-01T08:00:00Z') },
-  { '_id': 2, 'item': 'jkl', 'price': 20, 'quantity': 1, 'date': new Date('2014-03-01T09:00:00Z') },
-  { '_id': 3, 'item': 'xyz', 'price': 5, 'quantity': 10, 'date': new Date('2014-03-15T09:00:00Z') },
-  { '_id': 4, 'item': 'xyz', 'price': 5, 'quantity':  20, 'date': new Date('2014-04-04T11:21:39.736Z') },
-  { '_id': 5, 'item': 'abc', 'price': 10, 'quantity': 10, 'date': new Date('2014-04-04T21:23:13.331Z') },
-  { '_id': 6, 'item': 'def', 'price': 7.5, 'quantity': 5, 'date': new Date('2015-06-04T05:08:13Z') },
-  { '_id': 7, 'item': 'def', 'price': 7.5, 'quantity': 10, 'date': new Date('2015-09-10T08:43:00Z') },
-  { '_id': 8, 'item': 'abc', 'price': 10, 'quantity': 5, 'date': new Date('2016-02-06T20:20:13Z') },
+db['sales'].insertMany([
+  { 'item': 'abc', 'price': 10, 'quantity': 2, 'date': new Date('2014-03-01T08:00:00Z') },
+  { 'item': 'jkl', 'price': 20, 'quantity': 1, 'date': new Date('2014-03-01T09:00:00Z') },
+  { 'item': 'xyz', 'price': 5, 'quantity': 10, 'date': new Date('2014-03-15T09:00:00Z') },
+  { 'item': 'xyz', 'price': 5, 'quantity':  20, 'date': new Date('2014-04-04T11:21:39.736Z') },
+  { 'item': 'abc', 'price': 10, 'quantity': 10, 'date': new Date('2014-04-04T21:23:13.331Z') },
+  { 'item': 'def', 'price': 7.5, 'quantity': 5, 'date': new Date('2015-06-04T05:08:13Z') },
+  { 'item': 'def', 'price': 7.5, 'quantity': 10, 'date': new Date('2015-09-10T08:43:00Z') },
+  { 'item': 'abc', 'price': 10, 'quantity': 5, 'date': new Date('2016-02-06T20:20:13Z') },
 ]);
 
 // Run a find command to view items sold on April 4th, 2014.
-db.sales.find({ date: { $gte: new Date('2014-04-04'), $lt: new Date('2014-04-05') } });
+const salesOnApril4th = db['sales'].find({
+  date: { $gte: new Date('2014-04-04'), $lt: new Date('2014-04-05') }
+}).toArray();
 
-// Build an aggregation to view total sales for each product in 2014.
-const aggregation = [
+// Print a message to the output window.
+console.log(\`\${salesOnApril4th.length} sales occurred in 2014.\`);
+
+// Here we run an aggregation and open a cursor to the results.
+// Use '.toArray()' to exhaust the cursor to return the whole result set.
+// You can use '.hasNext()/.next()' to iterate through the cursor page by page.
+db['sales'].aggregate([
+  // Find all of the sales that occurred in 2014.
   { $match: { date: { $gte: new Date('2014-01-01'), $lt: new Date('2015-01-01') } } },
+  // Group the total sales for each product.
   { $group: { _id: '$item', totalSaleAmount: { $sum: { $multiply: [ '$price', '$quantity' ] } } } }
-];
-
-// Run the aggregation and open a cursor to the results.
-// Use toArray() to exhaust the cursor to return the whole result set.
-// You can use hasNext()/next() to iterate through the cursor page by page.
-db.sales.aggregate(aggregation);
+]);
 `;
 
 export default template;

--- a/src/templates/playgroundTemplate.ts
+++ b/src/templates/playgroundTemplate.ts
@@ -10,7 +10,7 @@ const template = `// MongoDB Playground
 use('mongodbVSCodePlaygroundDB');
 
 // Insert a few documents into the sales collection.
-db['sales'].insertMany([
+db.getCollection('sales').insertMany([
   { 'item': 'abc', 'price': 10, 'quantity': 2, 'date': new Date('2014-03-01T08:00:00Z') },
   { 'item': 'jkl', 'price': 20, 'quantity': 1, 'date': new Date('2014-03-01T09:00:00Z') },
   { 'item': 'xyz', 'price': 5, 'quantity': 10, 'date': new Date('2014-03-15T09:00:00Z') },
@@ -22,7 +22,7 @@ db['sales'].insertMany([
 ]);
 
 // Run a find command to view items sold on April 4th, 2014.
-const salesOnApril4th = db['sales'].find({
+const salesOnApril4th = db.getCollection('sales').find({
   date: { $gte: new Date('2014-04-04'), $lt: new Date('2014-04-05') }
 }).toArray();
 
@@ -32,7 +32,7 @@ console.log(\`\${salesOnApril4th.length} sales occurred in 2014.\`);
 // Here we run an aggregation and open a cursor to the results.
 // Use '.toArray()' to exhaust the cursor to return the whole result set.
 // You can use '.hasNext()/.next()' to iterate through the cursor page by page.
-db['sales'].aggregate([
+db.getCollection('sales').aggregate([
   // Find all of the sales that occurred in 2014.
   { $match: { date: { $gte: new Date('2014-01-01'), $lt: new Date('2015-01-01') } } },
   // Group the total sales for each product.


### PR DESCRIPTION
VSCODE-337
Opening to open a discussion with the team on how we can best supply a playground template for folks.

The changes in this one are:
- Removed the drop collection call. I'm thinking it's something that's a bit risky to have in a default script. It's a useful command, but I don't think it's something folks want to have a possibility of accidentally running.
- Removed the _id number usage (so we default the _id to ObjectId).
- Changed how we use collection methods collection methods from db.sales.find  to db['sales'].find to reduce possible rough spots with folks that have spaces and dashes in their collection names. EDIT: Based on Anna's reply: https://github.com/mongodb-js/vscode/pull/470#discussion_r1097199338 I'm thinking let's update it to db.getCollection('sales'). instead. I don't think our autocomplete for collection names works there but it's something we can add.
- Explicitly mentioned console.log usage and added a logged message. I think folks will want to debug their playgrounds often, and if they're not familiar with shell scripting or javascript environments this might not be intuitive without a callout.
- Explicitly mentioned cursor 20 document results higher up in the template. I'm under the impression people who don't use the shell often might not expect cursor results to be shown.