### PR TITLE
chore(ci): add missing output var in nightly build faiulres

### DIFF
--- a/.github/workflows/report-nightly-build-failures.yaml
+++ b/.github/workflows/report-nightly-build-failures.yaml
@@ -14,6 +14,16 @@ jobs:
   on-failure:
     runs-on: ubuntu-latest
     steps:
+      - name: Check trigger type
+        id: trigger_type
+        run: |
+          TRIGGER_TYPE=${{github.event.inputs.trigger_type}}
+          echo "trigger_type=${TRIGGER_TYPE}" >> $GITHUB_OUTPUT
+
+      - name: Report trigger type
+        run: |
+          echo "Trigger type: ${{steps.trigger_type.outputs.trigger_type}}"
+
       - name: Fail if nightly build failed
         if: ${{ github.event.workflow_run.conclusion == 'failure' && steps.trigger_type.outputs.trigger_type == 'scheduled'}}
         run: |


### PR DESCRIPTION
I've completely missed the fact that `steps.trigger_type.outputs.trigger_type` isn't a built-in thing, and there is a good chance that I'm reading the wrong event. Probably isn't worth the effort to keep investigating further, I wuld give this a try and if it doesn't work we can just drop it 