### PR TITLE
chore: get rid of eslint warnings

### DIFF
--- a/src/telemetry/telemetryService.ts
+++ b/src/telemetry/telemetryService.ts
@@ -130,6 +130,7 @@ export default class TelemetryService {
         this._context.extensionPath,
         './constants.json'
       );
+      // eslint-disable-next-line no-sync
       const constantsFile = fs.readFileSync(segmentKeyFileLocation).toString();
       const constants = JSON.parse(constantsFile) as { segmentKey: string };
 

--- a/src/telemetry/telemetryService.ts
+++ b/src/telemetry/telemetryService.ts
@@ -131,7 +131,7 @@ export default class TelemetryService {
         './constants.json'
       );
       // eslint-disable-next-line no-sync
-      const constantsFile = fs.readFileSync(segmentKeyFileLocation).toString();
+      const constantsFile = fs.readFileSync(segmentKeyFileLocation, 'utf8');
       const constants = JSON.parse(constantsFile) as { segmentKey: string };
 
       log.info('TELEMETRY key received', typeof constants.segmentKey);

--- a/src/test/suite/language/languageServerController.test.ts
+++ b/src/test/suite/language/languageServerController.test.ts
@@ -127,13 +127,13 @@ suite('Language Server Controller Test Suite', () => {
     expect(testLanguageServerController._isExecutingInProgress).to.equal(false);
   });
 
-  test('the language server dependency bundle exists', () => {
+  test('the language server dependency bundle exists', async () => {
     const extensionPath = mdbTestExtension.testExtensionContext.extensionPath;
     const languageServerModuleBundlePath = path.join(
       extensionPath,
       'dist',
       'languageServer.js'
     );
-    expect(fs.existsSync(languageServerModuleBundlePath)).to.equal(true);
+    await fs.promises.stat(languageServerModuleBundlePath);
   });
 });

--- a/src/test/suite/language/mongoDBService.test.ts
+++ b/src/test/suite/language/mongoDBService.test.ts
@@ -29,13 +29,13 @@ suite('MongoDBService Test Suite', () => {
     },
   };
 
-  test('the language server worker dependency bundle exists', () => {
+  test('the language server worker dependency bundle exists', async () => {
     const languageServerModuleBundlePath = path.join(
       mdbTestExtension.testExtensionContext.extensionPath,
       'dist',
       languageServerWorkerFileName
     );
-    expect(fs.existsSync(languageServerModuleBundlePath)).to.equal(true);
+    await fs.promises.stat(languageServerModuleBundlePath);
   });
 
   suite('Extension path', () => {


### PR DESCRIPTION
```
/Users/rhys/mongodb/vscode/src/telemetry/telemetryService.ts
  133:29  warning  Unexpected sync method: 'readFileSync'  no-sync

/Users/rhys/mongodb/vscode/src/test/suite/language/languageServerController.test.ts
  137:12  warning  Unexpected sync method: 'existsSync'  no-sync

/Users/rhys/mongodb/vscode/src/test/suite/language/mongoDBService.test.ts
  38:12  warning  Unexpected sync method: 'existsSync'  no-sync
```