### PR TITLE
feat(playground): adds new Time-Series options for collection creation in playgrounds VSCODE-362

### DIFF
--- a/src/templates/playgroundCreateCollectionTemplate.ts
+++ b/src/templates/playgroundCreateCollectionTemplate.ts
@@ -29,7 +29,9 @@ db.createCollection(collection);
     timeseries: { // Added in MongoDB 5.0
       timeField: <string>, // required for time series collections
       metaField: <string>,
-      granularity: <string>
+      granularity: <string>,
+      bucketMaxSpanSeconds: <number>, // Added in MongoDB 6.3
+      bucketRoundingSeconds: <number>, // Added in MongoDB 6.3
     },
     expireAfterSeconds: <number>,
     clusteredIndex: <document>, // Added in MongoDB 5.3


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. VSCODE-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
VSCODE-362

This PR adds new options (`bucketMaxSpanSeconds` and `bucketRoundingSeconds`), introduced in MongoDB 6.3, to time-series collection options in create-collection playground template.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
