### PR TITLE
feat(playground): makes creation of columnstore indexes more visible in index creation template VSCODE-364

### DIFF
--- a/src/templates/playgroundCreateIndexTemplate.ts
+++ b/src/templates/playgroundCreateIndexTemplate.ts
@@ -19,7 +19,7 @@ db.getCollection('CURRENT_COLLECTION')
        * '$**': 1, // wildcard index on all fields and subfields in a document
        * 'path.to.field.$**': 1 // wildcard index on a specific field and its subpaths
        *
-       * Columnstore index // added in MongoDB 6.3
+       * Columnstore index
        * '$**': 'columnstore', // columnstore index on multiple specific field
        * 'path.to.field.$**': 'columnstore', // columnstore index on one field and all the subfields
        *

--- a/src/templates/playgroundCreateIndexTemplate.ts
+++ b/src/templates/playgroundCreateIndexTemplate.ts
@@ -12,16 +12,16 @@ db.getCollection('CURRENT_COLLECTION')
        * Keys
        *
        * Normal index
-       * fieldA:  1, //ascending
-       * fieldB: -1  //descending
+       * fieldA:  1, // ascending
+       * fieldB: -1  // descending
        *
        * Wildcard index
-       * '$**': 1, //wildcard index on all fields and subfields in a document
-       * 'path.to.field.$**': 1 //wildcard index on a specific field and its subpaths
+       * '$**': 1, // wildcard index on all fields and subfields in a document
+       * 'path.to.field.$**': 1 // wildcard index on a specific field and its subpaths
        *
-       * Columnstore index //added in MongoDB 6.3
-       * '$**': "columnstore", //columnstore index on multiple specific field
-       * 'path.to.field.$**': "columnstore", //columnstore index on one field and all the subfields
+       * Columnstore index // added in MongoDB 6.3
+       * '$**': 'columnstore', // columnstore index on multiple specific field
+       * 'path.to.field.$**': 'columnstore', // columnstore index on one field and all the subfields
        *
        * Text index
        * fieldA: 'text',
@@ -37,7 +37,7 @@ db.getCollection('CURRENT_COLLECTION')
       /*
        * Options (https://docs.mongodb.com/manual/reference/method/db.collection.createIndex/#options-for-all-index-types)
        *
-       * background: true, //ignored in 4.2+
+       * background: true, // ignored in 4.2+
        * unique: false,
        * name: 'some name',
        * partialFilterExpression: {},
@@ -45,7 +45,7 @@ db.getCollection('CURRENT_COLLECTION')
        * expireAfterSeconds: TTL,
        * collation: {},
        * wildcardProjection: {},
-       * columnstoreProjection: {} //added in MongoDB 6.3
+       * columnstoreProjection: {} // added in MongoDB 6.3
        */
     }
   );

--- a/src/templates/playgroundCreateIndexTemplate.ts
+++ b/src/templates/playgroundCreateIndexTemplate.ts
@@ -19,6 +19,10 @@ db.getCollection('CURRENT_COLLECTION')
        * '$**': 1, //wildcard index on all fields and subfields in a document
        * 'path.to.field.$**': 1 //wildcard index on a specific field and its subpaths
        *
+       * Columnstore index //added in MongoDB 6.3
+       * '$**': "columnstore", //columnstore index on multiple specific field
+       * 'path.to.field.$**': "columnstore", //columnstore index on one field and all the subfields
+       *
        * Text index
        * fieldA: 'text',
        * fieldB: 'text'
@@ -39,7 +43,9 @@ db.getCollection('CURRENT_COLLECTION')
        * partialFilterExpression: {},
        * sparse: false,
        * expireAfterSeconds: TTL,
-       * collation: {}
+       * collation: {},
+       * wildcardProjection: {},
+       * columnstoreProjection: {} //added in MongoDB 6.3
        */
     }
   );


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. VSCODE-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
VSCODE-364

This PR adds makes creation of `columnstore` indexes more visible in index creation template. Additionally we also surface `columnstoreProjection` as available option, supported alongside `columnstore` indexes.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
