### PR TITLE
feat(tree-explorer): sort dbs in the tree by name

### DIFF
--- a/src/explorer/connectionTreeItem.ts
+++ b/src/explorer/connectionTreeItem.ts
@@ -150,6 +150,9 @@ export default class ConnectionTreeItem
     }
 
     const databases = await this.listDatabases();
+    databases.sort((a: string, b: string) => {
+      return a.localeCompare(b);
+    });
 
     this.cacheIsUpToDate = true;
 


### PR DESCRIPTION
Looks like we were defaulting to the server's returned ordering, this pr makes the databases in the list sorted. While most of the databases returned from MongoDB are already sorted, `admin`, `local`, and `config` appear before others alphabetically. These changes make those databases appear alphabetically as well as ensures databases that might return databases differently, (maybe Atlas Data Federation or Cosmos), order the same.

Reported in https://github.com/mongodb-js/vscode/issues/485 

Before merging I'll add a test.