### PR TITLE
feat: provide shell methods completions after getCollection VSCODE-390

### DIFF
--- a/src/language/visitor.ts
+++ b/src/language/visitor.ts
@@ -575,7 +575,7 @@ export class Visitor {
     }
   }
 
-  _checkIsCollectionSymbol(node: babel.types.MemberExpression): void {
+  _checkIsCollectionMemberExpression(node: babel.types.MemberExpression): void {
     if (
       node.object.type === 'MemberExpression' &&
       node.object.object.type === 'Identifier' &&
@@ -585,5 +585,25 @@ export class Visitor {
     ) {
       this._state.isCollectionSymbol = true;
     }
+  }
+
+  _checkIsCollectionCallExpression(node: babel.types.MemberExpression): void {
+    if (
+      node.object.type === 'CallExpression' &&
+      node.object.callee.type === 'MemberExpression' &&
+      node.object.callee.object.type === 'Identifier' &&
+      node.object.callee.object.name === 'db' &&
+      node.object.callee.property.type === 'Identifier' &&
+      node.object.callee.property.name === 'getCollection' &&
+      node.property.type === 'Identifier' &&
+      node.property.name.includes(PLACEHOLDER)
+    ) {
+      this._state.isCollectionSymbol = true;
+    }
+  }
+
+  _checkIsCollectionSymbol(node: babel.types.MemberExpression): void {
+    this._checkIsCollectionMemberExpression(node);
+    this._checkIsCollectionCallExpression(node);
   }
 }

--- a/src/test/suite/language/mongoDBService.test.ts
+++ b/src/test/suite/language/mongoDBService.test.ts
@@ -151,10 +151,22 @@ suite('MongoDBService Test Suite', () => {
       expect(completion).to.have.property('kind', CompletionItemKind.Method);
     });
 
-    test('provide shell collection methods completion if collection name is computed property', async () => {
+    test('provide shell collection methods completion for a collection name in a bracket notation', async () => {
       const result = await testMongoDBService.provideCompletionItems(
         ['use("test");', 'db["test"].'].join('\n'),
         { line: 1, character: 11 }
+      );
+      const completion = result.find(
+        (item: CompletionItem) => item.label === 'find'
+      );
+
+      expect(completion).to.have.property('kind', CompletionItemKind.Method);
+    });
+
+    test('provide shell collection methods completion for a collection name in getCollection', async () => {
+      const result = await testMongoDBService.provideCompletionItems(
+        ['use("test");', 'db.getCollection("test").'].join('\n'),
+        { line: 1, character: 41 }
       );
       const completion = result.find(
         (item: CompletionItem) => item.label === 'find'


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. VSCODE-1111: updates ace editor width in agg pipeline view -->
<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
Provide shell methods completion after a collection specified as `getCollection()`.

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->
Implements: https://github.com/mongodb-js/vscode/pull/417

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
