### PR TITLE
fix: save documents from tree view and do not reopen them for playground runs VSCODE-399, VSCODE-400

### DIFF
--- a/package.json
+++ b/package.json
@@ -619,7 +619,7 @@
         },
         {
           "command": "mdb.saveMongoDBDocument",
-          "when": "editorLangId == json"
+          "when": "resourceScheme == VIEW_DOCUMENT_SCHEME"
         },
         {
           "command": "mdb.runSelectedPlaygroundBlocks",
@@ -812,7 +812,7 @@
         "command": "mdb.saveMongoDBDocument",
         "key": "ctrl+s",
         "mac": "cmd+s",
-        "when": "editorLangId == json"
+        "when": "resourceScheme == VIEW_DOCUMENT_SCHEME"
       }
     ],
     "capabilities": {

--- a/package.json
+++ b/package.json
@@ -812,7 +812,7 @@
         "command": "mdb.saveMongoDBDocument",
         "key": "ctrl+s",
         "mac": "cmd+s",
-        "when": "mdb.isPlayground == true"
+        "when": "editorLangId == json"
       }
     ],
     "capabilities": {

--- a/src/editors/editorsController.ts
+++ b/src/editors/editorsController.ts
@@ -224,7 +224,6 @@ export default class EditorsController {
       DOCUMENT_SOURCE_URI_IDENTIFIER
     ) as DocumentSource;
 
-    // If not MongoDB document save to disk instead of MongoDB.
     if (
       activeEditor.document.uri.scheme !== 'VIEW_DOCUMENT_SCHEME' ||
       !namespace ||
@@ -233,8 +232,9 @@ export default class EditorsController {
       documentId === null ||
       documentId === undefined
     ) {
-      await vscode.commands.executeCommand('workbench.action.files.save');
-
+      void vscode.window.showErrorMessage(
+        `The current file can not be saved as a MongoDB document. Invalid URL: ${activeEditor.document.uri.toString()}`
+      );
       return false;
     }
 

--- a/src/editors/playgroundController.ts
+++ b/src/editors/playgroundController.ts
@@ -581,8 +581,6 @@ export default class PlaygroundController {
 
     this._playgroundResult = evaluateResponse.result;
 
-    this._explorerController.refresh();
-
     await this._openPlaygroundResult();
 
     return true;


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. VSCODE-1111: updates ace editor width in agg pipeline view -->
<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
Bug fixes for the release:
- [VSCODE-399](https://jira.mongodb.org/browse/VSCODE-399) Can not save a mongodb document from a tree view
- [VSCODE-400](https://jira.mongodb.org/browse/VSCODE-400) Run playground sets focus to a previously open document

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
