### PR TITLE
fix(tree-explorer): use nameOnly for fetching databases VSCODE-361

### DIFF
--- a/src/explorer/connectionTreeItem.ts
+++ b/src/explorer/connectionTreeItem.ts
@@ -99,7 +99,9 @@ export default class ConnectionTreeItem
     }
 
     try {
-      const dbs = await dataService.listDatabases();
+      const dbs = await dataService.listDatabases({
+        nameOnly: true,
+      });
 
       return dbs.map((dbItem) => dbItem.name);
     } catch (error) {


### PR DESCRIPTION
We only use the database here so passing `nameOnly` should give a speedup.

Part of VSCODE-361
This also fixes an issue where the database names aren't showing for free tier instances (or maybe specific admin roles). Haven't gotten to the exact cause yet. We're using the `listDatabases` with fallbacks for roles/privileges from Compass: https://github.com/mongodb-js/compass/blob/4e06bd332f20c122730e204e7d379b9cd1656767/packages/data-service/src/data-service.ts#L1039
