### PR TITLE
feat: add playground created telemetry event VSCODE-379

### DIFF
--- a/src/editors/playgroundController.ts
+++ b/src/editors/playgroundController.ts
@@ -327,6 +327,7 @@ export default class PlaygroundController {
       .replace('CURRENT_DATABASE', databaseName)
       .replace('CURRENT_COLLECTION', collectionName);
 
+    this._telemetryService.trackPlaygroundCreated('search');
     return this._createPlaygroundFileWithContent(content);
   }
 
@@ -341,6 +342,9 @@ export default class PlaygroundController {
       content = content
         .replace('NEW_DATABASE_NAME', element.databaseName)
         .replace('Create a new database', 'The current database to use');
+      this._telemetryService.trackPlaygroundCreated('createCollection');
+    } else {
+      this._telemetryService.trackPlaygroundCreated('createDatabase');
     }
 
     return this._createPlaygroundFileWithContent(content);
@@ -354,6 +358,7 @@ export default class PlaygroundController {
       .replace('CURRENT_DATABASE', databaseName)
       .replace('CURRENT_COLLECTION', collectionName);
 
+    this._telemetryService.trackPlaygroundCreated('index');
     return this._createPlaygroundFileWithContent(content);
   }
 
@@ -367,6 +372,7 @@ export default class PlaygroundController {
       .replace('CURRENT_COLLECTION', collectionName)
       .replace('DOCUMENT_CONTENTS', documentContents);
 
+    this._telemetryService.trackPlaygroundCreated('cloneDocument');
     return this._createPlaygroundFileWithContent(content);
   }
 
@@ -378,6 +384,7 @@ export default class PlaygroundController {
       .replace('CURRENT_DATABASE', databaseName)
       .replace('CURRENT_COLLECTION', collectionName);
 
+    this._telemetryService.trackPlaygroundCreated('insertDocument');
     return this._createPlaygroundFileWithContent(content);
   }
 
@@ -386,6 +393,8 @@ export default class PlaygroundController {
       .getConfiguration('mdb')
       .get('useDefaultTemplateForPlayground');
     const content = useDefaultTemplate ? playgroundTemplate : '';
+
+    this._telemetryService.trackPlaygroundCreated('crud');
     return this._createPlaygroundFileWithContent(content);
   }
 

--- a/src/editors/playgroundController.ts
+++ b/src/editors/playgroundController.ts
@@ -40,7 +40,10 @@ import playgroundSearchTemplate from '../templates/playgroundSearchTemplate';
 import playgroundTemplate from '../templates/playgroundTemplate';
 import { StatusView } from '../views';
 import TelemetryService from '../telemetry/telemetryService';
-import { isPlayground } from '../utils/playground';
+import {
+  isPlayground,
+  getPlaygroundExtensionForTelemetry,
+} from '../utils/playground';
 
 const log = createLogger('playground controller');
 
@@ -188,14 +191,18 @@ export default class PlaygroundController {
 
     vscode.workspace.onDidOpenTextDocument(async (document) => {
       if (isPlayground(document.uri)) {
-        this._telemetryService.trackPlaygroundLoaded();
+        this._telemetryService.trackPlaygroundLoaded(
+          getPlaygroundExtensionForTelemetry(document.uri)
+        );
         await vscode.languages.setTextDocumentLanguage(document, 'javascript');
       }
     });
 
     vscode.workspace.onDidSaveTextDocument((document) => {
       if (isPlayground(document.uri)) {
-        this._telemetryService.trackPlaygroundSaved();
+        this._telemetryService.trackPlaygroundSaved(
+          getPlaygroundExtensionForTelemetry(document.uri)
+        );
       }
     });
 

--- a/src/telemetry/telemetryService.ts
+++ b/src/telemetry/telemetryService.ts
@@ -32,7 +32,7 @@ export type SegmentProperties = {
 
 type LinkClickedTelemetryEventProperties = {
   screen: string;
-  link_id: string; // eslint-disable-line camelcase
+  link_id: string;
 };
 
 type ExtensionCommandRunTelemetryEventProperties = {
@@ -48,7 +48,6 @@ type DocumentEditedTelemetryEventProperties = {
   source: DocumentSource;
 };
 
-/* eslint-disable camelcase */
 type QueryExportedTelemetryEventProperties = {
   language: string;
   num_stages?: number;
@@ -56,7 +55,10 @@ type QueryExportedTelemetryEventProperties = {
   with_builders: boolean;
   with_driver_syntax: boolean;
 };
-/* eslint-enable camelcase */
+
+type PlaygroundCreatedTelemetryEventProperties = {
+  playground_type: string;
+};
 
 export type TelemetryEventProperties =
   | PlaygroundTelemetryEventProperties
@@ -65,7 +67,8 @@ export type TelemetryEventProperties =
   | NewConnectionTelemetryEventProperties
   | DocumentUpdatedTelemetryEventProperties
   | DocumentEditedTelemetryEventProperties
-  | QueryExportedTelemetryEventProperties;
+  | QueryExportedTelemetryEventProperties
+  | PlaygroundCreatedTelemetryEventProperties;
 
 export enum TelemetryEventTypes {
   PLAYGROUND_CODE_EXECUTED = 'Playground Code Executed',
@@ -78,6 +81,7 @@ export enum TelemetryEventTypes {
   DOCUMENT_EDITED = 'Document Edited',
   QUERY_EXPORTED = 'Query Exported',
   AGGREGATION_EXPORTED = 'Aggregation Exported',
+  PLAYGROUND_CREATED = 'Playground Created',
 }
 
 /**
@@ -311,5 +315,11 @@ export default class TelemetryService {
     aggExportedProps: QueryExportedTelemetryEventProperties
   ): void {
     this.track(TelemetryEventTypes.AGGREGATION_EXPORTED, aggExportedProps);
+  }
+
+  trackPlaygroundCreated(playgroundType: string): void {
+    this.track(TelemetryEventTypes.PLAYGROUND_CREATED, {
+      playground_type: playgroundType,
+    });
   }
 }

--- a/src/telemetry/telemetryService.ts
+++ b/src/telemetry/telemetryService.ts
@@ -60,6 +60,14 @@ type PlaygroundCreatedTelemetryEventProperties = {
   playground_type: string;
 };
 
+type PlaygroundSavedTelemetryEventProperties = {
+  file_type?: string;
+};
+
+type PlaygroundLoadedTelemetryEventProperties = {
+  file_type?: string;
+};
+
 export type TelemetryEventProperties =
   | PlaygroundTelemetryEventProperties
   | LinkClickedTelemetryEventProperties
@@ -68,7 +76,9 @@ export type TelemetryEventProperties =
   | DocumentUpdatedTelemetryEventProperties
   | DocumentEditedTelemetryEventProperties
   | QueryExportedTelemetryEventProperties
-  | PlaygroundCreatedTelemetryEventProperties;
+  | PlaygroundCreatedTelemetryEventProperties
+  | PlaygroundSavedTelemetryEventProperties
+  | PlaygroundLoadedTelemetryEventProperties;
 
 export enum TelemetryEventTypes {
   PLAYGROUND_CODE_EXECUTED = 'Playground Code Executed',
@@ -121,11 +131,11 @@ export default class TelemetryService {
       const constantsFile = fs.readFileSync(segmentKeyFileLocation, 'utf8');
       const constants = JSON.parse(constantsFile) as { segmentKey: string };
 
-      log.info('SegmentKey received', { type: typeof constants.segmentKey });
+      log.info('SegmentKey was found', { type: typeof constants.segmentKey });
 
       return constants.segmentKey;
     } catch (error) {
-      log.error('Reading SegmentKey failed', error);
+      log.error('SegmentKey was not found', error);
       return;
     }
   }
@@ -187,7 +197,7 @@ export default class TelemetryService {
       if (error) {
         log.error('Failed to track telemetry', error);
       } else {
-        log.info('Telemetry sent', error);
+        log.info('Telemetry sent', segmentProperties);
       }
     });
   }
@@ -289,12 +299,16 @@ export default class TelemetryService {
     });
   }
 
-  trackPlaygroundLoaded(): void {
-    this.track(TelemetryEventTypes.PLAYGROUND_LOADED);
+  trackPlaygroundLoaded(fileType?: string): void {
+    this.track(TelemetryEventTypes.PLAYGROUND_LOADED, {
+      file_type: fileType,
+    });
   }
 
-  trackPlaygroundSaved(): void {
-    this.track(TelemetryEventTypes.PLAYGROUND_SAVED);
+  trackPlaygroundSaved(fileType?: string): void {
+    this.track(TelemetryEventTypes.PLAYGROUND_SAVED, {
+      file_type: fileType,
+    });
   }
 
   trackDocumentUpdated(source: DocumentSource, success: boolean): void {

--- a/src/test/fixture/testSaving.mongodb
+++ b/src/test/fixture/testSaving.mongodb
@@ -1,1 +1,1 @@
-show dbs
+use('test');

--- a/src/test/fixture/testSaving.mongodb.js
+++ b/src/test/fixture/testSaving.mongodb.js
@@ -1,0 +1,3 @@
+/* global use, db */
+
+use('test');

--- a/src/test/suite/explorer/playgroundsExplorer.test.ts
+++ b/src/test/suite/explorer/playgroundsExplorer.test.ts
@@ -50,7 +50,9 @@ suite('Playgrounds Controller Test Suite', function () {
     try {
       const rootPath = path.resolve(__dirname, '../../../..');
       const children = await treeController.getPlaygrounds(rootPath);
-      assert.strictEqual(Object.keys(children).length, 7);
+
+      // The number of playground files in the project repository.
+      assert.strictEqual(Object.keys(children).length, 8);
     } catch (error) {
       assert(false, error as Error);
     }
@@ -69,7 +71,9 @@ suite('Playgrounds Controller Test Suite', function () {
       const rootPath = path.resolve(__dirname, '../../../..');
       const children = await treeController.getPlaygrounds(rootPath);
 
-      assert.strictEqual(Object.keys(children).length, 3);
+      // The number of playground files in the project repository,
+      // excluding the ./playgrounds directory.
+      assert.strictEqual(Object.keys(children).length, 4);
     } catch (error) {
       assert(false, error as Error);
     }

--- a/src/test/suite/telemetry/telemetryService.test.ts
+++ b/src/test/suite/telemetry/telemetryService.test.ts
@@ -11,8 +11,9 @@ import sinonChai from 'sinon-chai';
 
 import { ConnectionTypes } from '../../../connectionController';
 import { DocumentSource } from '../../../documentSource';
-import { ExportToLanguageMode } from '../../../types/playgroundType';
 import { mdbTestExtension } from '../stubbableMdbExtension';
+import { DatabaseTreeItem, DocumentTreeItem } from '../../../explorer';
+import { DataServiceStub } from '../stubs';
 
 const expect = chai.expect;
 
@@ -290,39 +291,13 @@ suite('Telemetry Controller Test Suite', () => {
     );
   });
 
-  test('track query exported to language', async function () {
-    this.timeout(5000);
-
-    const textFromEditor = "{ '_id': 1, 'item': 'abc', 'price': 10 }";
-    const selection = {
-      start: { line: 0, character: 0 },
-      end: { line: 0, character: 40 },
-    } as vscode.Selection;
-    const mode = ExportToLanguageMode.QUERY;
-    const language = 'python';
-
-    sandbox.replace(
-      mdbTestExtension.testExtensionController._playgroundController
-        ._playgroundSelectedCodeActionProvider,
-      'mode',
-      mode
-    );
-    sandbox.replace(
-      mdbTestExtension.testExtensionController._playgroundController
-        ._exportToLanguageCodeLensProvider,
-      '_exportToLanguageAddons',
-      {
-        textFromEditor,
-        selectedText: textFromEditor,
-        selection,
-        importStatements: false,
-        driverSyntax: false,
-        builders: false,
-        language,
-      }
-    );
-
-    await mdbTestExtension.testExtensionController._playgroundController._transpile();
+  test('track query exported to language', function () {
+    testTelemetryService.trackQueryExported({
+      language: 'python',
+      with_import_statements: false,
+      with_builders: false,
+      with_driver_syntax: false,
+    });
 
     sandbox.assert.calledWith(
       fakeSegmentAnalyticsTrack,
@@ -547,6 +522,172 @@ suite('Telemetry Controller Test Suite', () => {
       };
       const type = testTelemetryService.getPlaygroundResultType(res);
       expect(type).to.deep.equal('other');
+    });
+  });
+
+  suite('playground created', () => {
+    test('track on search for documents', async () => {
+      await vscode.commands.executeCommand('mdb.searchForDocuments', {
+        databaseName: 'databaseName',
+        collectionName: 'collectionName',
+      });
+      sandbox.assert.calledWith(
+        fakeSegmentAnalyticsTrack,
+        sinon.match({
+          anonymousId,
+          event: 'Playground Created',
+          properties: {
+            playground_type: 'search',
+            extension_version: '0.0.0-dev.0',
+          },
+        })
+      );
+    });
+
+    test('track on create collection', async () => {
+      const testDatabaseTreeItem = new DatabaseTreeItem(
+        'databaseName',
+        new DataServiceStub(),
+        false,
+        false,
+        {}
+      );
+      await vscode.commands.executeCommand(
+        'mdb.addCollection',
+        testDatabaseTreeItem
+      );
+      sandbox.assert.calledWith(
+        fakeSegmentAnalyticsTrack,
+        sinon.match({
+          anonymousId,
+          event: 'Playground Created',
+          properties: {
+            playground_type: 'createCollection',
+            extension_version: '0.0.0-dev.0',
+          },
+        })
+      );
+    });
+
+    test('track on create database', async () => {
+      await vscode.commands.executeCommand('mdb.addDatabase', {
+        connectionId: 'testconnectionId',
+      });
+      sandbox.assert.calledWith(
+        fakeSegmentAnalyticsTrack,
+        sinon.match({
+          anonymousId,
+          event: 'Playground Created',
+          properties: {
+            playground_type: 'createDatabase',
+            extension_version: '0.0.0-dev.0',
+          },
+        })
+      );
+    });
+
+    test('track on create index', async () => {
+      await vscode.commands.executeCommand('mdb.createIndexFromTreeView', {
+        databaseName: 'databaseName',
+        collectionName: 'collectionName',
+      });
+      sandbox.assert.calledWith(
+        fakeSegmentAnalyticsTrack,
+        sinon.match({
+          anonymousId,
+          event: 'Playground Created',
+          properties: {
+            playground_type: 'index',
+            extension_version: '0.0.0-dev.0',
+          },
+        })
+      );
+    });
+
+    test('track on clone document', async () => {
+      const mockDocument = {
+        _id: 'pancakes',
+        name: '',
+        time: {
+          $time: '12345',
+        },
+      };
+      const dataServiceStub = {
+        find: () => {
+          return Promise.resolve([mockDocument]);
+        },
+      } as Pick<DataService, 'find'> as unknown as DataService;
+      const documentItem = new DocumentTreeItem(
+        mockDocument,
+        'waffle.house',
+        0,
+        dataServiceStub,
+        () => Promise.resolve()
+      );
+      await vscode.commands.executeCommand(
+        'mdb.cloneDocumentFromTreeView',
+        documentItem
+      );
+      sandbox.assert.calledWith(
+        fakeSegmentAnalyticsTrack,
+        sinon.match({
+          anonymousId,
+          event: 'Playground Created',
+          properties: {
+            playground_type: 'cloneDocument',
+            extension_version: '0.0.0-dev.0',
+          },
+        })
+      );
+    });
+
+    test('track on crud from the command palette', async () => {
+      await vscode.commands.executeCommand('mdb.createPlayground');
+      sandbox.assert.calledWith(
+        fakeSegmentAnalyticsTrack,
+        sinon.match({
+          anonymousId,
+          event: 'Playground Created',
+          properties: {
+            playground_type: 'crud',
+            extension_version: '0.0.0-dev.0',
+          },
+        })
+      );
+    });
+
+    test('track on crud from overview page', async () => {
+      await vscode.commands.executeCommand(
+        'mdb.createNewPlaygroundFromOverviewPage'
+      );
+      sandbox.assert.calledWith(
+        fakeSegmentAnalyticsTrack,
+        sinon.match({
+          anonymousId,
+          event: 'Playground Created',
+          properties: {
+            playground_type: 'crud',
+            extension_version: '0.0.0-dev.0',
+          },
+        })
+      );
+    });
+
+    test('track on crud from tree view', async () => {
+      await vscode.commands.executeCommand(
+        'mdb.createNewPlaygroundFromTreeView'
+      );
+      sandbox.assert.calledWith(
+        fakeSegmentAnalyticsTrack,
+        sinon.match({
+          anonymousId,
+          event: 'Playground Created',
+          properties: {
+            playground_type: 'crud',
+            extension_version: '0.0.0-dev.0',
+          },
+        })
+      );
     });
   });
 });

--- a/src/test/suite/telemetry/telemetryService.test.ts
+++ b/src/test/suite/telemetry/telemetryService.test.ts
@@ -247,7 +247,7 @@ suite('Telemetry Controller Test Suite', () => {
     );
   });
 
-  test('track playground loaded event', async () => {
+  test('track mongodb playground loaded event', async () => {
     const docPath = path.resolve(
       __dirname,
       '../../../../src/test/fixture/testSaving.mongodb'
@@ -258,19 +258,44 @@ suite('Telemetry Controller Test Suite', () => {
       sinon.match({
         anonymousId,
         event: 'Playground Loaded',
-        properties: { extension_version: '0.0.0-dev.0' },
+        properties: {
+          file_type: 'mongodb',
+          extension_version: '0.0.0-dev.0',
+        },
+      })
+    );
+  });
+
+  test('track mongodbjs playground loaded event', async () => {
+    const docPath = path.resolve(
+      __dirname,
+      '../../../../src/test/fixture/testSaving.mongodb.js'
+    );
+    await vscode.workspace.openTextDocument(vscode.Uri.file(docPath));
+    sandbox.assert.calledWith(
+      fakeSegmentAnalyticsTrack,
+      sinon.match({
+        anonymousId,
+        event: 'Playground Loaded',
+        properties: {
+          file_type: 'mongodbjs',
+          extension_version: '0.0.0-dev.0',
+        },
       })
     );
   });
 
   test('track playground saved event', () => {
-    testTelemetryService.trackPlaygroundSaved();
+    testTelemetryService.trackPlaygroundSaved('mongodbjs');
     sandbox.assert.calledWith(
       fakeSegmentAnalyticsTrack,
       sinon.match({
         anonymousId,
         event: 'Playground Saved',
-        properties: { extension_version: '0.0.0-dev.0' },
+        properties: {
+          file_type: 'mongodbjs',
+          extension_version: '0.0.0-dev.0',
+        },
       })
     );
   });

--- a/src/utils/playground.ts
+++ b/src/utils/playground.ts
@@ -82,6 +82,18 @@ export const isPlayground = (fileUri?: vscode.Uri) => {
   );
 };
 
+export const getPlaygroundExtensionForTelemetry = (fileUri?: vscode.Uri) => {
+  let fileType;
+
+  if (fileUri?.fsPath.match(/\.(mongodb\.js)$/gi)) {
+    fileType = 'mongodbjs';
+  } else if (fileUri?.fsPath.match(/\.(mongodb)$/gi)) {
+    fileType = 'mongodb';
+  }
+
+  return fileType;
+};
+
 export const getPlaygrounds = async ({
   fsPath,
   excludeFromPlaygroundsSearch,


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. VSCODE-1111: updates ace editor width in agg pipeline view -->
<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
- Add the "Playground Created" telemetry event.
- Add `file_type` (mongodb|mongodbjs) to the "Playground Saved" and "Playground Loaded" telemetry events.

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
