### PR TITLE
feat: add autocomplete support for $percentile, $median ans $$USER_ROLES COMPASS-6780 COMPASS-6781

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@iconify/react": "^1.1.4",
         "@leafygreen-ui/logo": "^6.3.0",
         "@leafygreen-ui/toggle": "^7.0.5",
-        "@mongodb-js/mongodb-constants": "^0.4.0",
+        "@mongodb-js/mongodb-constants": "^0.6.0",
         "@mongosh/browser-runtime-electron": "^1.8.0",
         "@mongosh/i18n": "^1.8.0",
         "@mongosh/service-provider-server": "^1.8.0",
@@ -3274,9 +3274,9 @@
       }
     },
     "node_modules/@mongodb-js/mongodb-constants": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-constants/-/mongodb-constants-0.4.0.tgz",
-      "integrity": "sha512-Y+If46eMf9PFZmrv4TtBLHJ9T6QfpTvReaRuQTwJg1F/vWdNSW/Ro4F8LbUv7RRZU/Zx/n+mxvnS6nUBkj2ZEA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-constants/-/mongodb-constants-0.6.0.tgz",
+      "integrity": "sha512-O1jGPP2vSIvlmUW/kv6i2l0frQgLc8Brwfg1O0xq8OCucEZklhE3UJMTUEE2/3VOeZaLL2BPzG3rWvwy47dbXQ==",
       "dependencies": {
         "semver": "^7.3.8"
       }
@@ -26590,9 +26590,9 @@
       }
     },
     "@mongodb-js/mongodb-constants": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-constants/-/mongodb-constants-0.4.0.tgz",
-      "integrity": "sha512-Y+If46eMf9PFZmrv4TtBLHJ9T6QfpTvReaRuQTwJg1F/vWdNSW/Ro4F8LbUv7RRZU/Zx/n+mxvnS6nUBkj2ZEA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-constants/-/mongodb-constants-0.6.0.tgz",
+      "integrity": "sha512-O1jGPP2vSIvlmUW/kv6i2l0frQgLc8Brwfg1O0xq8OCucEZklhE3UJMTUEE2/3VOeZaLL2BPzG3rWvwy47dbXQ==",
       "requires": {
         "semver": "^7.3.8"
       }

--- a/package.json
+++ b/package.json
@@ -969,7 +969,7 @@
     "@iconify/react": "^1.1.4",
     "@leafygreen-ui/logo": "^6.3.0",
     "@leafygreen-ui/toggle": "^7.0.5",
-    "@mongodb-js/mongodb-constants": "^0.4.0",
+    "@mongodb-js/mongodb-constants": "^0.6.0",
     "@mongosh/browser-runtime-electron": "^1.8.0",
     "@mongosh/i18n": "^1.8.0",
     "@mongosh/service-provider-server": "^1.8.0",

--- a/syntaxes/mongodbInjection.tmLanguage.json
+++ b/syntaxes/mongodbInjection.tmLanguage.json
@@ -182,6 +182,15 @@
         },
         {
           "name": "meta.object.member.mongodb",
+          "match": "\\$median\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.$median.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
           "match": "\\$min\\b",
           "captures": {
             "0": {
@@ -195,6 +204,15 @@
           "captures": {
             "0": {
               "name": "keyword.other.$minN.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$percentile\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.$percentile.mongodb"
             }
           }
         },


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. VSCODE-1111: updates ace editor width in agg pipeline view -->
<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
Bump `@mongodb-js/mongodb-constants` to add autocomplete support for `$percentile` and `$median` accumulators and the `$$USER_ROLES` system variable.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [x] New feature
- [x] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
