### PR TITLE
chore: add new utm attributes to all mongodb links VSCODE-356

### DIFF
--- a/src/explorer/helpTree.ts
+++ b/src/explorer/helpTree.ts
@@ -109,9 +109,16 @@ export default class HelpTree
         'report'
       );
 
+      const telemetryUserIdentity =
+        this._telemetryService?.getTelemetryUserIdentity();
+
       const atlas = new HelpLinkTreeItem(
         'Create Free Atlas Cluster',
-        LINKS.createAtlasCluster,
+        LINKS.createAtlasCluster(
+          telemetryUserIdentity?.userId ??
+            telemetryUserIdentity?.anonymousId ??
+            ''
+        ),
         'freeClusterCTA',
         'atlas',
         true

--- a/src/explorer/helpTree.ts
+++ b/src/explorer/helpTree.ts
@@ -1,9 +1,9 @@
 import * as vscode from 'vscode';
 import path from 'path';
-
 import { getImagesPath } from '../extensionConstants';
 import { TelemetryService } from '../telemetry';
 import { openLink } from '../utils/linkHelper';
+import LINKS from '../utils/links';
 
 const HELP_LINK_CONTEXT_VALUE = 'HELP_LINK';
 
@@ -76,14 +76,14 @@ export default class HelpTree
     if (!element) {
       const whatsNew = new HelpLinkTreeItem(
         "What's New",
-        'https://github.com/mongodb-js/vscode/blob/main/CHANGELOG.md',
+        LINKS.changelog,
         'whatsNew',
         'megaphone'
       );
 
       const extensionDocs = new HelpLinkTreeItem(
         'Extension Documentation',
-        'https://docs.mongodb.com/mongodb-vscode/',
+        LINKS.extensionDocs,
         'extensionDocumentation',
         'book'
       );
@@ -97,26 +97,21 @@ export default class HelpTree
 
       const feedback = new HelpLinkTreeItem(
         'Suggest a Feature',
-        'https://feedback.mongodb.com/forums/929236-mongodb-for-vs-code/',
+        LINKS.feedback,
         'feedback',
         'lightbulb'
       );
 
       const reportBug = new HelpLinkTreeItem(
         'Report a Bug',
-        'https://github.com/mongodb-js/vscode/issues',
+        LINKS.reportBug,
         'reportABug',
         'report'
       );
 
-      const telemetryUserIdentity =
-        this._telemetryService?.getTelemetryUserIdentity();
-      const ajsAid = telemetryUserIdentity
-        ? `&ajs_aid=${telemetryUserIdentity[0]}`
-        : '';
       const atlas = new HelpLinkTreeItem(
         'Create Free Atlas Cluster',
-        `https://mongodb.com/products/vs-code/vs-code-atlas-signup?utm_campaign=vs-code-extension&utm_source=visual-studio&utm_medium=product${ajsAid}`,
+        LINKS.createAtlasCluster,
         'freeClusterCTA',
         'atlas',
         true

--- a/src/explorer/helpTree.ts
+++ b/src/explorer/helpTree.ts
@@ -83,14 +83,14 @@ export default class HelpTree
 
       const extensionDocs = new HelpLinkTreeItem(
         'Extension Documentation',
-        LINKS.extensionDocs,
+        LINKS.extensionDocs(),
         'extensionDocumentation',
         'book'
       );
 
       const mdbDocs = new HelpLinkTreeItem(
         'MongoDB Documentation',
-        'https://docs.mongodb.com/manual/',
+        LINKS.mongodbDocs,
         'mongoDBDocumentation',
         'leaf'
       );

--- a/src/language/mongoDBService.ts
+++ b/src/language/mongoDBService.ts
@@ -36,6 +36,7 @@ import type {
 import type { ClearCompletionsCache } from '../types/completionsCache';
 import { Visitor } from './visitor';
 import type { CompletionState } from './visitor';
+import LINKS from '../utils/links';
 
 import DIAGNOSTIC_CODES from './diagnosticCodes';
 
@@ -445,7 +446,7 @@ export default class MongoDBService {
     description?: string;
   }) {
     const title = operator.replace(/[$]/g, '');
-    const link = `https://www.mongodb.com/docs/manual/reference/operator/aggregation/${title}/`;
+    const link = LINKS.aggregationDocs(title);
     return {
       kind: MarkupKind.Markdown,
       value: description
@@ -461,7 +462,7 @@ export default class MongoDBService {
     bsonType: string;
     description?: string;
   }) {
-    const link = `https://www.mongodb.com/docs/mongodb-shell/reference/data-types/#${bsonType}`;
+    const link = LINKS.bsonDocs(bsonType);
     return {
       kind: MarkupKind.Markdown,
       value: description
@@ -478,7 +479,7 @@ export default class MongoDBService {
     description?: string;
   }) {
     const title = variable.replace(/[$]/g, '');
-    const link = `https://www.mongodb.com/docs/manual/reference/aggregation-variables/#mongodb-variable-variable.${title}`;
+    const link = LINKS.systemVariableDocs(title);
     return {
       kind: MarkupKind.Markdown,
       value: description

--- a/src/test/suite/explorer/helpExplorer.test.ts
+++ b/src/test/suite/explorer/helpExplorer.test.ts
@@ -45,6 +45,12 @@ suite('Help Explorer Test Suite', function () {
 
     assert.strictEqual(atlasHelpItem.label, 'Create Free Atlas Cluster');
     assert.strictEqual(atlasHelpItem.url.includes('mongodb.com'), true);
+    const { userId, anonymousId } =
+      mdbTestExtension.testExtensionController._telemetryService.getTelemetryUserIdentity();
+    assert.strictEqual(
+      new URL(atlasHelpItem.url).searchParams.get('ajs_aid'),
+      userId ?? anonymousId
+    );
     assert.strictEqual(atlasHelpItem.iconName, 'atlas');
     assert.strictEqual(atlasHelpItem.linkId, 'freeClusterCTA');
     assert(atlasHelpItem.useRedirect === true);

--- a/src/test/suite/explorer/helpExplorer.test.ts
+++ b/src/test/suite/explorer/helpExplorer.test.ts
@@ -44,12 +44,7 @@ suite('Help Explorer Test Suite', function () {
     const atlasHelpItem = helpTreeItems[5];
 
     assert.strictEqual(atlasHelpItem.label, 'Create Free Atlas Cluster');
-    const telemetryUserIdentity =
-      mdbTestExtension.testExtensionController._telemetryService.getTelemetryUserIdentity();
-    assert.strictEqual(
-      atlasHelpItem.url,
-      `https://mongodb.com/products/vs-code/vs-code-atlas-signup?utm_campaign=vs-code-extension&utm_source=visual-studio&utm_medium=product&ajs_aid=${telemetryUserIdentity[0]}`
-    );
+    assert.strictEqual(atlasHelpItem.url.includes('mongodb.com'), true);
     assert.strictEqual(atlasHelpItem.iconName, 'atlas');
     assert.strictEqual(atlasHelpItem.linkId, 'freeClusterCTA');
     assert(atlasHelpItem.useRedirect === true);

--- a/src/test/suite/utils/links.test.ts
+++ b/src/test/suite/utils/links.test.ts
@@ -1,0 +1,53 @@
+import { expect } from 'chai';
+import LINKS from '../../../utils/links';
+
+const expectedLinks = {
+  changelog: 'https://github.com/mongodb-js/vscode/blob/main/CHANGELOG.md',
+  feedback:
+    'https://feedback.mongodb.com/forums/929236-mongodb-for-vs-code/?utm_source=vscode&utm_medium=product',
+  github: 'https://github.com/mongodb-js/vscode',
+  reportBug: 'https://github.com/mongodb-js/vscode/issues',
+  atlas:
+    'https://www.mongodb.com/cloud/atlas?utm_source=vscode&utm_medium=product',
+  createAtlasCluster:
+    'https://mongodb.com/products/vs-code/vs-code-atlas-signup?ajs_aid=hi&utm_source=vscode&utm_medium=product',
+  docs: 'https://docs.mongodb.com/?utm_source=vscode&utm_medium=product',
+  mongodbDocs:
+    'https://docs.mongodb.com/manual/?utm_source=vscode&utm_medium=product',
+  extensionDocs:
+    'https://docs.mongodb.com/mongodb-vscode/hi?utm_source=vscode&utm_medium=product',
+  aggregationDocs:
+    'https://www.mongodb.com/docs/manual/reference/operator/aggregation/hi/?utm_source=vscode&utm_medium=product',
+  bsonDocs:
+    'https://www.mongodb.com/docs/mongodb-shell/reference/data-types/?utm_source=vscode&utm_medium=product#hi',
+  systemVariableDocs:
+    'https://www.mongodb.com/docs/manual/reference/aggregation-variables/?utm_source=vscode&utm_medium=product#mongodb-variable-variable.hi',
+  kerberosPrincipalDocs:
+    'https://docs.mongodb.com/manual/core/kerberos/?utm_source=vscode&utm_medium=product#principals',
+  ldapDocs:
+    'https://docs.mongodb.com/manual/core/security-ldap/?utm_source=vscode&utm_medium=product',
+  authDatabaseDocs:
+    'https://docs.mongodb.com/manual/core/security-users/?utm_source=vscode&utm_medium=product#user-authentication-database',
+  sshConnectionDocs:
+    'https://docs.mongodb.com/compass/current/connect/advanced-connection-options/ssh-connection/?utm_source=vscode&utm_medium=product#ssh-connection',
+  configureSSLDocs:
+    'https://docs.mongodb.com/manual/tutorial/configure-ssl/hi?utm_source=vscode&utm_medium=product',
+  pemKeysDocs:
+    'https://docs.mongodb.com/manual/reference/configuration-options/?utm_source=vscode&utm_medium=product#net.ssl.PEMKeyPassword',
+};
+
+suite('LINKS', () => {
+  test('should have all links', () => {
+    expect(Object.keys(expectedLinks)).to.deep.eq(Object.keys(LINKS));
+  });
+
+  Object.entries(expectedLinks).forEach(([name, expected]) => {
+    test(`${name} link should return ${expected}`, () => {
+      if (typeof LINKS[name] === 'function') {
+        expect(expected).to.eq(LINKS[name]('hi'));
+      } else {
+        expect(expected).to.eq(LINKS[name]);
+      }
+    });
+  });
+});

--- a/src/test/suite/views/webview-app/components/atlas-cta/atlas-cta.test.tsx
+++ b/src/test/suite/views/webview-app/components/atlas-cta/atlas-cta.test.tsx
@@ -60,8 +60,16 @@ describe('Resources Panel Component Test Suite', () => {
         'OPEN_TRUSTED_LINK'
       );
       assert.strictEqual(
-        fakeVscodeWindowPostMessage.firstCall.args[0].linkTo,
-        'https://mongodb.com/products/vs-code/vs-code-atlas-signup?utm_campaign=vs-code-extension&utm_source=visual-studio&utm_medium=product&ajs_aid=mockAnonymousID'
+        fakeVscodeWindowPostMessage.firstCall.args[0].linkTo.includes(
+          'mongodb.com'
+        ),
+        true
+      );
+      assert.strictEqual(
+        new URL(
+          fakeVscodeWindowPostMessage.firstCall.args[0].linkTo
+        ).searchParams.get('ajs_aid'),
+        'mockAnonymousID'
       );
       // The assert below is a bit redundant but will prevent us from redirecting to a non-https URL by mistake
       assert(

--- a/src/utils/links.ts
+++ b/src/utils/links.ts
@@ -14,8 +14,10 @@ const LINKS = {
   mongodbDocs: 'https://docs.mongodb.com/manual/',
   feedback: 'https://feedback.mongodb.com/forums/929236-mongodb-for-vs-code/',
   reportBug: 'https://github.com/mongodb-js/vscode/issues',
-  createAtlasCluster:
-    'https://mongodb.com/products/vs-code/vs-code-atlas-signup',
+  createAtlasCluster: (userId: string) => {
+    const ajsAid = userId ? `?ajs_aid=${encodeURIComponent(userId)}` : '';
+    return `https://mongodb.com/products/vs-code/vs-code-atlas-signup${ajsAid}`;
+  },
   aggregationDocs: (title: string) => {
     return `https://www.mongodb.com/docs/manual/reference/operator/aggregation/${title}/`;
   },

--- a/src/utils/links.ts
+++ b/src/utils/links.ts
@@ -1,0 +1,41 @@
+const addUTMAttrs = (url: string) => {
+  const parsed = new URL(url);
+  if (!parsed.host.includes('mongodb')) {
+    return url;
+  }
+  parsed.searchParams.set('utm_source', 'vscode');
+  parsed.searchParams.set('utm_medium', 'product');
+  return parsed.toString();
+};
+
+const LINKS = {
+  changelog: 'https://github.com/mongodb-js/vscode/blob/main/CHANGELOG.md',
+  extensionDocs: 'https://docs.mongodb.com/mongodb-vscode/',
+  mongodbDocs: 'https://docs.mongodb.com/manual/',
+  feedback: 'https://feedback.mongodb.com/forums/929236-mongodb-for-vs-code/',
+  reportBug: 'https://github.com/mongodb-js/vscode/issues',
+  createAtlasCluster:
+    'https://mongodb.com/products/vs-code/vs-code-atlas-signup',
+  aggregationDocs: (title: string) => {
+    return `https://www.mongodb.com/docs/manual/reference/operator/aggregation/${title}/`;
+  },
+  bsonDocs: (type: string) => {
+    return `https://www.mongodb.com/docs/mongodb-shell/reference/data-types/#${type}`;
+  },
+  systemVariableDocs: (name: string) => {
+    return `https://www.mongodb.com/docs/manual/reference/aggregation-variables/#mongodb-variable-variable.${name}`;
+  },
+};
+
+export default Object.fromEntries(
+  Object.entries(LINKS).map(([k, v]) => {
+    return [
+      k,
+      typeof v === 'string'
+        ? addUTMAttrs(v)
+        : (name: string) => {
+            return addUTMAttrs(v(name));
+          },
+    ];
+  })
+) as typeof LINKS;

--- a/src/utils/links.ts
+++ b/src/utils/links.ts
@@ -14,6 +14,9 @@ const LINKS = {
   github: 'https://github.com/mongodb-js/vscode',
   reportBug: 'https://github.com/mongodb-js/vscode/issues',
   atlas: 'https://www.mongodb.com/cloud/atlas',
+  /**
+   * @param anonymousId Segment analytics `anonymousId` (not `userId`) {@link https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/querystring/}
+   */
   createAtlasCluster: (anonymousId: string) => {
     const ajsAid = anonymousId
       ? `?ajs_aid=${encodeURIComponent(anonymousId)}`

--- a/src/utils/links.ts
+++ b/src/utils/links.ts
@@ -10,13 +10,20 @@ const addUTMAttrs = (url: string) => {
 
 const LINKS = {
   changelog: 'https://github.com/mongodb-js/vscode/blob/main/CHANGELOG.md',
-  extensionDocs: 'https://docs.mongodb.com/mongodb-vscode/',
-  mongodbDocs: 'https://docs.mongodb.com/manual/',
   feedback: 'https://feedback.mongodb.com/forums/929236-mongodb-for-vs-code/',
+  github: 'https://github.com/mongodb-js/vscode',
   reportBug: 'https://github.com/mongodb-js/vscode/issues',
-  createAtlasCluster: (userId: string) => {
-    const ajsAid = userId ? `?ajs_aid=${encodeURIComponent(userId)}` : '';
+  atlas: 'https://www.mongodb.com/cloud/atlas',
+  createAtlasCluster: (anonymousId: string) => {
+    const ajsAid = anonymousId
+      ? `?ajs_aid=${encodeURIComponent(anonymousId)}`
+      : '';
     return `https://mongodb.com/products/vs-code/vs-code-atlas-signup${ajsAid}`;
+  },
+  docs: 'https://docs.mongodb.com/',
+  mongodbDocs: 'https://docs.mongodb.com/manual/',
+  extensionDocs(subcategory = '') {
+    return `https://docs.mongodb.com/mongodb-vscode/${subcategory}`;
   },
   aggregationDocs: (title: string) => {
     return `https://www.mongodb.com/docs/manual/reference/operator/aggregation/${title}/`;
@@ -27,6 +34,18 @@ const LINKS = {
   systemVariableDocs: (name: string) => {
     return `https://www.mongodb.com/docs/manual/reference/aggregation-variables/#mongodb-variable-variable.${name}`;
   },
+  kerberosPrincipalDocs:
+    'https://docs.mongodb.com/manual/core/kerberos/#principals',
+  ldapDocs: 'https://docs.mongodb.com/manual/core/security-ldap/',
+  authDatabaseDocs:
+    'https://docs.mongodb.com/manual/core/security-users/#user-authentication-database',
+  sshConnectionDocs:
+    'https://docs.mongodb.com/compass/current/connect/advanced-connection-options/ssh-connection/#ssh-connection',
+  configureSSLDocs(subsection = '') {
+    return `https://docs.mongodb.com/manual/tutorial/configure-ssl/${subsection}`;
+  },
+  pemKeysDocs:
+    'https://docs.mongodb.com/manual/reference/configuration-options/#net.ssl.PEMKeyPassword',
 };
 
 export default Object.fromEntries(

--- a/src/views/webview-app/components/atlas-cta/atlas-cta.tsx
+++ b/src/views/webview-app/components/atlas-cta/atlas-cta.tsx
@@ -10,6 +10,7 @@ import { VSCODE_EXTENSION_SEGMENT_ANONYMOUS_ID } from '../../extension-app-messa
 import AtlasLogo from './atlas-logo';
 
 import styles from './atlas-cta.less';
+import LINKS from '../../../../utils/links';
 
 type DispatchProps = {
   onLinkClicked: (screen: string, linkId: string) => void;
@@ -19,7 +20,7 @@ type DispatchProps = {
 class AtlasCTA extends React.Component<DispatchProps> {
   onAtlasCtaClicked = (): void => {
     const telemetryUserId = window[VSCODE_EXTENSION_SEGMENT_ANONYMOUS_ID];
-    const atlasLink = `https://mongodb.com/products/vs-code/vs-code-atlas-signup?utm_campaign=vs-code-extension&utm_source=visual-studio&utm_medium=product&ajs_aid=${telemetryUserId}`;
+    const atlasLink = LINKS.createAtlasCluster(telemetryUserId);
     this.props.openTrustedLink(atlasLink);
 
     this.onLinkClicked('overviewPage', 'freeClusterCTA');
@@ -43,7 +44,7 @@ class AtlasCTA extends React.Component<DispatchProps> {
               className={styles['atlas-cta-text-link']}
               target="_blank"
               rel="noopener"
-              href="https://www.mongodb.com/cloud/atlas"
+              href={LINKS.atlas}
               onClick={this.onLinkClicked.bind(
                 this,
                 'overviewPage',

--- a/src/views/webview-app/components/connect-form/general-tab/authentication/kerberos.tsx
+++ b/src/views/webview-app/components/connect-form/general-tab/authentication/kerberos.tsx
@@ -10,6 +10,7 @@ import {
 import FormInput from '../../../form/form-input';
 
 import styles from '../../../../connect.module.less';
+import LINKS from '../../../../../../utils/links';
 
 type DispatchProps = {
   kerberosParametersChanged: (newParams: KerberosParameters) => void;
@@ -126,7 +127,7 @@ class Kerberos extends React.Component<props> {
           changeHandler={this.onPrincipalChanged}
           value={kerberosPrincipal || ''}
           // Open the help page for the principal.
-          linkTo="https://docs.mongodb.com/manual/core/kerberos/#principals"
+          linkTo={LINKS.kerberosPrincipalDocs}
         />
         <FormInput
           label="Password"

--- a/src/views/webview-app/components/connect-form/general-tab/authentication/ldap.tsx
+++ b/src/views/webview-app/components/connect-form/general-tab/authentication/ldap.tsx
@@ -7,6 +7,7 @@ import {
   LDAPUsernameChangedAction,
 } from '../../../../store/actions';
 import FormInput from '../../../form/form-input';
+import LINKS from '../../../../../../utils/links';
 
 type DispatchProps = {
   onLDAPPasswordChanged: (newPassword: string) => void;
@@ -58,7 +59,7 @@ class LDAP extends React.Component<props> {
           changeHandler={this.onUsernameChanged}
           value={ldapUsername || ''}
           // Open the help page for LDAP.
-          linkTo="https://docs.mongodb.com/manual/core/security-ldap/"
+          linkTo={LINKS.ldapDocs}
         />
         <FormInput
           label="Password"

--- a/src/views/webview-app/components/connect-form/general-tab/authentication/mongodb-authentication.tsx
+++ b/src/views/webview-app/components/connect-form/general-tab/authentication/mongodb-authentication.tsx
@@ -8,6 +8,7 @@ import {
   UsernameChangedAction,
 } from '../../../../store/actions';
 import FormInput from '../../../form/form-input';
+import LINKS from '../../../../../../utils/links';
 
 type DispatchProps = {
   onAuthSourceChanged: (newAuthSource: string) => void;
@@ -78,7 +79,7 @@ class MongoDBAuthentication extends React.Component<props> {
           changeHandler={this.onAuthSourceChanged}
           value={mongodbDatabaseName || ''}
           // Opens "Authentication Database" documentation.
-          linkTo="https://docs.mongodb.com/manual/core/security-users/#user-authentication-database"
+          linkTo={LINKS.authDatabaseDocs}
         />
       </div>
     );

--- a/src/views/webview-app/components/connect-form/general-tab/authentication/scram-sha-256.tsx
+++ b/src/views/webview-app/components/connect-form/general-tab/authentication/scram-sha-256.tsx
@@ -8,6 +8,7 @@ import {
   UsernameChangedAction,
 } from '../../../../store/actions';
 import FormInput from '../../../form/form-input';
+import LINKS from '../../../../../../utils/links';
 
 type DispatchProps = {
   onAuthSourceChanged: (newAuthSource: string) => void;
@@ -78,7 +79,7 @@ class ScramSha256 extends React.Component<props> {
           changeHandler={this.onAuthSourceChanged}
           value={mongodbDatabaseName || ''}
           // Opens "Authentication Database" documentation.
-          linkTo="https://docs.mongodb.com/manual/core/security-users/#user-authentication-database"
+          linkTo={LINKS.authDatabaseDocs}
         />
       </div>
     );

--- a/src/views/webview-app/components/connect-form/ssh-tab/ssh-tunnel-identity-file-validation.tsx
+++ b/src/views/webview-app/components/connect-form/ssh-tab/ssh-tunnel-identity-file-validation.tsx
@@ -13,6 +13,7 @@ import { AppState } from '../../../store/store';
 import FormInput from '../../form/form-input';
 import FileInputButton from '../../form/file-input-button';
 import FormGroup from '../../form/form-group';
+import LINKS from '../../../../../utils/links';
 
 type DispatchProps = {
   onChangeSSHTunnelIdentityFile: () => void;
@@ -97,7 +98,7 @@ class SSHTunnelIdentityFileValidation extends React.Component<props> {
           error={!isValid && sshTunnelHostname === undefined}
           changeHandler={this.onSSHTunnelHostnameChanged}
           value={sshTunnelHostname || ''}
-          linkTo="https://docs.mongodb.com/compass/current/connect"
+          linkTo={LINKS.sshConnectionDocs}
         />
         <FormInput
           label="SSH Tunnel Port"

--- a/src/views/webview-app/components/connect-form/ssh-tab/ssh-tunnel-password-validation.tsx
+++ b/src/views/webview-app/components/connect-form/ssh-tab/ssh-tunnel-password-validation.tsx
@@ -11,6 +11,7 @@ import {
 import { AppState } from '../../../store/store';
 import FormInput from '../../form/form-input';
 import FormGroup from '../../form/form-group';
+import LINKS from '../../../../../utils/links';
 
 type DispatchProps = {
   onSSHTunnelHostnameChanged: (sshTunnelHostname: string) => void;
@@ -83,7 +84,7 @@ class SSHTunnelPasswordValidation extends React.Component<props> {
           error={!isValid && sshTunnelHostname === undefined}
           changeHandler={this.onSSHTunnelHostnameChanged}
           value={sshTunnelHostname || ''}
-          linkTo="https://docs.mongodb.com/compass/current/connect"
+          linkTo={LINKS.sshConnectionDocs}
         />
         <FormInput
           label="SSH Tunnel Port"

--- a/src/views/webview-app/components/connect-form/ssl-tab/ssl-server-client-validation.tsx
+++ b/src/views/webview-app/components/connect-form/ssl-tab/ssl-server-client-validation.tsx
@@ -12,6 +12,7 @@ import {
 import { AppState } from '../../../store/store';
 
 import styles from '../../../connect.module.less';
+import LINKS from '../../../../../utils/links';
 
 type StateProps = {
   isValid: boolean;
@@ -63,7 +64,7 @@ class SSLServerClientValidation extends React.Component<props> {
           error={!isValid && sslCA === undefined}
           onClick={this.onCertificateAuthorityChanged}
           values={sslCA}
-          link="https://docs.mongodb.com/manual/tutorial/configure-ssl/#certificate-authorities"
+          link={LINKS.configureSSLDocs('#certificate-authorities')}
         />
         <FileInputButton
           label="Client Certificate and Key (.pem)"
@@ -71,7 +72,7 @@ class SSLServerClientValidation extends React.Component<props> {
           error={!isValid && sslCert === undefined}
           onClick={this.onClientCertificateChanged}
           values={sslCert}
-          link="https://docs.mongodb.com/manual/tutorial/configure-ssl/#pem-file"
+          link={LINKS.configureSSLDocs('#pem-file')}
         />
         <FormInput
           label="Client Key Password"
@@ -80,7 +81,7 @@ class SSLServerClientValidation extends React.Component<props> {
           changeHandler={this.onClientKeyPasswordChanged}
           value={sslPass || ''}
           // Opens documentation about net.ssl.PEMKeyPassword.
-          linkTo="https://docs.mongodb.com/manual/reference/configuration-options/#net.ssl.PEMKeyPassword"
+          linkTo={LINKS.pemKeysDocs}
         />
       </div>
     );

--- a/src/views/webview-app/components/connect-form/ssl-tab/ssl-server-validation.tsx
+++ b/src/views/webview-app/components/connect-form/ssl-tab/ssl-server-validation.tsx
@@ -7,6 +7,7 @@ import { ActionTypes, OnChangeSSLCAAction } from '../../../store/actions';
 import { AppState } from '../../../store/store';
 
 import styles from '../../../connect.module.less';
+import LINKS from '../../../../../utils/links';
 
 type StateProps = {
   isValid: boolean;
@@ -39,7 +40,7 @@ class SSLServerValidation extends React.Component<props> {
           error={!isValid && sslCA === undefined}
           id="sslCA"
           label="Certificate Authority"
-          link="https://docs.mongodb.com/manual/tutorial/configure-ssl/#certificate-authorities"
+          link={LINKS.configureSSLDocs('#certificate-authorities')}
           multi
           onClick={this.onClickChangeSSLCA}
           values={this.props.sslCA}

--- a/src/views/webview-app/components/connection-status/connection-status.tsx
+++ b/src/views/webview-app/components/connection-status/connection-status.tsx
@@ -15,6 +15,7 @@ import InfoSprinkle from '../info-sprinkle/info-sprinkle';
 import { CONNECTION_STATUS } from '../../extension-app-message-constants';
 
 import styles from './connection-status.less';
+import LINKS from '../../../../utils/links';
 
 const CONNECTION_STATUS_POLLING_FREQ_MS = 1000;
 
@@ -92,7 +93,7 @@ export class ConnectionStatus extends React.Component<
             <div>All set. Ready to start?</div>
             <div>
               Create a playground.
-              <InfoSprinkle linkTo="https://docs.mongodb.com/mongodb-vscode/playgrounds" />
+              <InfoSprinkle linkTo={LINKS.extensionDocs('playgrounds')} />
             </div>
           </div>
           <button

--- a/src/views/webview-app/components/resources-panel/resources-panel.tsx
+++ b/src/views/webview-app/components/resources-panel/resources-panel.tsx
@@ -12,31 +12,32 @@ import {
 } from '../../store/actions';
 
 import styles from './resources-panel.less';
+import LINKS from '../../../../utils/links';
 
 const ResourceLinks = [
   {
     title: 'Product overview',
     description: 'Get an overview on MongoDB',
     linkId: 'productOverview',
-    url: 'https://docs.mongodb.com/',
+    url: LINKS.docs,
   },
   {
     title: 'Extension documentation',
     description: 'Check the documentation about the extension',
     linkId: 'extensionDocumentation',
-    url: 'https://docs.mongodb.com/mongodb-vscode/',
+    url: LINKS.extensionDocs(),
   },
   {
     title: 'Connect to your database',
     description: 'Connect in just a few steps',
     linkId: 'connectInfo',
-    url: 'https://docs.mongodb.com/mongodb-vscode/connect',
+    url: LINKS.extensionDocs('connect'),
   },
   {
     title: 'Interact with your data',
     description: 'Play with your data, create queries and aggregations',
     linkId: 'interactWithYourData',
-    url: 'https://docs.mongodb.com/mongodb-vscode/playgrounds',
+    url: LINKS.extensionDocs('playgrounds'),
   },
 ];
 
@@ -44,22 +45,22 @@ const FooterFeatures = [
   {
     title: 'Navigate databases',
     linkId: 'navigateDatabaseInfo',
-    url: 'https://docs.mongodb.com/mongodb-vscode/databases-collections',
+    url: LINKS.extensionDocs('databases-collections'),
   },
   {
     title: 'Perform CRUD operations',
     linkId: 'crudInfo',
-    url: 'https://docs.mongodb.com/mongodb-vscode/crud-ops',
+    url: LINKS.extensionDocs('crud-ops'),
   },
   {
     title: 'Run aggregation pipelines',
     linkId: 'aggPipelineInfo',
-    url: 'https://docs.mongodb.com/mongodb-vscode/run-agg-pipelines',
+    url: LINKS.extensionDocs('run-agg-pipelines'),
   },
   {
     title: 'Playgrounds',
     linkId: 'playgroundsInfo',
-    url: 'https://docs.mongodb.com/mongodb-vscode/playgrounds',
+    url: LINKS.extensionDocs('playgrounds'),
   },
 ];
 
@@ -67,17 +68,17 @@ const FooterLinks = [
   {
     title: 'Github',
     linkId: 'github',
-    url: 'https://github.com/mongodb-js/vscode',
+    url: LINKS.github,
   },
   {
     title: 'Suggest a feature',
     linkId: 'feedback',
-    url: 'https://feedback.mongodb.com/forums/929236-mongodb-for-vs-code/',
+    url: LINKS.feedback,
   },
   {
     title: 'Report a bug',
     linkId: 'reportABug',
-    url: 'https://github.com/mongodb-js/vscode/issues',
+    url: LINKS.reportBug,
   },
 ];
 


### PR DESCRIPTION
This patch adds new utm attrs to all mongodb urls in the plugin. Moved all the links to one place so that it should hopefully be hard to miss adding those when new urls will be added