### PR TITLE
fix: disable playground loaded event VSCODE-432

### DIFF
--- a/src/editors/playgroundController.ts
+++ b/src/editors/playgroundController.ts
@@ -191,9 +191,11 @@ export default class PlaygroundController {
 
     vscode.workspace.onDidOpenTextDocument(async (document) => {
       if (isPlayground(document.uri)) {
-        this._telemetryService.trackPlaygroundLoaded(
+        // TODO: re-enable with fewer 'Playground Loaded' events
+        // https://jira.mongodb.org/browse/VSCODE-432
+        /* this._telemetryService.trackPlaygroundLoaded(
           getPlaygroundExtensionForTelemetry(document.uri)
-        );
+        ); */
         await vscode.languages.setTextDocumentLanguage(document, 'javascript');
       }
     });

--- a/src/test/suite/telemetry/telemetryService.test.ts
+++ b/src/test/suite/telemetry/telemetryService.test.ts
@@ -247,7 +247,8 @@ suite('Telemetry Controller Test Suite', () => {
     );
   });
 
-  test('track mongodb playground loaded event', async () => {
+  // TODO: re-enable two tests after https://jira.mongodb.org/browse/VSCODE-432
+  test.skip('track mongodb playground loaded event', async () => {
     const docPath = path.resolve(
       __dirname,
       '../../../../src/test/fixture/testSaving.mongodb'
@@ -266,7 +267,7 @@ suite('Telemetry Controller Test Suite', () => {
     );
   });
 
-  test('track mongodbjs playground loaded event', async () => {
+  test.skip('track mongodbjs playground loaded event', async () => {
     const docPath = path.resolve(
       __dirname,
       '../../../../src/test/fixture/testSaving.mongodb.js'


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. VSCODE-1111: updates ace editor width in agg pipeline view -->
<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
Currently, VSCode has been generating too much of “Playground Loaded” Segment events. We temporarily stop tracking the event and re-enable it with fewer events when the cause is found.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
