### PR TITLE
chore: added migration step to migrate keytar secrets to vscode SecretStorage - VSCODE-435

### DIFF
--- a/src/telemetry/telemetryService.ts
+++ b/src/telemetry/telemetryService.ts
@@ -68,6 +68,15 @@ type PlaygroundLoadedTelemetryEventProperties = {
   file_type?: string;
 };
 
+type KeytarSecretsMigrationFailedTelemetryEventProperties =
+  | { reason: 'KEYTAR_UNAVAILABLE'; totalConnections: number }
+  | {
+      reason: 'CONNECTION_MIGRATION_FAILED';
+      totalConnections: number;
+      failedConnections: number;
+      errorMessage: string;
+    };
+
 export type TelemetryEventProperties =
   | PlaygroundTelemetryEventProperties
   | LinkClickedTelemetryEventProperties
@@ -78,7 +87,8 @@ export type TelemetryEventProperties =
   | QueryExportedTelemetryEventProperties
   | PlaygroundCreatedTelemetryEventProperties
   | PlaygroundSavedTelemetryEventProperties
-  | PlaygroundLoadedTelemetryEventProperties;
+  | PlaygroundLoadedTelemetryEventProperties
+  | KeytarSecretsMigrationFailedTelemetryEventProperties;
 
 export enum TelemetryEventTypes {
   PLAYGROUND_CODE_EXECUTED = 'Playground Code Executed',
@@ -92,6 +102,7 @@ export enum TelemetryEventTypes {
   QUERY_EXPORTED = 'Query Exported',
   AGGREGATION_EXPORTED = 'Aggregation Exported',
   PLAYGROUND_CREATED = 'Playground Created',
+  KEYTAR_SECRETS_MIGRATION_FAILED = 'KeyTar Secrets Migration Failed',
 }
 
 /**

--- a/src/test/suite/stubs.ts
+++ b/src/test/suite/stubs.ts
@@ -34,6 +34,7 @@ class ExtensionContextStub implements vscode.ExtensionContext {
   storageUri;
   globalStorageUri;
   logUri;
+  _secrets: Record<string, string> = {};
   secrets;
   extension;
 
@@ -45,7 +46,17 @@ class ExtensionContextStub implements vscode.ExtensionContext {
     this.globalStoragePath = '';
     this.logPath = '';
     this.subscriptions = [];
-    this.secrets = {};
+    this.secrets = {
+      get: (key: string) => {
+        return this._secrets[key];
+      },
+      store: (key: string, value: string) => {
+        this._secrets[key] = value;
+      },
+      delete: (key: string) => {
+        delete this._secrets[key];
+      },
+    };
     this.extension = '';
     this.workspaceState = {
       keys: (): readonly string[] => {


### PR DESCRIPTION
…t storage

<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. VSCODE-1111: updates ace editor width in agg pipeline view -->
<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->
## Description
In this PR, we added a one-off migration step to migrate secrets stored using keytar to VsCode's SecretStorage. The idea is to run this migration only once when the extension activates and loads the connections, unless there was some error other than keytar unavailable.

<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
