### PR TITLE
refactor: simplify constructor argument assignment VSCODE-441

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -35,7 +35,6 @@
       "type": "node",
       "request": "attach",
       "name": "Attach to Language Server",
-      "protocol": "inspector",
       "port": 6009,
       "sourceMaps": true,
       "outFiles": [

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -106,11 +106,15 @@ export default class ConnectionController {
   // Used by other parts of the extension that respond to changes in the connections.
   private eventEmitter: EventEmitter = new EventEmitter();
 
-  constructor(
-    statusView: StatusView,
-    storageController: StorageController,
-    telemetryService: TelemetryService
-  ) {
+  constructor({
+    statusView,
+    storageController,
+    telemetryService,
+  }: {
+    statusView: StatusView;
+    storageController: StorageController;
+    telemetryService: TelemetryService;
+  }) {
     this._statusView = statusView;
     this._storageController = storageController;
     this._telemetryService = telemetryService;

--- a/src/editors/collectionDocumentsProvider.ts
+++ b/src/editors/collectionDocumentsProvider.ts
@@ -22,13 +22,19 @@ export default class CollectionViewProvider
   _statusView: StatusView;
   _editDocumentCodeLensProvider: EditDocumentCodeLensProvider;
 
-  constructor(
-    context: vscode.ExtensionContext,
-    connectionController: ConnectionController,
-    operationsStore: CollectionDocumentsOperationsStore,
-    statusView: StatusView,
-    editDocumentCodeLensProvider: EditDocumentCodeLensProvider
-  ) {
+  constructor({
+    context,
+    connectionController,
+    operationsStore,
+    statusView,
+    editDocumentCodeLensProvider,
+  }: {
+    context: vscode.ExtensionContext;
+    connectionController: ConnectionController;
+    operationsStore: CollectionDocumentsOperationsStore;
+    statusView: StatusView;
+    editDocumentCodeLensProvider: EditDocumentCodeLensProvider;
+  }) {
     this._context = context;
     this._connectionController = connectionController;
     this._operationsStore = operationsStore;

--- a/src/editors/editorsController.ts
+++ b/src/editors/editorsController.ts
@@ -104,19 +104,31 @@ export default class EditorsController {
   _editDocumentCodeLensProvider: EditDocumentCodeLensProvider;
   _collectionDocumentsCodeLensProvider: CollectionDocumentsCodeLensProvider;
 
-  constructor(
-    context: vscode.ExtensionContext,
-    connectionController: ConnectionController,
-    playgroundController: PlaygroundController,
-    statusView: StatusView,
-    telemetryService: TelemetryService,
-    playgroundResultViewProvider: PlaygroundResultProvider,
-    activeConnectionCodeLensProvider: ActiveConnectionCodeLensProvider,
-    exportToLanguageCodeLensProvider: ExportToLanguageCodeLensProvider,
-    playgroundSelectedCodeActionProvider: PlaygroundSelectedCodeActionProvider,
-    playgroundDiagnosticsCodeActionProvider: PlaygroundDiagnosticsCodeActionProvider,
-    editDocumentCodeLensProvider: EditDocumentCodeLensProvider
-  ) {
+  constructor({
+    context,
+    connectionController,
+    playgroundController,
+    statusView,
+    telemetryService,
+    playgroundResultViewProvider,
+    activeConnectionCodeLensProvider,
+    exportToLanguageCodeLensProvider,
+    playgroundSelectedCodeActionProvider,
+    playgroundDiagnosticsCodeActionProvider,
+    editDocumentCodeLensProvider,
+  }: {
+    context: vscode.ExtensionContext;
+    connectionController: ConnectionController;
+    playgroundController: PlaygroundController;
+    statusView: StatusView;
+    telemetryService: TelemetryService;
+    playgroundResultViewProvider: PlaygroundResultProvider;
+    activeConnectionCodeLensProvider: ActiveConnectionCodeLensProvider;
+    exportToLanguageCodeLensProvider: ExportToLanguageCodeLensProvider;
+    playgroundSelectedCodeActionProvider: PlaygroundSelectedCodeActionProvider;
+    playgroundDiagnosticsCodeActionProvider: PlaygroundDiagnosticsCodeActionProvider;
+    editDocumentCodeLensProvider: EditDocumentCodeLensProvider;
+  }) {
     this._connectionController = connectionController;
     this._playgroundController = playgroundController;
     this._context = context;
@@ -124,20 +136,20 @@ export default class EditorsController {
     this._telemetryService = telemetryService;
     this._memoryFileSystemProvider = new MemoryFileSystemProvider();
     this._documentIdStore = new DocumentIdStore();
-    this._mongoDBDocumentService = new MongoDBDocumentService(
-      this._context,
-      this._connectionController,
-      this._statusView,
-      this._telemetryService
-    );
+    this._mongoDBDocumentService = new MongoDBDocumentService({
+      context: this._context,
+      connectionController: this._connectionController,
+      statusView: this._statusView,
+      telemetryService: this._telemetryService,
+    });
     this._editDocumentCodeLensProvider = editDocumentCodeLensProvider;
-    this._collectionViewProvider = new CollectionDocumentsProvider(
-      this._context,
+    this._collectionViewProvider = new CollectionDocumentsProvider({
+      context: this._context,
       connectionController,
-      this._collectionDocumentsOperationsStore,
-      new StatusView(context),
-      this._editDocumentCodeLensProvider
-    );
+      operationsStore: this._collectionDocumentsOperationsStore,
+      statusView: new StatusView(context),
+      editDocumentCodeLensProvider: this._editDocumentCodeLensProvider,
+    });
     this._playgroundResultViewProvider = playgroundResultViewProvider;
     this._activeConnectionCodeLensProvider = activeConnectionCodeLensProvider;
     this._exportToLanguageCodeLensProvider = exportToLanguageCodeLensProvider;

--- a/src/editors/mongoDBDocumentService.ts
+++ b/src/editors/mongoDBDocumentService.ts
@@ -24,12 +24,17 @@ export default class MongoDBDocumentService {
   _statusView: StatusView;
   _telemetryService: TelemetryService;
 
-  constructor(
-    context: vscode.ExtensionContext,
-    connectionController: ConnectionController,
-    statusView: StatusView,
-    telemetryService: TelemetryService
-  ) {
+  constructor({
+    context,
+    connectionController,
+    statusView,
+    telemetryService,
+  }: {
+    context: vscode.ExtensionContext;
+    connectionController: ConnectionController;
+    statusView: StatusView;
+    telemetryService: TelemetryService;
+  }) {
     this._context = context;
     this._connectionController = connectionController;
     this._statusView = statusView;

--- a/src/editors/playgroundController.ts
+++ b/src/editors/playgroundController.ts
@@ -11,11 +11,7 @@ import ConnectionController, {
   DataServiceEventTypes,
 } from '../connectionController';
 import { createLogger } from '../logging';
-import {
-  ExplorerController,
-  ConnectionTreeItem,
-  DatabaseTreeItem,
-} from '../explorer';
+import { ConnectionTreeItem, DatabaseTreeItem } from '../explorer';
 import ExportToLanguageCodeLensProvider from './exportToLanguageCodeLensProvider';
 import formatError from '../utils/formatError';
 import { LanguageServerController } from '../language';
@@ -118,21 +114,28 @@ export default class PlaygroundController {
   private _playgroundResultTextDocument?: vscode.TextDocument;
   private _statusView: StatusView;
   private _playgroundResultViewProvider: PlaygroundResultProvider;
-  private _explorerController: ExplorerController;
 
   private _codeToEvaluate = '';
 
-  constructor(
-    connectionController: ConnectionController,
-    languageServerController: LanguageServerController,
-    telemetryService: TelemetryService,
-    statusView: StatusView,
-    playgroundResultViewProvider: PlaygroundResultProvider,
-    activeConnectionCodeLensProvider: ActiveConnectionCodeLensProvider,
-    exportToLanguageCodeLensProvider: ExportToLanguageCodeLensProvider,
-    playgroundSelectedCodeActionProvide: PlaygroundSelectedCodeActionProvider,
-    explorerController: ExplorerController
-  ) {
+  constructor({
+    connectionController,
+    languageServerController,
+    telemetryService,
+    statusView,
+    playgroundResultViewProvider,
+    activeConnectionCodeLensProvider,
+    exportToLanguageCodeLensProvider,
+    playgroundSelectedCodeActionProvider,
+  }: {
+    connectionController: ConnectionController;
+    languageServerController: LanguageServerController;
+    telemetryService: TelemetryService;
+    statusView: StatusView;
+    playgroundResultViewProvider: PlaygroundResultProvider;
+    activeConnectionCodeLensProvider: ActiveConnectionCodeLensProvider;
+    exportToLanguageCodeLensProvider: ExportToLanguageCodeLensProvider;
+    playgroundSelectedCodeActionProvider: PlaygroundSelectedCodeActionProvider;
+  }) {
     this._connectionController = connectionController;
     this._activeTextEditor = vscode.window.activeTextEditor;
     this._languageServerController = languageServerController;
@@ -144,8 +147,7 @@ export default class PlaygroundController {
     this._activeConnectionCodeLensProvider = activeConnectionCodeLensProvider;
     this._exportToLanguageCodeLensProvider = exportToLanguageCodeLensProvider;
     this._playgroundSelectedCodeActionProvider =
-      playgroundSelectedCodeActionProvide;
-    this._explorerController = explorerController;
+      playgroundSelectedCodeActionProvider;
 
     this._connectionController.addEventListener(
       DataServiceEventTypes.ACTIVE_CONNECTION_CHANGED,

--- a/src/explorer/collectionTreeItem.ts
+++ b/src/explorer/collectionTreeItem.ts
@@ -84,17 +84,27 @@ export default class CollectionTreeItem
 
   iconPath: { light: string; dark: string };
 
-  constructor(
-    collection: CollectionModelType,
-    databaseName: string,
-    dataService: any,
-    isExpanded: boolean,
-    cacheIsUpToDate: boolean,
-    cachedDocumentCount: number | null,
-    existingDocumentListChild?: DocumentListTreeItem,
-    existingSchemaChild?: SchemaTreeItem,
-    existingIndexListChild?: IndexListTreeItem
-  ) {
+  constructor({
+    collection,
+    databaseName,
+    dataService,
+    isExpanded,
+    cacheIsUpToDate,
+    cachedDocumentCount,
+    existingDocumentListChild,
+    existingSchemaChild,
+    existingIndexListChild,
+  }: {
+    collection: CollectionModelType;
+    databaseName: string;
+    dataService: DataService;
+    isExpanded: boolean;
+    cacheIsUpToDate: boolean;
+    cachedDocumentCount: number | null;
+    existingDocumentListChild?: DocumentListTreeItem;
+    existingSchemaChild?: SchemaTreeItem;
+    existingIndexListChild?: IndexListTreeItem;
+  }) {
     super(
       collection.name,
       isExpanded
@@ -113,40 +123,40 @@ export default class CollectionTreeItem
     this.cacheIsUpToDate = cacheIsUpToDate;
     this._documentListChild = existingDocumentListChild
       ? existingDocumentListChild
-      : new DocumentListTreeItem(
-          this.collectionName,
-          this.databaseName,
-          this._type,
-          this._dataService,
-          false, // Collapsed.
-          MAX_DOCUMENTS_VISIBLE,
-          this.documentCount,
-          this.refreshDocumentCount,
-          false, // Cache is not up to date.
-          [] // Empty cache.
-        );
+      : new DocumentListTreeItem({
+          collectionName: this.collectionName,
+          databaseName: this.databaseName,
+          type: this._type,
+          dataService: this._dataService,
+          isExpanded: false,
+          maxDocumentsToShow: MAX_DOCUMENTS_VISIBLE,
+          cachedDocumentCount: this.documentCount,
+          refreshDocumentCount: this.refreshDocumentCount,
+          cacheIsUpToDate: false,
+          childrenCache: [], // Empty cache.
+        });
     this._schemaChild = existingSchemaChild
       ? existingSchemaChild
-      : new SchemaTreeItem(
-          this.collectionName,
-          this.databaseName,
-          this._dataService,
-          false, // Collapsed.
-          false, // Hasn't been clicked to show more documents.
-          false, // No more fields to show.
-          false, // Cached is not up to date.
-          {} // Empty cache.
-        );
+      : new SchemaTreeItem({
+          collectionName: this.collectionName,
+          databaseName: this.databaseName,
+          dataService: this._dataService,
+          isExpanded: false,
+          hasClickedShowMoreFields: false,
+          hasMoreFieldsToShow: false,
+          cacheIsUpToDate: false,
+          childrenCache: {}, // Empty cache.
+        });
     this._indexListChild = existingIndexListChild
       ? existingIndexListChild
-      : new IndexListTreeItem(
-          this.collectionName,
-          this.databaseName,
-          this._dataService,
-          false, // Collapsed.
-          false, // Cache is not up to date.
-          [] // Empty cache.
-        );
+      : new IndexListTreeItem({
+          collectionName: this.collectionName,
+          databaseName: this.databaseName,
+          dataService: this._dataService,
+          isExpanded: false,
+          cacheIsUpToDate: false,
+          childrenCache: [], // Empty cache.
+        });
 
     this.tooltip =
       collection.type === CollectionTypes.view
@@ -187,42 +197,42 @@ export default class CollectionTreeItem
   }
 
   rebuildDocumentListTreeItem(): void {
-    this._documentListChild = new DocumentListTreeItem(
-      this.collectionName,
-      this.databaseName,
-      this._type,
-      this._dataService,
-      this._documentListChild.isExpanded,
-      this._documentListChild.getMaxDocumentsToShow(),
-      this.documentCount,
-      this.refreshDocumentCount,
-      this._documentListChild.cacheIsUpToDate,
-      this._documentListChild.getChildrenCache()
-    );
+    this._documentListChild = new DocumentListTreeItem({
+      collectionName: this.collectionName,
+      databaseName: this.databaseName,
+      type: this._type,
+      dataService: this._dataService,
+      isExpanded: this._documentListChild.isExpanded,
+      maxDocumentsToShow: this._documentListChild.getMaxDocumentsToShow(),
+      cachedDocumentCount: this.documentCount,
+      refreshDocumentCount: this.refreshDocumentCount,
+      cacheIsUpToDate: this._documentListChild.cacheIsUpToDate,
+      childrenCache: this._documentListChild.getChildrenCache(),
+    });
   }
 
   rebuildSchemaTreeItem(): void {
-    this._schemaChild = new SchemaTreeItem(
-      this.collectionName,
-      this.databaseName,
-      this._dataService,
-      this._schemaChild.isExpanded,
-      this._schemaChild.hasClickedShowMoreFields,
-      this._schemaChild.hasMoreFieldsToShow,
-      this._schemaChild.cacheIsUpToDate,
-      this._schemaChild.childrenCache
-    );
+    this._schemaChild = new SchemaTreeItem({
+      collectionName: this.collectionName,
+      databaseName: this.databaseName,
+      dataService: this._dataService,
+      isExpanded: this._schemaChild.isExpanded,
+      hasClickedShowMoreFields: this._schemaChild.hasClickedShowMoreFields,
+      hasMoreFieldsToShow: this._schemaChild.hasMoreFieldsToShow,
+      cacheIsUpToDate: this._schemaChild.cacheIsUpToDate,
+      childrenCache: this._schemaChild.childrenCache,
+    });
   }
 
   rebuildIndexListTreeItem(): void {
-    this._indexListChild = new IndexListTreeItem(
-      this.collectionName,
-      this.databaseName,
-      this._dataService,
-      this._indexListChild.isExpanded,
-      this._indexListChild.cacheIsUpToDate,
-      this._indexListChild.getChildrenCache()
-    );
+    this._indexListChild = new IndexListTreeItem({
+      collectionName: this.collectionName,
+      databaseName: this.databaseName,
+      dataService: this._dataService,
+      isExpanded: this._indexListChild.isExpanded,
+      cacheIsUpToDate: this._indexListChild.cacheIsUpToDate,
+      childrenCache: this._indexListChild.getChildrenCache(),
+    });
   }
 
   rebuildChildrenCache(): void {
@@ -259,36 +269,36 @@ export default class CollectionTreeItem
     this.cacheIsUpToDate = false;
     this.documentCount = null;
 
-    this._documentListChild = new DocumentListTreeItem(
-      this.collectionName,
-      this.databaseName,
-      this._type,
-      this._dataService,
-      false, // Collapsed.
-      MAX_DOCUMENTS_VISIBLE,
-      this.documentCount,
-      this.refreshDocumentCount,
-      false, // Cache is not up to date.
-      [] // Empty cache.
-    );
-    this._schemaChild = new SchemaTreeItem(
-      this.collectionName,
-      this.databaseName,
-      this._dataService,
-      false, // Collapsed.
-      false, // Hasn't been clicked to show more documents.
-      false, // No more fields to show.
-      false, // Cached is not up to date.
-      {} // Empty cache.
-    );
-    this._indexListChild = new IndexListTreeItem(
-      this.collectionName,
-      this.databaseName,
-      this._dataService,
-      false, // Collapsed.
-      false, // Cache is not up to date.
-      [] // Empty cache.
-    );
+    this._documentListChild = new DocumentListTreeItem({
+      collectionName: this.collectionName,
+      databaseName: this.databaseName,
+      type: this._type,
+      dataService: this._dataService,
+      isExpanded: false,
+      maxDocumentsToShow: MAX_DOCUMENTS_VISIBLE,
+      cachedDocumentCount: this.documentCount,
+      refreshDocumentCount: this.refreshDocumentCount,
+      cacheIsUpToDate: false,
+      childrenCache: [], // Empty cache.
+    });
+    this._schemaChild = new SchemaTreeItem({
+      collectionName: this.collectionName,
+      databaseName: this.databaseName,
+      dataService: this._dataService,
+      isExpanded: false,
+      hasClickedShowMoreFields: false,
+      hasMoreFieldsToShow: false,
+      cacheIsUpToDate: false,
+      childrenCache: {}, // Empty cache.
+    });
+    this._indexListChild = new IndexListTreeItem({
+      collectionName: this.collectionName,
+      databaseName: this.databaseName,
+      dataService: this._dataService,
+      isExpanded: false,
+      cacheIsUpToDate: false,
+      childrenCache: [], // Empty cache.
+    });
   }
 
   getDocumentListChild(): DocumentListTreeItem {

--- a/src/explorer/collectionTreeItem.ts
+++ b/src/explorer/collectionTreeItem.ts
@@ -13,7 +13,7 @@ import TreeItemParent from './treeItemParentInterface';
 import SchemaTreeItem from './schemaTreeItem';
 
 function getIconPath(
-  type: CollectionTypes,
+  type: string,
   isExpanded: boolean
 ): { light: string; dark: string } {
   const LIGHT = path.join(getImagesPath(), 'light');
@@ -42,10 +42,9 @@ function getIconPath(
   };
 }
 
-type CollectionModelType = {
-  name: string;
-  type: CollectionTypes;
-};
+export type CollectionDetailsType = Awaited<
+  ReturnType<DataService['listCollections']>
+>[number];
 
 function isChildCacheOutOfSync(
   child: DocumentListTreeItem | SchemaTreeItem | IndexListTreeItem
@@ -67,13 +66,13 @@ export default class CollectionTreeItem
   private _schemaChild: SchemaTreeItem;
   private _indexListChild: IndexListTreeItem;
 
-  collection: CollectionModelType;
+  collection: CollectionDetailsType;
   collectionName: string;
   databaseName: string;
   namespace: string;
 
   private _dataService: DataService;
-  private _type: CollectionTypes;
+  private _type: string;
   documentCount: number | null = null;
 
   isExpanded: boolean;
@@ -95,7 +94,7 @@ export default class CollectionTreeItem
     existingSchemaChild,
     existingIndexListChild,
   }: {
-    collection: CollectionModelType;
+    collection: CollectionDetailsType;
     databaseName: string;
     dataService: DataService;
     isExpanded: boolean;

--- a/src/explorer/connectionTreeItem.ts
+++ b/src/explorer/connectionTreeItem.ts
@@ -44,14 +44,21 @@ export default class ConnectionTreeItem
 
   isExpanded: boolean;
 
-  constructor(
-    connectionId: string,
-    collapsibleState: vscode.TreeItemCollapsibleState,
-    isExpanded: boolean,
-    connectionController: ConnectionController,
-    cacheIsUpToDate: boolean,
-    childrenCache: { [key: string]: DatabaseTreeItem } // Existing cache.
-  ) {
+  constructor({
+    connectionId,
+    collapsibleState,
+    isExpanded,
+    connectionController,
+    cacheIsUpToDate,
+    childrenCache,
+  }: {
+    connectionId: string;
+    collapsibleState: vscode.TreeItemCollapsibleState;
+    isExpanded: boolean;
+    connectionController: ConnectionController;
+    cacheIsUpToDate: boolean;
+    childrenCache: { [key: string]: DatabaseTreeItem }; // Existing cache.
+  }) {
     super(
       connectionController.getSavedConnectionName(connectionId),
       collapsibleState
@@ -139,13 +146,13 @@ export default class ConnectionTreeItem
           return;
         }
 
-        this._childrenCache[databaseName] = new DatabaseTreeItem(
+        this._childrenCache[databaseName] = new DatabaseTreeItem({
           databaseName,
           dataService,
-          prevChild.isExpanded,
-          prevChild.cacheIsUpToDate,
-          prevChild.getChildrenCache()
-        );
+          isExpanded: prevChild.isExpanded,
+          cacheIsUpToDate: prevChild.cacheIsUpToDate,
+          childrenCache: prevChild.getChildrenCache(),
+        });
       });
 
       return Object.values(this._childrenCache);
@@ -167,21 +174,21 @@ export default class ConnectionTreeItem
       if (pastChildrenCache[name]) {
         // We create a new element here instead of reusing the cached one
         // in order to ensure the expanded state is set.
-        this._childrenCache[name] = new DatabaseTreeItem(
-          name,
+        this._childrenCache[name] = new DatabaseTreeItem({
+          databaseName: name,
           dataService,
-          pastChildrenCache[name].isExpanded,
-          pastChildrenCache[name].cacheIsUpToDate,
-          pastChildrenCache[name].getChildrenCache()
-        );
+          isExpanded: pastChildrenCache[name].isExpanded,
+          cacheIsUpToDate: pastChildrenCache[name].cacheIsUpToDate,
+          childrenCache: pastChildrenCache[name].getChildrenCache(),
+        });
       } else {
-        this._childrenCache[name] = new DatabaseTreeItem(
-          name,
+        this._childrenCache[name] = new DatabaseTreeItem({
+          databaseName: name,
           dataService,
-          false, // Collapsed.
-          false, // Cache is not up to date (no cache).
-          {} // No existing cache.
-        );
+          isExpanded: false,
+          cacheIsUpToDate: false, // Cache is not up to date (no cache).
+          childrenCache: {}, // No existing cache.
+        });
       }
     });
 

--- a/src/explorer/databaseTreeItem.ts
+++ b/src/explorer/databaseTreeItem.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import type { DataService } from 'mongodb-data-service';
 
 import CollectionTreeItem from './collectionTreeItem';
+import type { CollectionDetailsType } from './collectionTreeItem';
 import formatError from '../utils/formatError';
 import { getImagesPath } from '../extensionConstants';
 import TreeItemParent from './treeItemParentInterface';
@@ -114,8 +115,8 @@ export default class DatabaseTreeItem
       // Create new collection tree items, using previously cached items
       // where possible.
 
-      const systemCollections: string[] = [];
-      const otherCollections: string[] = [];
+      const systemCollections: CollectionDetailsType[] = [];
+      const otherCollections: CollectionDetailsType[] = [];
 
       collections.forEach((collection) => {
         if (collection.name.startsWith('system.')) {
@@ -125,15 +126,17 @@ export default class DatabaseTreeItem
         }
       });
 
-      const sortFunction = (collectionA: any, collectionB: any) =>
-        (collectionA.name || '').localeCompare(collectionB.name || '');
+      const sortFunction = (
+        collectionA: CollectionDetailsType,
+        collectionB: CollectionDetailsType
+      ) => (collectionA.name || '').localeCompare(collectionB.name || '');
 
       const collectionTreeEntries = [
         ...otherCollections.sort(sortFunction),
         ...systemCollections.sort(sortFunction),
       ];
 
-      collectionTreeEntries.forEach((collection: any) => {
+      collectionTreeEntries.forEach((collection) => {
         if (pastChildrenCache[collection.name]) {
           this._childrenCache[collection.name] = new CollectionTreeItem({
             collection,
@@ -198,7 +201,7 @@ export default class DatabaseTreeItem
         value: '',
         placeHolder: 'e.g. myNewCollection',
         prompt: `Are you sure you wish to drop this database? Enter the database name '${databaseName}' to confirm.`,
-        validateInput: (inputDatabaseName: any) => {
+        validateInput: (inputDatabaseName) => {
           if (
             inputDatabaseName &&
             !databaseName.startsWith(inputDatabaseName)

--- a/src/explorer/documentListTreeItem.ts
+++ b/src/explorer/documentListTreeItem.ts
@@ -31,7 +31,15 @@ class ShowMoreDocumentsTreeItem extends vscode.TreeItem {
   isShowMoreItem = true;
   onShowMoreClicked: () => void;
 
-  constructor(namespace: string, showMore: () => void, documentsShown: number) {
+  constructor({
+    namespace,
+    showMore,
+    documentsShown,
+  }: {
+    namespace: string;
+    showMore: () => void;
+    documentsShown: number;
+  }) {
     super('Show more...', vscode.TreeItemCollapsibleState.None);
 
     // We assign the item a unique id so that when it is selected the selection
@@ -110,18 +118,29 @@ export default class DocumentListTreeItem
 
   iconPath: { light: string; dark: string };
 
-  constructor(
-    collectionName: string,
-    databaseName: string,
-    type: CollectionTypes,
-    dataService: DataService,
-    isExpanded: boolean,
-    maxDocumentsToShow: number,
-    cachedDocumentCount: number | null,
-    refreshDocumentCount: () => Promise<number>,
-    cacheIsUpToDate: boolean,
-    childrenCache: Array<DocumentTreeItem | ShowMoreDocumentsTreeItem> // Existing cache.
-  ) {
+  constructor({
+    collectionName,
+    databaseName,
+    type,
+    dataService,
+    isExpanded,
+    maxDocumentsToShow,
+    cachedDocumentCount,
+    refreshDocumentCount,
+    cacheIsUpToDate,
+    childrenCache,
+  }: {
+    collectionName: string;
+    databaseName: string;
+    type: CollectionTypes;
+    dataService: DataService;
+    isExpanded: boolean;
+    maxDocumentsToShow: number;
+    cachedDocumentCount: number | null;
+    refreshDocumentCount: () => Promise<number>;
+    cacheIsUpToDate: boolean;
+    childrenCache: Array<DocumentTreeItem | ShowMoreDocumentsTreeItem>; // Existing cache.
+  }) {
     super(ITEM_LABEL, getCollapsableStateForDocumentList(isExpanded, type));
 
     this.collectionName = collectionName;
@@ -172,13 +191,13 @@ export default class DocumentListTreeItem
 
       pastChildrenCache.forEach((pastTreeItem, index) => {
         this._childrenCache.push(
-          new DocumentTreeItem(
-            (pastTreeItem as DocumentTreeItem).document,
-            this.namespace,
-            index,
-            this._dataService,
-            () => this.resetCache()
-          )
+          new DocumentTreeItem({
+            document: (pastTreeItem as DocumentTreeItem).document,
+            namespace: this.namespace,
+            documentIndexInTree: index,
+            dataService: this._dataService,
+            resetDocumentListCache: () => this.resetCache(),
+          })
         );
       });
 
@@ -186,11 +205,11 @@ export default class DocumentListTreeItem
         return [
           ...this._childrenCache,
           // Add a `Show more...` item when there are more documents to show.
-          new ShowMoreDocumentsTreeItem(
-            this.namespace,
-            () => this.onShowMoreClicked(),
-            this._maxDocumentsToShow
-          ),
+          new ShowMoreDocumentsTreeItem({
+            namespace: this.namespace,
+            showMore: () => this.onShowMoreClicked(),
+            documentsShown: this._maxDocumentsToShow,
+          }),
         ];
       }
 
@@ -218,13 +237,13 @@ export default class DocumentListTreeItem
     if (documents) {
       documents.forEach((document, index) => {
         this._childrenCache.push(
-          new DocumentTreeItem(
+          new DocumentTreeItem({
             document,
-            this.namespace,
-            index,
-            this._dataService,
-            () => this.resetCache()
-          )
+            namespace: this.namespace,
+            documentIndexInTree: index,
+            dataService: this._dataService,
+            resetDocumentListCache: () => this.resetCache(),
+          })
         );
       });
     }
@@ -232,11 +251,11 @@ export default class DocumentListTreeItem
     if (this.hasMoreDocumentsToShow()) {
       return [
         ...this._childrenCache,
-        new ShowMoreDocumentsTreeItem(
-          this.namespace,
-          () => this.onShowMoreClicked(),
-          this._maxDocumentsToShow
-        ),
+        new ShowMoreDocumentsTreeItem({
+          namespace: this.namespace,
+          showMore: () => this.onShowMoreClicked(),
+          documentsShown: this._maxDocumentsToShow,
+        }),
       ];
     }
 

--- a/src/explorer/documentListTreeItem.ts
+++ b/src/explorer/documentListTreeItem.ts
@@ -51,7 +51,7 @@ class ShowMoreDocumentsTreeItem extends vscode.TreeItem {
 
 const getCollapsableStateForDocumentList = (
   isExpanded: boolean,
-  type: CollectionTypes
+  type: string
 ): vscode.TreeItemCollapsibleState => {
   if (type === CollectionTypes.view) {
     return vscode.TreeItemCollapsibleState.None;
@@ -77,10 +77,7 @@ function getIconPath(): { light: string; dark: string } {
   };
 }
 
-function getTooltip(
-  type: CollectionTypes,
-  documentCount: number | null
-): string {
+function getTooltip(type: string, documentCount: number | null): string {
   const typeString = type === CollectionTypes.view ? 'View' : 'Collection';
   if (documentCount !== null) {
     return `${typeString} Documents - ${documentCount}`;
@@ -110,7 +107,7 @@ export default class DocumentListTreeItem
   collectionName: string;
   databaseName: string;
   namespace: string;
-  type: CollectionTypes;
+  type: string;
 
   private _dataService: DataService;
 
@@ -132,7 +129,7 @@ export default class DocumentListTreeItem
   }: {
     collectionName: string;
     databaseName: string;
-    type: CollectionTypes;
+    type: string;
     dataService: DataService;
     isExpanded: boolean;
     maxDocumentsToShow: number;

--- a/src/explorer/documentTreeItem.ts
+++ b/src/explorer/documentTreeItem.ts
@@ -20,13 +20,19 @@ export default class DocumentTreeItem
   documentId: any;
   resetDocumentListCache: () => Promise<void>;
 
-  constructor(
-    document: Document,
-    namespace: string,
-    documentIndexInTree: number,
-    dataService: DataService,
-    resetDocumentListCache: () => Promise<void>
-  ) {
+  constructor({
+    document,
+    namespace,
+    documentIndexInTree,
+    dataService,
+    resetDocumentListCache,
+  }: {
+    document: Document;
+    namespace: string;
+    documentIndexInTree: number;
+    dataService: DataService;
+    resetDocumentListCache: () => Promise<void>;
+  }) {
     // A document can not have a `_id` when it is in a view. In this instance
     // we just show the document's index in the tree.
     super(

--- a/src/explorer/explorerTreeController.ts
+++ b/src/explorer/explorerTreeController.ts
@@ -167,18 +167,18 @@ export default class ExplorerTreeController
           connectionExpandedState = vscode.TreeItemCollapsibleState.None;
         }
 
-        this._connectionTreeItems[connection.id] = new ConnectionTreeItem(
-          connection.id,
-          connectionExpandedState,
-          isActiveConnection,
-          this._connectionController,
-          pastConnectionTreeItems[connection.id]
+        this._connectionTreeItems[connection.id] = new ConnectionTreeItem({
+          connectionId: connection.id,
+          collapsibleState: connectionExpandedState,
+          isExpanded: isActiveConnection,
+          connectionController: this._connectionController,
+          cacheIsUpToDate: pastConnectionTreeItems[connection.id]
             ? pastConnectionTreeItems[connection.id].cacheIsUpToDate
             : false,
-          pastConnectionTreeItems[connection.id]
+          childrenCache: pastConnectionTreeItems[connection.id]
             ? pastConnectionTreeItems[connection.id].getChildrenCache()
-            : {}
-        );
+            : {},
+        });
       });
 
       return Promise.resolve(

--- a/src/explorer/fieldTreeItem.ts
+++ b/src/explorer/fieldTreeItem.ts
@@ -175,11 +175,15 @@ export default class FieldTreeItem
 
   iconPath: string | { light: string; dark: string };
 
-  constructor(
-    field: SchemaFieldType,
-    isExpanded: boolean,
-    existingCache: { [fieldName: string]: FieldTreeItem }
-  ) {
+  constructor({
+    field,
+    isExpanded,
+    existingCache,
+  }: {
+    field: SchemaFieldType;
+    isExpanded: boolean;
+    existingCache: { [fieldName: string]: FieldTreeItem };
+  }) {
     super(field.name, getCollapsibleStateForField(field, isExpanded));
 
     this.field = field;
@@ -219,17 +223,18 @@ export default class FieldTreeItem
       if (subDocumentFields) {
         subDocumentFields.forEach((subField) => {
           if (pastChildrenCache[subField.name]) {
-            this._childrenCache[subField.name] = new FieldTreeItem(
-              subField,
-              pastChildrenCache[subField.name].isExpanded,
-              pastChildrenCache[subField.name].getChildrenCache()
-            );
+            this._childrenCache[subField.name] = new FieldTreeItem({
+              field: subField,
+              isExpanded: pastChildrenCache[subField.name].isExpanded,
+              existingCache:
+                pastChildrenCache[subField.name].getChildrenCache(),
+            });
           } else {
-            this._childrenCache[subField.name] = new FieldTreeItem(
-              subField,
-              false,
-              {}
-            );
+            this._childrenCache[subField.name] = new FieldTreeItem({
+              field: subField,
+              isExpanded: false,
+              existingCache: {},
+            });
           }
         });
       }
@@ -244,17 +249,18 @@ export default class FieldTreeItem
       if (arrayElementFields) {
         arrayElementFields.forEach((arrayField) => {
           if (pastChildrenCache[arrayField.name]) {
-            this._childrenCache[arrayField.name] = new FieldTreeItem(
-              arrayField,
-              pastChildrenCache[arrayField.name].isExpanded,
-              pastChildrenCache[arrayField.name].getChildrenCache()
-            );
+            this._childrenCache[arrayField.name] = new FieldTreeItem({
+              field: arrayField,
+              isExpanded: pastChildrenCache[arrayField.name].isExpanded,
+              existingCache:
+                pastChildrenCache[arrayField.name].getChildrenCache(),
+            });
           } else {
-            this._childrenCache[arrayField.name] = new FieldTreeItem(
-              arrayField,
-              false,
-              {}
-            );
+            this._childrenCache[arrayField.name] = new FieldTreeItem({
+              field: arrayField,
+              isExpanded: false,
+              existingCache: {},
+            });
           }
         });
       }

--- a/src/explorer/helpTree.ts
+++ b/src/explorer/helpTree.ts
@@ -30,13 +30,19 @@ export class HelpLinkTreeItem extends vscode.TreeItem {
   url: string;
   useRedirect: boolean;
 
-  constructor(
-    title: string,
-    url: string,
-    linkId: string,
-    iconName?: string,
-    useRedirect = false
-  ) {
+  constructor({
+    title,
+    url,
+    linkId,
+    iconName,
+    useRedirect = false,
+  }: {
+    title: string;
+    url: string;
+    linkId: string;
+    iconName?: string;
+    useRedirect?: boolean;
+  }) {
     super(title, vscode.TreeItemCollapsibleState.None);
 
     this.linkId = linkId;
@@ -74,55 +80,55 @@ export default class HelpTree
   async getChildren(element?: any): Promise<any[]> {
     // When no element is present we are at the root.
     if (!element) {
-      const whatsNew = new HelpLinkTreeItem(
-        "What's New",
-        LINKS.changelog,
-        'whatsNew',
-        'megaphone'
-      );
+      const whatsNew = new HelpLinkTreeItem({
+        title: "What's New",
+        url: LINKS.changelog,
+        linkId: 'whatsNew',
+        iconName: 'megaphone',
+      });
 
-      const extensionDocs = new HelpLinkTreeItem(
-        'Extension Documentation',
-        LINKS.extensionDocs(),
-        'extensionDocumentation',
-        'book'
-      );
+      const extensionDocs = new HelpLinkTreeItem({
+        title: 'Extension Documentation',
+        url: LINKS.extensionDocs(),
+        linkId: 'extensionDocumentation',
+        iconName: 'book',
+      });
 
-      const mdbDocs = new HelpLinkTreeItem(
-        'MongoDB Documentation',
-        LINKS.mongodbDocs,
-        'mongoDBDocumentation',
-        'leaf'
-      );
+      const mdbDocs = new HelpLinkTreeItem({
+        title: 'MongoDB Documentation',
+        url: LINKS.mongodbDocs,
+        linkId: 'mongoDBDocumentation',
+        iconName: 'leaf',
+      });
 
-      const feedback = new HelpLinkTreeItem(
-        'Suggest a Feature',
-        LINKS.feedback,
-        'feedback',
-        'lightbulb'
-      );
+      const feedback = new HelpLinkTreeItem({
+        title: 'Suggest a Feature',
+        url: LINKS.feedback,
+        linkId: 'feedback',
+        iconName: 'lightbulb',
+      });
 
-      const reportBug = new HelpLinkTreeItem(
-        'Report a Bug',
-        LINKS.reportBug,
-        'reportABug',
-        'report'
-      );
+      const reportBug = new HelpLinkTreeItem({
+        title: 'Report a Bug',
+        url: LINKS.reportBug,
+        linkId: 'reportABug',
+        iconName: 'report',
+      });
 
       const telemetryUserIdentity =
         this._telemetryService?.getTelemetryUserIdentity();
 
-      const atlas = new HelpLinkTreeItem(
-        'Create Free Atlas Cluster',
-        LINKS.createAtlasCluster(
+      const atlas = new HelpLinkTreeItem({
+        title: 'Create Free Atlas Cluster',
+        url: LINKS.createAtlasCluster(
           telemetryUserIdentity?.userId ??
             telemetryUserIdentity?.anonymousId ??
             ''
         ),
-        'freeClusterCTA',
-        'atlas',
-        true
-      );
+        linkId: 'freeClusterCTA',
+        iconName: 'atlas',
+        useRedirect: true,
+      });
 
       return Promise.resolve([
         whatsNew,

--- a/src/explorer/indexListTreeItem.ts
+++ b/src/explorer/indexListTreeItem.ts
@@ -36,14 +36,21 @@ export default class IndexListTreeItem
 
   private _childrenCache: IndexTreeItem[] = [];
 
-  constructor(
-    collectionName: string,
-    databaseName: string,
-    dataService: DataService,
-    isExpanded: boolean,
-    cacheIsUpToDate: boolean,
-    childrenCache: IndexTreeItem[] // Existing cache.
-  ) {
+  constructor({
+    collectionName,
+    databaseName,
+    dataService,
+    isExpanded,
+    cacheIsUpToDate,
+    childrenCache,
+  }: {
+    collectionName: string;
+    databaseName: string;
+    dataService: DataService;
+    isExpanded: boolean;
+    cacheIsUpToDate: boolean;
+    childrenCache: IndexTreeItem[]; // Existing cache.
+  }) {
     super(
       ITEM_LABEL,
       isExpanded
@@ -79,11 +86,11 @@ export default class IndexListTreeItem
       // We manually rebuild each node to ensure we update the expanded state.
       pastChildrenCache.forEach((cachedItem: IndexTreeItem) => {
         this._childrenCache.push(
-          new IndexTreeItem(
-            cachedItem.index,
-            cachedItem.namespace,
-            cachedItem.isExpanded
-          )
+          new IndexTreeItem({
+            index: cachedItem.index,
+            namespace: cachedItem.namespace,
+            isExpanded: cachedItem.isExpanded,
+          })
         );
       });
 
@@ -110,11 +117,11 @@ export default class IndexListTreeItem
     if (indexes) {
       this._childrenCache = sortTreeItemsByLabel(
         indexes.map((index: IndexModel) => {
-          return new IndexTreeItem(
+          return new IndexTreeItem({
             index,
-            this._namespace,
-            false /* Not expanded. */
-          );
+            namespace: this._namespace,
+            isExpanded: false,
+          });
         })
       ) as IndexTreeItem[];
     } else {

--- a/src/explorer/indexTreeItem.ts
+++ b/src/explorer/indexTreeItem.ts
@@ -73,7 +73,13 @@ export class IndexFieldTreeItem
   indexKey: string;
   indexKeyType: IndexKeyType;
 
-  constructor(indexKey: string, indexKeyType: IndexKeyType) {
+  constructor({
+    indexKey,
+    indexKeyType,
+  }: {
+    indexKey: string;
+    indexKeyType: IndexKeyType;
+  }) {
     super(indexKey, vscode.TreeItemCollapsibleState.None);
 
     this.indexKey = indexKey;
@@ -110,7 +116,15 @@ export default class IndexTreeItem
   isExpanded: boolean;
   cacheIsUpToDate = true;
 
-  constructor(index: IndexModel, namespace: string, isExpanded: boolean) {
+  constructor({
+    index,
+    namespace,
+    isExpanded,
+  }: {
+    index: IndexModel;
+    namespace: string;
+    isExpanded: boolean;
+  }) {
     super(
       index.name,
       isExpanded
@@ -140,7 +154,11 @@ export default class IndexTreeItem
 
     return Promise.resolve(
       Object.keys(this.index.key).map(
-        (indexKey) => new IndexFieldTreeItem(indexKey, this.index.key[indexKey])
+        (indexKey) =>
+          new IndexFieldTreeItem({
+            indexKey,
+            indexKeyType: this.index.key[indexKey],
+          })
       )
     );
   }

--- a/src/explorer/playgroundsTree.ts
+++ b/src/explorer/playgroundsTree.ts
@@ -114,7 +114,10 @@ export default class PlaygroundsTree
     this._playgroundsTreeItems = Object.fromEntries(
       playgrounds.map((playground) => [
         playground.path,
-        new PlaygroundsTreeItem(playground.name, playground.path),
+        new PlaygroundsTreeItem({
+          fileName: playground.name,
+          filePath: playground.path,
+        }),
       ])
     );
 
@@ -138,7 +141,10 @@ export default class PlaygroundsTree
 
           if (Object.keys(playgrounds).length > 0) {
             this._playgroundsTreeHeaders.push(
-              new PlaygroundsTreeHeader(folder.uri, playgrounds)
+              new PlaygroundsTreeHeader({
+                fileUri: folder.uri,
+                playgroundsTreeItems: playgrounds,
+              })
             );
           }
         }

--- a/src/explorer/playgroundsTreeHeader.ts
+++ b/src/explorer/playgroundsTreeHeader.ts
@@ -14,12 +14,15 @@ export default class PlaygroundsTreeHeader
   doesNotRequireTreeUpdate = true;
   cacheIsUpToDate = true;
 
-  constructor(
-    fileUri: vscode.Uri,
+  constructor({
+    fileUri,
+    playgroundsTreeItems,
+  }: {
+    fileUri: vscode.Uri;
     playgroundsTreeItems: {
       [key: string]: PlaygroundsTreeItem;
-    }
-  ) {
+    };
+  }) {
     super(fileUri.path, vscode.TreeItemCollapsibleState.Expanded);
     this._playgroundsTreeItems = playgroundsTreeItems;
 

--- a/src/explorer/playgroundsTreeItem.ts
+++ b/src/explorer/playgroundsTreeItem.ts
@@ -22,7 +22,7 @@ export default class PlaygroundsTreeItem
 
   contextValue = PLAYGROUND_ITEM;
 
-  constructor(fileName: string, filePath: string) {
+  constructor({ fileName, filePath }: { fileName: string; filePath: string }) {
     super(fileName);
     this.filePath = filePath;
 

--- a/src/explorer/schemaTreeItem.ts
+++ b/src/explorer/schemaTreeItem.ts
@@ -61,16 +61,25 @@ export default class SchemaTreeItem
 
   iconPath: { light: string; dark: string };
 
-  constructor(
-    collectionName: string,
-    databaseName: string,
-    dataService: DataService,
-    isExpanded: boolean,
-    hasClickedShowMoreFields: boolean,
-    hasMoreFieldsToShow: boolean,
-    cacheIsUpToDate: boolean,
-    childrenCache: { [fieldName: string]: FieldTreeItem }
-  ) {
+  constructor({
+    collectionName,
+    databaseName,
+    dataService,
+    isExpanded,
+    hasClickedShowMoreFields,
+    hasMoreFieldsToShow,
+    cacheIsUpToDate,
+    childrenCache,
+  }: {
+    collectionName: string;
+    databaseName: string;
+    dataService: DataService;
+    isExpanded: boolean;
+    hasClickedShowMoreFields: boolean;
+    hasMoreFieldsToShow: boolean;
+    cacheIsUpToDate: boolean;
+    childrenCache: { [fieldName: string]: FieldTreeItem };
+  }) {
     super(
       ITEM_LABEL,
       isExpanded
@@ -139,17 +148,17 @@ export default class SchemaTreeItem
     for (let i = 0; i < fieldsToShow; i++) {
       if (currentCache[schema.fields[i].name]) {
         // Use the past cached field item.
-        newFieldTreeItems[schema.fields[i].name] = new FieldTreeItem(
-          schema.fields[i],
-          currentCache[schema.fields[i].name].isExpanded,
-          currentCache[schema.fields[i].name].getChildrenCache()
-        );
+        newFieldTreeItems[schema.fields[i].name] = new FieldTreeItem({
+          field: schema.fields[i],
+          isExpanded: currentCache[schema.fields[i].name].isExpanded,
+          existingCache: currentCache[schema.fields[i].name].getChildrenCache(),
+        });
       } else {
-        newFieldTreeItems[schema.fields[i].name] = new FieldTreeItem(
-          schema.fields[i],
-          false, // Not expanded.
-          {} // No past cache.
-        );
+        newFieldTreeItems[schema.fields[i].name] = new FieldTreeItem({
+          field: schema.fields[i],
+          isExpanded: false, // Not expanded.
+          existingCache: {}, // No past cache.
+        });
       }
     }
 
@@ -169,11 +178,11 @@ export default class SchemaTreeItem
 
       // We manually rebuild each node to ensure we update the expanded state.
       Object.keys(pastChildrenCache).forEach((fieldName) => {
-        this.childrenCache[fieldName] = new FieldTreeItem(
-          pastChildrenCache[fieldName].field,
-          pastChildrenCache[fieldName].isExpanded,
-          pastChildrenCache[fieldName].getChildrenCache()
-        );
+        this.childrenCache[fieldName] = new FieldTreeItem({
+          field: pastChildrenCache[fieldName].field,
+          isExpanded: pastChildrenCache[fieldName].isExpanded,
+          existingCache: pastChildrenCache[fieldName].getChildrenCache(),
+        });
       });
 
       if (!this.hasClickedShowMoreFields && this.hasMoreFieldsToShow) {

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -76,11 +76,11 @@ export default class MDBExtensionController implements vscode.Disposable {
       context,
       options.shouldTrackTelemetry
     );
-    this._connectionController = new ConnectionController(
-      this._statusView,
-      this._storageController,
-      this._telemetryService
-    );
+    this._connectionController = new ConnectionController({
+      statusView: this._statusView,
+      storageController: this._storageController,
+      telemetryService: this._telemetryService,
+    });
     this._languageServerController = new LanguageServerController(context);
     this._explorerController = new ExplorerController(
       this._connectionController
@@ -102,35 +102,37 @@ export default class MDBExtensionController implements vscode.Disposable {
       new PlaygroundSelectedCodeActionProvider();
     this._playgroundDiagnosticsCodeActionProvider =
       new PlaygroundDiagnosticsCodeActionProvider();
-    this._playgroundController = new PlaygroundController(
-      this._connectionController,
-      this._languageServerController,
-      this._telemetryService,
-      this._statusView,
-      this._playgroundResultViewProvider,
-      this._activeConnectionCodeLensProvider,
-      this._exportToLanguageCodeLensProvider,
-      this._playgroundSelectedCodeActionProvider,
-      this._explorerController
-    );
-    this._editorsController = new EditorsController(
+    this._playgroundController = new PlaygroundController({
+      connectionController: this._connectionController,
+      languageServerController: this._languageServerController,
+      telemetryService: this._telemetryService,
+      statusView: this._statusView,
+      playgroundResultViewProvider: this._playgroundResultViewProvider,
+      activeConnectionCodeLensProvider: this._activeConnectionCodeLensProvider,
+      exportToLanguageCodeLensProvider: this._exportToLanguageCodeLensProvider,
+      playgroundSelectedCodeActionProvider:
+        this._playgroundSelectedCodeActionProvider,
+    });
+    this._editorsController = new EditorsController({
       context,
-      this._connectionController,
-      this._playgroundController,
-      this._statusView,
-      this._telemetryService,
-      this._playgroundResultViewProvider,
-      this._activeConnectionCodeLensProvider,
-      this._exportToLanguageCodeLensProvider,
-      this._playgroundSelectedCodeActionProvider,
-      this._playgroundDiagnosticsCodeActionProvider,
-      this._editDocumentCodeLensProvider
-    );
-    this._webviewController = new WebviewController(
-      this._connectionController,
-      this._storageController,
-      this._telemetryService
-    );
+      connectionController: this._connectionController,
+      playgroundController: this._playgroundController,
+      statusView: this._statusView,
+      telemetryService: this._telemetryService,
+      playgroundResultViewProvider: this._playgroundResultViewProvider,
+      activeConnectionCodeLensProvider: this._activeConnectionCodeLensProvider,
+      exportToLanguageCodeLensProvider: this._exportToLanguageCodeLensProvider,
+      playgroundSelectedCodeActionProvider:
+        this._playgroundSelectedCodeActionProvider,
+      playgroundDiagnosticsCodeActionProvider:
+        this._playgroundDiagnosticsCodeActionProvider,
+      editDocumentCodeLensProvider: this._editDocumentCodeLensProvider,
+    });
+    this._webviewController = new WebviewController({
+      connectionController: this._connectionController,
+      storageController: this._storageController,
+      telemetryService: this._telemetryService,
+    });
     this._editorsController.registerProviders();
   }
 

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -46,11 +46,11 @@ suite('Connection Controller Test Suite', function () {
     testStorageController,
     extensionContextStub
   );
-  const testConnectionController = new ConnectionController(
-    new StatusView(extensionContextStub),
-    testStorageController,
-    testTelemetryService
-  );
+  const testConnectionController = new ConnectionController({
+    statusView: new StatusView(extensionContextStub),
+    storageController: testStorageController,
+    telemetryService: testTelemetryService,
+  });
   let showErrorMessageStub: SinonStub;
   const sandbox = sinon.createSandbox();
 

--- a/src/test/suite/editors/activeConnectionCodeLensProvider.test.ts
+++ b/src/test/suite/editors/activeConnectionCodeLensProvider.test.ts
@@ -23,10 +23,9 @@ suite('Active Connection CodeLens Provider Test Suite', () => {
   const testStatusView = new StatusView(extensionContextStub);
   let testConnectionController: ConnectionController;
   let testCodeLensProvider: ActiveConnectionCodeLensProvider;
-  let sandbox: sinon.SinonSandbox;
+  const sandbox = sinon.createSandbox();
 
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
     testConnectionController = new ConnectionController({
       statusView: testStatusView,
       storageController: testStorageController,
@@ -124,10 +123,6 @@ suite('Active Connection CodeLens Provider Test Suite', () => {
         sandbox.replace(vscode.window, 'showQuickPick', fakeShowQuickPick);
         const fakeIsPlayground = sandbox.fake.returns(false);
         sandbox.replace(testCodeLensProvider, 'isPlayground', fakeIsPlayground);
-      });
-
-      afterEach(() => {
-        sandbox.restore();
       });
 
       test('show not show the active connection code lenses', () => {

--- a/src/test/suite/editors/activeConnectionCodeLensProvider.test.ts
+++ b/src/test/suite/editors/activeConnectionCodeLensProvider.test.ts
@@ -21,32 +21,36 @@ suite('Active Connection CodeLens Provider Test Suite', () => {
     extensionContextStub
   );
   const testStatusView = new StatusView(extensionContextStub);
+  let testConnectionController: ConnectionController;
+  let testCodeLensProvider: ActiveConnectionCodeLensProvider;
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    testConnectionController = new ConnectionController({
+      statusView: testStatusView,
+      storageController: testStorageController,
+      telemetryService: testTelemetryService,
+    });
+    testCodeLensProvider = new ActiveConnectionCodeLensProvider(
+      testConnectionController
+    );
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
 
   suite('the MongoDB playground in JS', () => {
-    const sandbox = sinon.createSandbox();
-
     suite('user is not connected', () => {
-      const testConnectionController = new ConnectionController(
-        testStatusView,
-        testStorageController,
-        testTelemetryService
-      );
-      const testCodeLensProvider = new ActiveConnectionCodeLensProvider(
-        testConnectionController
-      );
-      const fakeShowQuickPick = sandbox.fake();
-
       beforeEach(() => {
         testCodeLensProvider.setActiveTextEditor(
           vscode.window.activeTextEditor
         );
+        const fakeShowQuickPick = sandbox.fake();
         sandbox.replace(vscode.window, 'showQuickPick', fakeShowQuickPick);
         const fakeIsPlayground = sandbox.fake.returns(true);
         sandbox.replace(testCodeLensProvider, 'isPlayground', fakeIsPlayground);
-      });
-
-      afterEach(() => {
-        sandbox.restore();
       });
 
       test('show disconnected message in code lenses', () => {
@@ -63,15 +67,6 @@ suite('Active Connection CodeLens Provider Test Suite', () => {
     });
 
     suite('user is connected', () => {
-      const testConnectionController = new ConnectionController(
-        testStatusView,
-        testStorageController,
-        testTelemetryService
-      );
-      const testCodeLensProvider = new ActiveConnectionCodeLensProvider(
-        testConnectionController
-      );
-
       beforeEach(() => {
         const findStub = sandbox.stub();
         findStub.resolves([
@@ -123,20 +118,9 @@ suite('Active Connection CodeLens Provider Test Suite', () => {
   });
 
   suite('the regular JS file', () => {
-    const sandbox = sinon.createSandbox();
-
     suite('user is not connected', () => {
-      const testConnectionController = new ConnectionController(
-        testStatusView,
-        testStorageController,
-        testTelemetryService
-      );
-      const testCodeLensProvider = new ActiveConnectionCodeLensProvider(
-        testConnectionController
-      );
-      const fakeShowQuickPick = sandbox.fake();
-
       beforeEach(() => {
+        const fakeShowQuickPick = sandbox.fake();
         sandbox.replace(vscode.window, 'showQuickPick', fakeShowQuickPick);
         const fakeIsPlayground = sandbox.fake.returns(false);
         sandbox.replace(testCodeLensProvider, 'isPlayground', fakeIsPlayground);
@@ -155,15 +139,6 @@ suite('Active Connection CodeLens Provider Test Suite', () => {
     });
 
     suite('user is connected', () => {
-      const testConnectionController = new ConnectionController(
-        testStatusView,
-        testStorageController,
-        testTelemetryService
-      );
-      const testCodeLensProvider = new ActiveConnectionCodeLensProvider(
-        testConnectionController
-      );
-
       beforeEach(() => {
         const findStub = sandbox.stub();
         findStub.resolves([

--- a/src/test/suite/editors/collectionDocumentsProvider.test.ts
+++ b/src/test/suite/editors/collectionDocumentsProvider.test.ts
@@ -37,9 +37,34 @@ suite('Collection Documents Provider Test Suite', () => {
     extensionContextStub
   );
   const sandbox = sinon.createSandbox();
+  let testConnectionController: ConnectionController;
+  let testStatusView: StatusView;
+
+  let testQueryStore: CollectionDocumentsOperationsStore;
+  let testCodeLensProvider: EditDocumentCodeLensProvider;
+  let testCollectionViewProvider: CollectionDocumentsProvider;
 
   beforeEach(() => {
     sandbox.stub(vscode.window, 'showInformationMessage');
+    testStatusView = new StatusView(extensionContextStub);
+
+    testConnectionController = new ConnectionController({
+      statusView: testStatusView,
+      storageController: testStorageController,
+      telemetryService: testTelemetryService,
+    });
+
+    testQueryStore = new CollectionDocumentsOperationsStore();
+    testCodeLensProvider = new EditDocumentCodeLensProvider(
+      testConnectionController
+    );
+    testCollectionViewProvider = new CollectionDocumentsProvider({
+      context: extensionContextStub,
+      connectionController: testConnectionController,
+      operationsStore: testQueryStore,
+      statusView: testStatusView,
+      editDocumentCodeLensProvider: testCodeLensProvider,
+    });
   });
 
   afterEach(() => {
@@ -53,24 +78,7 @@ suite('Collection Documents Provider Test Suite', () => {
       find: findStub,
     } as Pick<DataService, 'find'> as unknown as DataService;
 
-    const testConnectionController = new ConnectionController(
-      new StatusView(extensionContextStub),
-      testStorageController,
-      testTelemetryService
-    );
     testConnectionController.setActiveDataService(testDataService);
-
-    const testQueryStore = new CollectionDocumentsOperationsStore();
-    const testCodeLensProvider = new EditDocumentCodeLensProvider(
-      testConnectionController
-    );
-    const testCollectionViewProvider = new CollectionDocumentsProvider(
-      extensionContextStub,
-      testConnectionController,
-      testQueryStore,
-      new StatusView(extensionContextStub),
-      testCodeLensProvider
-    );
 
     const operationId = testQueryStore.createNewOperation();
     const uri = vscode.Uri.parse(
@@ -111,24 +119,7 @@ suite('Collection Documents Provider Test Suite', () => {
       find: findStub,
     } as Pick<DataService, 'find'> as unknown as DataService;
 
-    const testConnectionController = new ConnectionController(
-      new StatusView(extensionContextStub),
-      testStorageController,
-      testTelemetryService
-    );
     testConnectionController.setActiveDataService(testDataService);
-
-    const testQueryStore = new CollectionDocumentsOperationsStore();
-    const testCodeLensProvider = new EditDocumentCodeLensProvider(
-      testConnectionController
-    );
-    const testCollectionViewProvider = new CollectionDocumentsProvider(
-      extensionContextStub,
-      testConnectionController,
-      testQueryStore,
-      new StatusView(extensionContextStub),
-      testCodeLensProvider
-    );
 
     const operationId = testQueryStore.createNewOperation();
     const uri = vscode.Uri.parse(
@@ -153,24 +144,7 @@ suite('Collection Documents Provider Test Suite', () => {
     const testDataService = {
       find: findStub,
     } as Pick<DataService, 'find'> as unknown as DataService;
-    const testConnectionController = new ConnectionController(
-      new StatusView(extensionContextStub),
-      testStorageController,
-      testTelemetryService
-    );
     testConnectionController.setActiveDataService(testDataService);
-
-    const testQueryStore = new CollectionDocumentsOperationsStore();
-    const testCodeLensProvider = new EditDocumentCodeLensProvider(
-      testConnectionController
-    );
-    const testCollectionViewProvider = new CollectionDocumentsProvider(
-      extensionContextStub,
-      testConnectionController,
-      testQueryStore,
-      new StatusView(extensionContextStub),
-      testCodeLensProvider
-    );
 
     const operationId = testQueryStore.createNewOperation();
     testQueryStore.operations[operationId].currentLimit = 5;
@@ -203,26 +177,9 @@ suite('Collection Documents Provider Test Suite', () => {
       DataService,
       'find'
     > as unknown as DataService;
-    const testConnectionController = new ConnectionController(
-      new StatusView(extensionContextStub),
-      testStorageController,
-      testTelemetryService
-    );
     testConnectionController.setActiveDataService(mockActiveDataService);
 
-    const testStatusView = new StatusView(extensionContextStub);
-
-    const testQueryStore = new CollectionDocumentsOperationsStore();
-    const testCodeLensProvider = new EditDocumentCodeLensProvider(
-      testConnectionController
-    );
-    const testCollectionViewProvider = new CollectionDocumentsProvider(
-      extensionContextStub,
-      testConnectionController,
-      testQueryStore,
-      testStatusView,
-      testCodeLensProvider
-    );
+    testCollectionViewProvider._statusView = testStatusView;
 
     const operationId = testQueryStore.createNewOperation();
     const uri = vscode.Uri.parse(
@@ -245,23 +202,6 @@ suite('Collection Documents Provider Test Suite', () => {
   });
 
   test('provideTextDocumentContent sets different code lenses for different namespaces from the same connection', async () => {
-    const testConnectionController = new ConnectionController(
-      new StatusView(extensionContextStub),
-      testStorageController,
-      testTelemetryService
-    );
-    const testQueryStore = new CollectionDocumentsOperationsStore();
-    const testCodeLensProvider = new EditDocumentCodeLensProvider(
-      testConnectionController
-    );
-    const testCollectionViewProvider = new CollectionDocumentsProvider(
-      extensionContextStub,
-      testConnectionController,
-      testQueryStore,
-      new StatusView(extensionContextStub),
-      testCodeLensProvider
-    );
-
     testCollectionViewProvider._operationsStore =
       new CollectionDocumentsOperationsStore();
 
@@ -435,23 +375,6 @@ suite('Collection Documents Provider Test Suite', () => {
   });
 
   test('provideTextDocumentContent sets different code lenses for identical namespaces from the different connections', async () => {
-    const testConnectionController = new ConnectionController(
-      new StatusView(extensionContextStub),
-      testStorageController,
-      testTelemetryService
-    );
-    const testQueryStore = new CollectionDocumentsOperationsStore();
-    const testCodeLensProvider = new EditDocumentCodeLensProvider(
-      testConnectionController
-    );
-    const testCollectionViewProvider = new CollectionDocumentsProvider(
-      extensionContextStub,
-      testConnectionController,
-      testQueryStore,
-      new StatusView(extensionContextStub),
-      testCodeLensProvider
-    );
-
     testCollectionViewProvider._operationsStore =
       new CollectionDocumentsOperationsStore();
 

--- a/src/test/suite/editors/editDocumentCodeLensProvider.test.ts
+++ b/src/test/suite/editors/editDocumentCodeLensProvider.test.ts
@@ -22,11 +22,11 @@ suite('Edit Document Code Lens Provider Test Suite', () => {
     extensionContextStub
   );
   const testStatusView = new StatusView(extensionContextStub);
-  const testConnectionController = new ConnectionController(
-    testStatusView,
-    testStorageController,
-    testTelemetryService
-  );
+  const testConnectionController = new ConnectionController({
+    statusView: testStatusView,
+    storageController: testStorageController,
+    telemetryService: testTelemetryService,
+  });
   const sandbox = sinon.createSandbox();
 
   afterEach(() => {

--- a/src/test/suite/editors/mongoDBDocumentService.test.ts
+++ b/src/test/suite/editors/mongoDBDocumentService.test.ts
@@ -24,17 +24,17 @@ suite('MongoDB Document Service Test Suite', () => {
     testStorageController,
     extensionContextStub
   );
-  const testConnectionController = new ConnectionController(
-    testStatusView,
-    testStorageController,
-    testTelemetryService
-  );
-  const testMongoDBDocumentService = new MongoDBDocumentService(
-    extensionContextStub,
-    testConnectionController,
-    testStatusView,
-    testTelemetryService
-  );
+  const testConnectionController = new ConnectionController({
+    statusView: testStatusView,
+    storageController: testStorageController,
+    telemetryService: testTelemetryService,
+  });
+  const testMongoDBDocumentService = new MongoDBDocumentService({
+    context: extensionContextStub,
+    connectionController: testConnectionController,
+    statusView: testStatusView,
+    telemetryService: testTelemetryService,
+  });
 
   const sandbox = sinon.createSandbox();
 

--- a/src/test/suite/editors/playgroundResultProvider.test.ts
+++ b/src/test/suite/editors/playgroundResultProvider.test.ts
@@ -27,11 +27,11 @@ suite('Playground Result Provider Test Suite', () => {
     extensionContextStub
   );
   const testStatusView = new StatusView(extensionContextStub);
-  const testConnectionController = new ConnectionController(
-    testStatusView,
-    testStorageController,
-    testTelemetryService
-  );
+  const testConnectionController = new ConnectionController({
+    statusView: testStatusView,
+    storageController: testStorageController,
+    telemetryService: testTelemetryService,
+  });
   const testEditDocumentCodeLensProvider = new EditDocumentCodeLensProvider(
     testConnectionController
   );
@@ -352,13 +352,13 @@ suite('Playground Result Provider Test Suite', () => {
     expect(firstCodeLensesInfo[1].line).to.be.equal(9);
 
     const testQueryStore = new CollectionDocumentsOperationsStore();
-    const testCollectionViewProvider = new CollectionDocumentsProvider(
-      extensionContextStub,
-      testConnectionController,
-      testQueryStore,
-      testStatusView,
-      testEditDocumentCodeLensProvider
-    );
+    const testCollectionViewProvider = new CollectionDocumentsProvider({
+      context: extensionContextStub,
+      connectionController: testConnectionController,
+      operationsStore: testQueryStore,
+      statusView: testStatusView,
+      editDocumentCodeLensProvider: testEditDocumentCodeLensProvider,
+    });
 
     testCollectionViewProvider._operationsStore =
       new CollectionDocumentsOperationsStore();

--- a/src/test/suite/editors/playgroundSelectedCodeActionProvider.test.ts
+++ b/src/test/suite/editors/playgroundSelectedCodeActionProvider.test.ts
@@ -6,7 +6,6 @@ import sinon from 'sinon';
 import ActiveConnectionCodeLensProvider from '../../../editors/activeConnectionCodeLensProvider';
 import ExportToLanguageCodeLensProvider from '../../../editors/exportToLanguageCodeLensProvider';
 import PlaygroundSelectedCodeActionProvider from '../../../editors/playgroundSelectedCodeActionProvider';
-import { ExplorerController } from '../../../explorer';
 import { LanguageServerController } from '../../../language';
 import { mdbTestExtension } from '../stubbableMdbExtension';
 import { PlaygroundController } from '../../../editors';
@@ -49,22 +48,24 @@ suite('Playground Selected CodeAction Provider Test Suite', function () {
         );
       const testExportToLanguageCodeLensProvider =
         new ExportToLanguageCodeLensProvider();
-      const testExplorerController = new ExplorerController(
-        mdbTestExtension.testExtensionController._connectionController
-      );
 
       mdbTestExtension.testExtensionController._playgroundController =
-        new PlaygroundController(
-          mdbTestExtension.testExtensionController._connectionController,
-          mdbTestExtension.testExtensionController._languageServerController,
-          mdbTestExtension.testExtensionController._telemetryService,
-          mdbTestExtension.testExtensionController._statusView,
-          mdbTestExtension.testExtensionController._playgroundResultViewProvider,
+        new PlaygroundController({
+          connectionController:
+            mdbTestExtension.testExtensionController._connectionController,
+          languageServerController:
+            mdbTestExtension.testExtensionController._languageServerController,
+          telemetryService:
+            mdbTestExtension.testExtensionController._telemetryService,
+          statusView: mdbTestExtension.testExtensionController._statusView,
+          playgroundResultViewProvider:
+            mdbTestExtension.testExtensionController
+              ._playgroundResultViewProvider,
           activeConnectionCodeLensProvider,
-          testExportToLanguageCodeLensProvider,
-          testCodeActionProvider,
-          testExplorerController
-        );
+          exportToLanguageCodeLensProvider:
+            testExportToLanguageCodeLensProvider,
+          playgroundSelectedCodeActionProvider: testCodeActionProvider,
+        });
 
       const fakeOpenPlaygroundResult = sandbox.fake();
       sandbox.replace(

--- a/src/test/suite/explorer/collectionTreeItem.test.ts
+++ b/src/test/suite/explorer/collectionTreeItem.test.ts
@@ -1,6 +1,8 @@
 import assert from 'assert';
+import type { DataService } from 'mongodb-data-service';
 
 import CollectionTreeItem from '../../../explorer/collectionTreeItem';
+import type { CollectionDetailsType } from '../../../explorer/collectionTreeItem';
 import { CollectionTypes } from '../../../explorer/documentListTreeItem';
 import { ext } from '../../../extensionConstants';
 import { ExtensionContextStub, DataServiceStub } from '../stubs';
@@ -8,22 +10,29 @@ import { ExtensionContextStub, DataServiceStub } from '../stubs';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { contributes } = require('../../../../package.json');
 
+function getTestCollectionTreeItem(
+  options?: Partial<ConstructorParameters<typeof CollectionTreeItem>[0]>
+) {
+  return new CollectionTreeItem({
+    collection: {
+      name: 'testColName',
+      type: CollectionTypes.collection,
+    } as unknown as CollectionDetailsType,
+    databaseName: 'testDbName',
+    dataService: {} as DataService,
+    isExpanded: false,
+    cacheIsUpToDate: false,
+    cachedDocumentCount: null,
+    ...options,
+  });
+}
+
 suite('CollectionTreeItem Test Suite', () => {
   ext.context = new ExtensionContextStub();
 
   test('its context value should be in the package json', () => {
     let registeredCommandInPackageJson = false;
-    const testCollectionTreeItem = new CollectionTreeItem(
-      {
-        name: 'mock_collection_name_1',
-        type: CollectionTypes.collection,
-      },
-      'mock_db_name',
-      'imaginary data service',
-      false,
-      false,
-      null
-    );
+    const testCollectionTreeItem = getTestCollectionTreeItem();
 
     contributes.menus['view/item/context'].forEach((contextItem) => {
       if (contextItem.when.includes(testCollectionTreeItem.contextValue)) {
@@ -31,167 +40,103 @@ suite('CollectionTreeItem Test Suite', () => {
       }
     });
 
-    assert(
-      registeredCommandInPackageJson,
-      'Expected collection tree item to be registered with a command in package json'
-    );
+    assert.strictEqual(registeredCommandInPackageJson, true);
   });
 
   test('when expanded shows a documents folder and schema folder', async () => {
-    const testCollectionTreeItem = new CollectionTreeItem(
-      {
-        name: 'mock_collection_name_1',
-        type: CollectionTypes.collection,
-      },
-      'mock_db_name',
-      new DataServiceStub(),
-      false,
-      false,
-      null
-    );
+    const testCollectionTreeItem = getTestCollectionTreeItem({
+      dataService: new DataServiceStub() as unknown as DataService,
+    });
 
     await testCollectionTreeItem.onDidExpand();
 
     const collectionChildren = await testCollectionTreeItem.getChildren();
 
-    assert(
-      collectionChildren.length === 3,
-      `Expected 3 children to be returned, found ${collectionChildren.length}`
-    );
-    assert(
-      collectionChildren[0].label === 'Documents',
-      `Expected first child tree item to be named Documents found ${collectionChildren[0].label}`
-    );
-    assert(
-      collectionChildren[1].label === 'Schema',
-      `Expected the second child tree item to be named Schema found ${collectionChildren[1].label}`
-    );
-    assert(
-      collectionChildren[2].label === 'Indexes',
-      `Expected the second child tree item to be named Indexes found ${collectionChildren[2].label}`
-    );
+    assert.strictEqual(collectionChildren.length, 3);
+    assert.strictEqual(collectionChildren[0].label, 'Documents');
+    assert.strictEqual(collectionChildren[1].label, 'Schema');
+    assert.strictEqual(collectionChildren[2].label, 'Indexes');
   });
 
   test('when expanded it shows the document count in the description of the document list', async () => {
-    const testCollectionTreeItem = new CollectionTreeItem(
-      {
-        name: 'mock_collection_name_1',
-        type: CollectionTypes.collection,
-      },
-      'mock_db_name',
-      { estimatedCount: () => Promise.resolve(5000) },
-      false,
-      false,
-      null
-    );
+    const testCollectionTreeItem = getTestCollectionTreeItem({
+      dataService: {
+        estimatedCount: () => Promise.resolve(5000),
+      } as unknown as DataService,
+    });
 
     await testCollectionTreeItem.onDidExpand();
 
     const collectionChildren = await testCollectionTreeItem.getChildren();
 
-    assert(
-      collectionChildren[0].label === 'Documents',
-      `Expected document list label to be 'Documents' got '${collectionChildren[0].label}'`
-    );
-    assert(
-      collectionChildren[0].description === '5K',
-      `Expected document list description to be '5K' got '${collectionChildren[0].description}'`
-    );
-    assert(
-      collectionChildren[0].tooltip === 'Collection Documents - 5000',
-      `Expected document list tooltip to be 'Collection Documents - 5000' got '${collectionChildren[0].tooltip}'`
+    assert.strictEqual(collectionChildren[0].label, 'Documents');
+    assert.strictEqual(collectionChildren[0].description, '5K');
+    assert.strictEqual(
+      collectionChildren[0].tooltip,
+      'Collection Documents - 5000'
     );
   });
 
   test('a view should show a different icon from a collection', () => {
-    const testCollectionViewTreeItem = new CollectionTreeItem(
-      {
+    const testCollectionViewTreeItem = getTestCollectionTreeItem({
+      collection: {
         name: 'mock_collection_name_1',
         type: CollectionTypes.view,
-      },
-      'mock_db_name',
-      'imaginary data service',
-      false,
-      false,
-      null
-    );
+      } as unknown as CollectionDetailsType,
+    });
 
     const viewIconPath = testCollectionViewTreeItem.iconPath;
-    assert(
-      viewIconPath.light.includes('view-folder.svg'),
-      'Expected icon path to point to an svg by the name "view-folder" with a light mode'
-    );
-    assert(
-      viewIconPath.dark.includes('view-folder.svg'),
-      'Expected icon path to point to an svg by the name "view-folder" a dark mode'
-    );
+    assert.strictEqual(viewIconPath.light.includes('view-folder.svg'), true);
+    assert.strictEqual(viewIconPath.dark.includes('view-folder.svg'), true);
 
-    const testCollectionCollectionTreeItem = new CollectionTreeItem(
-      {
+    const testCollectionCollectionTreeItem = getTestCollectionTreeItem({
+      collection: {
         name: 'mock_collection_name_1',
         type: CollectionTypes.collection,
-      },
-      'mock_db_name',
-      'imaginary data service',
-      false,
-      false,
-      null
-    );
-
+      } as unknown as CollectionDetailsType,
+    });
     const collectionIconPath = testCollectionCollectionTreeItem.iconPath;
-    assert(
+    assert.strictEqual(
       collectionIconPath.light.includes('collection-folder-closed.svg'),
-      'Expected icon path to point to an svg by the name "collection" with a light mode'
+      true
     );
-    assert(
+    assert.strictEqual(
       collectionIconPath.dark.includes('collection-folder-closed.svg'),
-      'Expected icon path to point to an svg by the name "collection" with a light mode'
+      true
     );
   });
 
   test('a time-series collection should show a different icon from a collection', () => {
-    const testCollectionViewTreeItem = new CollectionTreeItem(
-      {
+    const testCollectionTimeSeriesTreeItem = getTestCollectionTreeItem({
+      collection: {
         name: 'mock_collection_name_1',
         type: CollectionTypes.timeseries,
-      },
-      'mock_db_name',
-      'imaginary data service',
-      false,
-      false,
-      null
-    );
-
-    const viewIconPath = testCollectionViewTreeItem.iconPath;
-    assert(
+      } as unknown as CollectionDetailsType,
+    });
+    const viewIconPath = testCollectionTimeSeriesTreeItem.iconPath;
+    assert.strictEqual(
       viewIconPath.light.includes('collection-timeseries.svg'),
-      'Expected icon path to point to an svg by the name "collection-timeseries" with a light mode'
+      true
     );
-    assert(
+    assert.strictEqual(
       viewIconPath.dark.includes('collection-timeseries.svg'),
-      'Expected icon path to point to an svg by the name "collection-timeseries" a dark mode'
+      true
     );
 
-    const testCollectionCollectionTreeItem = new CollectionTreeItem(
-      {
+    const testCollectionCollectionTreeItem = getTestCollectionTreeItem({
+      collection: {
         name: 'mock_collection_name_1',
         type: CollectionTypes.collection,
-      },
-      'mock_db_name',
-      'imaginary data service',
-      false,
-      false,
-      null
-    );
-
+      } as unknown as CollectionDetailsType,
+    });
     const collectionIconPath = testCollectionCollectionTreeItem.iconPath;
-    assert(
+    assert.strictEqual(
       collectionIconPath.light.includes('collection-folder-closed.svg'),
-      'Expected icon path to point to an svg by the name "collection" with a light mode'
+      true
     );
-    assert(
+    assert.strictEqual(
       collectionIconPath.dark.includes('collection-folder-closed.svg'),
-      'Expected icon path to point to an svg by the name "collection" with a light mode'
+      true
     );
   });
 });

--- a/src/test/suite/explorer/connectionTreeItem.test.ts
+++ b/src/test/suite/explorer/connectionTreeItem.test.ts
@@ -14,6 +14,18 @@ import { mdbTestExtension } from '../stubbableMdbExtension';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { contributes } = require('../../../../package.json');
 
+function getTestConnectionTreeItem() {
+  return new ConnectionTreeItem({
+    connectionId: 'test',
+    collapsibleState: vscode.TreeItemCollapsibleState.Expanded,
+    isExpanded: true,
+    connectionController:
+      mdbTestExtension.testExtensionController._connectionController,
+    cacheIsUpToDate: false,
+    childrenCache: {},
+  });
+}
+
 suite('ConnectionTreeItem Test Suite', () => {
   test('its context value should be in the package json', function () {
     let connectedRegisteredCommandInPackageJson = false;
@@ -43,14 +55,7 @@ suite('ConnectionTreeItem Test Suite', () => {
     const sandbox = sinon.createSandbox();
 
     beforeEach(() => {
-      testConnectionTreeItem = new ConnectionTreeItem(
-        '',
-        vscode.TreeItemCollapsibleState.Expanded,
-        true,
-        mdbTestExtension.testExtensionController._connectionController,
-        false,
-        {}
-      );
+      testConnectionTreeItem = getTestConnectionTreeItem();
     });
 
     afterEach(() => {
@@ -101,14 +106,7 @@ suite('ConnectionTreeItem Test Suite', () => {
     const sandbox = sinon.createSandbox();
 
     beforeEach(() => {
-      testConnectionTreeItem = new ConnectionTreeItem(
-        '',
-        vscode.TreeItemCollapsibleState.Expanded,
-        true,
-        mdbTestExtension.testExtensionController._connectionController,
-        false,
-        {}
-      );
+      testConnectionTreeItem = getTestConnectionTreeItem();
     });
 
     afterEach(() => {

--- a/src/test/suite/explorer/documentTreeItem.test.ts
+++ b/src/test/suite/explorer/documentTreeItem.test.ts
@@ -4,27 +4,32 @@ import type { DataService } from 'mongodb-data-service';
 import DocumentTreeItem from '../../../explorer/documentTreeItem';
 import { DataServiceStub } from '../stubs';
 
-const dataServiceStub = new DataServiceStub() as any as DataService;
+const dataServiceStub = new DataServiceStub() as unknown as DataService;
+
+function getTestDocumentTreeItem(
+  options?: Partial<ConstructorParameters<typeof DocumentTreeItem>[0]>
+) {
+  return new DocumentTreeItem({
+    document: {},
+    namespace: 'name.space',
+    documentIndexInTree: 1,
+    dataService: dataServiceStub,
+    resetDocumentListCache: () => Promise.resolve(),
+    ...options,
+  });
+}
 
 suite('DocumentTreeItem Test Suite', () => {
   test('it makes the document _id the label of the document tree item', function () {
     const mockDocument = {
       _id: 'mock_document_id',
     };
-
-    const testCollectionTreeItem = new DocumentTreeItem(
-      mockDocument,
-      'namespace',
-      1,
-      {} as DataService,
-      () => Promise.resolve()
-    );
+    const testCollectionTreeItem = getTestDocumentTreeItem({
+      document: mockDocument,
+    });
 
     const documentTreeItemLabel = testCollectionTreeItem.label;
-    assert(
-      documentTreeItemLabel === '"mock_document_id"',
-      `Expected tree item label to be "mock_document_id", found ${documentTreeItemLabel}.`
-    );
+    assert.strictEqual(documentTreeItemLabel, '"mock_document_id"');
   });
 
   test('when the document has an object _id, it is stringified into the tree item label', function () {
@@ -34,43 +39,25 @@ suite('DocumentTreeItem Test Suite', () => {
         anotherIdField: 'mock_document_id_field_2',
       },
     };
-
+    const testCollectionTreeItem = getTestDocumentTreeItem({
+      document: mockDocument,
+    });
     const expectedLabel = JSON.stringify(mockDocument._id);
 
-    const testCollectionTreeItem = new DocumentTreeItem(
-      mockDocument,
-      'namespace',
-      1,
-      dataServiceStub,
-      () => Promise.resolve()
-    );
-
     const documentTreeItemLabel = testCollectionTreeItem.label;
-    assert(
-      documentTreeItemLabel === expectedLabel,
-      `Expected tree item label to be ${expectedLabel}, found ${documentTreeItemLabel}.`
-    );
+    assert.strictEqual(documentTreeItemLabel, expectedLabel);
   });
 
   test('when the document does not have an _id, its label is the supplied index', function () {
     const mockDocument = {
       noIdField: true,
     };
-
+    const testCollectionTreeItem = getTestDocumentTreeItem({
+      document: mockDocument,
+    });
     const expectedLabel = 'Document 2';
 
-    const testCollectionTreeItem = new DocumentTreeItem(
-      mockDocument,
-      'namespace',
-      1,
-      dataServiceStub,
-      () => Promise.resolve()
-    );
-
     const documentTreeItemLabel = testCollectionTreeItem.label;
-    assert(
-      documentTreeItemLabel === expectedLabel,
-      `Expected tree item label to be ${expectedLabel}, found ${documentTreeItemLabel}.`
-    );
+    assert.strictEqual(documentTreeItemLabel, expectedLabel);
   });
 });

--- a/src/test/suite/explorer/indexListTreeItem.test.ts
+++ b/src/test/suite/explorer/indexListTreeItem.test.ts
@@ -11,6 +11,20 @@ import IndexListTreeItem from '../../../explorer/indexListTreeItem';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { contributes } = require('../../../../package.json');
 
+function getTestIndexListTreeItem(
+  options?: Partial<ConstructorParameters<typeof IndexListTreeItem>[0]>
+) {
+  return new IndexListTreeItem({
+    collectionName: 'zebraWearwolf',
+    databaseName: 'giraffeVampire',
+    dataService: {} as DataService,
+    isExpanded: false,
+    cacheIsUpToDate: false,
+    childrenCache: [],
+    ...options,
+  });
+}
+
 suite('IndexListTreeItem Test Suite', () => {
   let showErrorMessageStub: SinonStub;
   const sandbox = sinon.createSandbox();
@@ -25,18 +39,7 @@ suite('IndexListTreeItem Test Suite', () => {
 
   test('its context value should be in the package json', () => {
     let indexListRegisteredCommandInPackageJson = false;
-    const testIndexListTreeItem = new IndexListTreeItem(
-      'pineapple',
-      'tasty_fruits',
-      {
-        indexes: (): ReturnType<DataService['indexes']> => {
-          return Promise.resolve([]);
-        },
-      } as unknown as DataService,
-      false,
-      false,
-      []
-    );
+    const testIndexListTreeItem = getTestIndexListTreeItem();
 
     contributes.menus['view/item/context'].forEach((contextItem) => {
       if (contextItem.when.includes(testIndexListTreeItem.contextValue)) {
@@ -58,7 +61,7 @@ suite('IndexListTreeItem Test Suite', () => {
           _id: 1,
         },
         name: '_id_',
-        ns: 'tasty_fruits.pineapple',
+        ns: 'giraffeVampire.pineapple',
       },
       {
         v: 1,
@@ -67,25 +70,21 @@ suite('IndexListTreeItem Test Suite', () => {
           gnocchi: -1,
         },
         name: '_id_1_gnocchi_1',
-        ns: 'tasty_fruits.pineapple',
+        ns: 'giraffeVampire.pineapple',
       },
     ];
 
     let namespaceRequested = '';
-    const testIndexListTreeItem = new IndexListTreeItem(
-      'pineapple',
-      'tasty_fruits',
-      {
+    const testIndexListTreeItem = getTestIndexListTreeItem({
+      collectionName: 'pineapple',
+      dataService: {
         indexes: (ns): ReturnType<DataService['indexes']> => {
           namespaceRequested = ns;
 
           return Promise.resolve(fakeFetchIndexes as any[]);
         },
       } as DataService,
-      false,
-      false,
-      []
-    );
+    });
 
     await testIndexListTreeItem.onDidExpand();
 
@@ -97,35 +96,21 @@ suite('IndexListTreeItem Test Suite', () => {
       assert(false, `Expected no error, found: ${formatError(error).message}`);
     }
 
-    assert(namespaceRequested === 'tasty_fruits.pineapple');
-
-    assert(
-      indexTreeItems.length === 2,
-      `Expected 2 indexTreeItems to be returned, found ${indexTreeItems.length}`
-    );
-    assert(
-      indexTreeItems[0].label === '_id_',
-      `Expected first child tree item to be named '_id_' found ${indexTreeItems[0].label}`
-    );
-    assert(
-      indexTreeItems[1].label === '_id_1_gnocchi_1',
-      `Expected the second child tree item to be named '_id_1_gnocchi_1' found ${indexTreeItems[1].label}`
-    );
+    assert.strictEqual(namespaceRequested, 'giraffeVampire.pineapple');
+    assert.strictEqual(indexTreeItems.length, 2);
+    assert.strictEqual(indexTreeItems[0].label, '_id_');
+    assert.strictEqual(indexTreeItems[1].label, '_id_1_gnocchi_1');
   });
 
   test('it shows an indexes icon', () => {
-    const testIndexListTreeItem = new IndexListTreeItem(
-      'pineapple',
-      'tasty_fruits',
-      {
+    const testIndexListTreeItem = getTestIndexListTreeItem({
+      collectionName: 'pineapple',
+      dataService: {
         indexes: (): ReturnType<DataService['indexes']> => {
           return Promise.resolve([] as IndexDefinition[]);
         },
       } as unknown as DataService,
-      false,
-      false,
-      []
-    );
+    });
 
     const indexesIconPath = testIndexListTreeItem.iconPath as {
       light: string;
@@ -139,27 +124,22 @@ suite('IndexListTreeItem Test Suite', () => {
 
   test('when theres an error fetching indexes, the error is thrown in the caller (no timeout)', async () => {
     const expectedMessage = 'Some error message indexes could throw';
-    const testIndexListTreeItem = new IndexListTreeItem(
-      'pineapple',
-      'tasty_fruits',
-      {
+    const testIndexListTreeItem = getTestIndexListTreeItem({
+      dataService: {
         indexes: (): ReturnType<DataService['indexes']> => {
           return Promise.reject(new Error(expectedMessage));
         },
       } as unknown as DataService,
-      false,
-      false,
-      []
-    );
+    });
 
     await testIndexListTreeItem.onDidExpand();
 
     try {
       await testIndexListTreeItem.getChildren();
 
-      assert(
-        showErrorMessageStub.firstCall.args[0] === expectedMessage,
-        `Expected error message "${expectedMessage}" when disconnecting with no active connection, recieved "${showErrorMessageStub.firstCall.args[0]}"`
+      assert.strictEqual(
+        showErrorMessageStub.firstCall.args[0],
+        expectedMessage
       );
     } catch (error) {
       assert(!!error, 'Expected an error disconnect response.');
@@ -174,7 +154,7 @@ suite('IndexListTreeItem Test Suite', () => {
           _id: 1,
         },
         name: '_id_',
-        ns: 'tasty_fruits.pineapple',
+        ns: 'giraffeVampire.pineapple',
       },
       {
         v: 1,
@@ -183,22 +163,18 @@ suite('IndexListTreeItem Test Suite', () => {
           gnocchi: -1,
         },
         name: '_id_1_gnocchi_1',
-        ns: 'tasty_fruits.pineapple',
+        ns: 'giraffeVampire.pineapple',
       },
     ];
 
-    const testIndexListTreeItem = new IndexListTreeItem(
-      'pineapple',
-      'tasty_fruits',
-      {
+    const testIndexListTreeItem = getTestIndexListTreeItem({
+      collectionName: 'pineapple',
+      dataService: {
         indexes: (): ReturnType<DataService['indexes']> => {
           return Promise.resolve(fakeFetchIndexes as any[]);
         },
       } as unknown as DataService,
-      false,
-      false,
-      []
-    );
+    });
 
     await testIndexListTreeItem.onDidExpand();
 
@@ -212,18 +188,18 @@ suite('IndexListTreeItem Test Suite', () => {
 
     indexTreeItems[0].onDidExpand();
 
-    const newIndexListTreeItem = new IndexListTreeItem(
-      testIndexListTreeItem.collectionName,
-      testIndexListTreeItem.databaseName,
-      {
+    const newIndexListTreeItem = getTestIndexListTreeItem({
+      collectionName: testIndexListTreeItem.collectionName,
+      databaseName: testIndexListTreeItem.databaseName,
+      dataService: {
         indexes: (): ReturnType<DataService['indexes']> => {
           return Promise.resolve([]);
         },
       } as unknown as DataService,
-      testIndexListTreeItem.isExpanded,
-      testIndexListTreeItem.cacheIsUpToDate,
-      testIndexListTreeItem.getChildrenCache()
-    );
+      isExpanded: testIndexListTreeItem.isExpanded,
+      cacheIsUpToDate: testIndexListTreeItem.cacheIsUpToDate,
+      childrenCache: testIndexListTreeItem.getChildrenCache(),
+    });
 
     let newIndexTreeItems;
     try {
@@ -232,18 +208,14 @@ suite('IndexListTreeItem Test Suite', () => {
       assert(false, `Expected no error, found: ${formatError(error).message}`);
     }
 
-    assert(
-      newIndexTreeItems[1].label === '_id_1_gnocchi_1',
-      `Expected the second child tree item to be named '_id_1_gnocchi_1' found ${newIndexTreeItems[1].label}`
-    );
+    assert.strictEqual(newIndexTreeItems[1].label, '_id_1_gnocchi_1');
     assert(
       newIndexTreeItems[0].isExpanded,
       'Expected the first index in list to be expanded'
     );
-    assert(
-      newIndexTreeItems[0].collapsibleState ===
-        vscode.TreeItemCollapsibleState.Expanded,
-      'Expected the first index in list have expanded tree state'
+    assert.strictEqual(
+      newIndexTreeItems[0].collapsibleState,
+      vscode.TreeItemCollapsibleState.Expanded
     );
   });
 });

--- a/src/test/suite/explorer/indexTreeItem.test.ts
+++ b/src/test/suite/explorer/indexTreeItem.test.ts
@@ -7,8 +7,8 @@ import IndexTreeItem, {
 
 suite('IndexTreeItem Test Suite', () => {
   test('it has tree items for each key in the index', async () => {
-    const testIndexTreeItem = new IndexTreeItem(
-      {
+    const testIndexTreeItem = new IndexTreeItem({
+      index: {
         v: 1,
         key: {
           _id: 1,
@@ -17,32 +17,23 @@ suite('IndexTreeItem Test Suite', () => {
         name: '_id_1_gnocchi_1',
         ns: 'tasty_fruits.pineapple',
       },
-      'tasty_fruits.pineapple',
-      false
-    );
+      namespace: 'tasty_fruits.pineapple',
+      isExpanded: false,
+    });
 
     const indexKeyTreeItems = await testIndexTreeItem.getChildren();
 
-    assert(
-      indexKeyTreeItems.length === 2,
-      `Expected 2 tree items to be returned, found ${indexKeyTreeItems.length}`
-    );
-    assert(
-      indexKeyTreeItems[0].label === '_id',
-      `Expected first child tree item to be named '_id' found ${indexKeyTreeItems[0].label}`
-    );
-    assert(
-      indexKeyTreeItems[1].label === 'gnocchi',
-      `Expected the second child tree item to be named 'gnocchi' found ${indexKeyTreeItems[1].label}`
-    );
+    assert.strictEqual(indexKeyTreeItems.length, 2);
+    assert.strictEqual(indexKeyTreeItems[0].label, '_id');
+    assert.strictEqual(indexKeyTreeItems[1].label, 'gnocchi');
   });
 
   suite('IndexFieldTreeItem', () => {
     test('it has an icon for the index type', () => {
-      const testIndexFieldTreeItem = new IndexFieldTreeItem(
-        'locations',
-        IndexKeyType.GEOSPHERE
-      );
+      const testIndexFieldTreeItem = new IndexFieldTreeItem({
+        indexKey: 'locations',
+        indexKeyType: IndexKeyType.GEOSPHERE,
+      });
 
       const iconPath = testIndexFieldTreeItem.iconPath as {
         light: string;

--- a/src/test/suite/language/languageServerController.test.ts
+++ b/src/test/suite/language/languageServerController.test.ts
@@ -11,7 +11,6 @@ import ActiveDBCodeLensProvider from '../../../editors/activeConnectionCodeLensP
 import PlaygroundSelectedCodeActionProvider from '../../../editors/playgroundSelectedCodeActionProvider';
 import ConnectionController from '../../../connectionController';
 import EditDocumentCodeLensProvider from '../../../editors/editDocumentCodeLensProvider';
-import { ExplorerController } from '../../../explorer';
 import ExportToLanguageCodeLensProvider from '../../../editors/exportToLanguageCodeLensProvider';
 import { LanguageServerController } from '../../../language';
 import { mdbTestExtension } from '../stubbableMdbExtension';
@@ -39,11 +38,11 @@ suite('Language Server Controller Test Suite', () => {
     extensionContextStub
   );
   const testStatusView = new StatusView(extensionContextStub);
-  const testConnectionController = new ConnectionController(
-    testStatusView,
-    testStorageController,
-    testTelemetryService
-  );
+  const testConnectionController = new ConnectionController({
+    statusView: testStatusView,
+    storageController: testStorageController,
+    telemetryService: testTelemetryService,
+  });
   const testEditDocumentCodeLensProvider = new EditDocumentCodeLensProvider(
     testConnectionController
   );
@@ -52,9 +51,6 @@ suite('Language Server Controller Test Suite', () => {
     testEditDocumentCodeLensProvider
   );
   const testActiveDBCodeLensProvider = new ActiveDBCodeLensProvider(
-    testConnectionController
-  );
-  const testExplorerController = new ExplorerController(
     testConnectionController
   );
   const testExportToLanguageCodeLensProvider =
@@ -70,17 +66,16 @@ suite('Language Server Controller Test Suite', () => {
     languageServerControllerStub = new LanguageServerController(
       extensionContextStub
     );
-    testPlaygroundController = new PlaygroundController(
-      testConnectionController,
-      languageServerControllerStub,
-      testTelemetryService,
-      testStatusView,
-      testPlaygroundResultProvider,
-      testActiveDBCodeLensProvider,
-      testExportToLanguageCodeLensProvider,
-      testCodeActionProvider,
-      testExplorerController
-    );
+    testPlaygroundController = new PlaygroundController({
+      connectionController: testConnectionController,
+      languageServerController: languageServerControllerStub,
+      telemetryService: testTelemetryService,
+      statusView: testStatusView,
+      playgroundResultViewProvider: testPlaygroundResultProvider,
+      activeConnectionCodeLensProvider: testActiveDBCodeLensProvider,
+      exportToLanguageCodeLensProvider: testExportToLanguageCodeLensProvider,
+      playgroundSelectedCodeActionProvider: testCodeActionProvider,
+    });
     await languageServerControllerStub.startLanguageServer();
     await testPlaygroundController._connectToServiceProvider();
   });

--- a/src/test/suite/mdbExtensionController.test.ts
+++ b/src/test/suite/mdbExtensionController.test.ts
@@ -25,10 +25,13 @@ import {
   StorageVariables,
 } from '../../storage/storageController';
 import { VIEW_COLLECTION_SCHEME } from '../../editors/collectionDocumentsProvider';
+import type { CollectionDetailsType } from '../../explorer/collectionTreeItem';
 
 const testDatabaseURI = 'mongodb://localhost:27018';
 
-function getTestConnectionTreeItem() {
+function getTestConnectionTreeItem(
+  options?: Partial<ConstructorParameters<typeof ConnectionTreeItem>[0]>
+) {
   return new ConnectionTreeItem({
     connectionId: 'tasty_sandwhich',
     collapsibleState: vscode.TreeItemCollapsibleState.None,
@@ -37,6 +40,7 @@ function getTestConnectionTreeItem() {
       mdbTestExtension.testExtensionController._connectionController,
     cacheIsUpToDate: false,
     childrenCache: {},
+    ...options,
   });
 }
 
@@ -47,7 +51,7 @@ function getTestCollectionTreeItem(
     collection: {
       name: 'testColName',
       type: CollectionTypes.collection,
-    },
+    } as unknown as CollectionDetailsType,
     databaseName: 'testDbName',
     dataService: {} as DataService,
     isExpanded: false,
@@ -58,7 +62,7 @@ function getTestCollectionTreeItem(
 }
 
 function getTestDatabaseTreeItem(
-  options?: Partial<ConstructorParameters<typeof CollectionTreeItem>[0]>
+  options?: Partial<ConstructorParameters<typeof DatabaseTreeItem>[0]>
 ) {
   return new DatabaseTreeItem({
     databaseName: 'zebra',
@@ -277,7 +281,9 @@ suite('MDBExtensionController Test Suite', function () {
     });
 
     test('mdb.treeItemRemoveConnection command should call removeMongoDBConnection on the connection controller with the tree item connection id', async () => {
-      const testTreeItem = getTestConnectionTreeItem();
+      const testTreeItem = getTestConnectionTreeItem({
+        connectionId: 'craving_for_pancakes_with_maple_syrup',
+      });
       const fakeRemoveMongoDBConnection = sandbox.fake();
       sandbox.replace(
         mdbTestExtension.testExtensionController._connectionController,
@@ -420,7 +426,7 @@ suite('MDBExtensionController Test Suite', function () {
       let count = 9000;
       const testTreeItem = getTestCollectionTreeItem({
         dataService: {
-          estimatedCount: { estimatedCount: () => Promise.resolve(count) },
+          estimatedCount: () => Promise.resolve(count),
         } as unknown as DataService,
       });
       await testTreeItem.onDidExpand();
@@ -465,14 +471,14 @@ suite('MDBExtensionController Test Suite', function () {
     });
 
     test('mdb.refreshIndexes command should reset its cache and call to refresh the explorer controller', async () => {
-      const testTreeItem = new IndexListTreeItem(
-        'zebraWearwolf',
-        'giraffeVampire',
-        {} as DataService,
-        false,
-        false,
-        []
-      );
+      const testTreeItem = new IndexListTreeItem({
+        collectionName: 'zebraWearwolf',
+        databaseName: 'giraffeVampire',
+        dataService: {} as DataService,
+        isExpanded: false,
+        cacheIsUpToDate: false,
+        childrenCache: [],
+      });
 
       // Set cached.
       testTreeItem.cacheIsUpToDate = true;
@@ -693,7 +699,7 @@ suite('MDBExtensionController Test Suite', function () {
         collection: {
           name: 'doesntExistColName',
           type: CollectionTypes.collection,
-        },
+        } as unknown as CollectionDetailsType,
         dataService:
           testConnectionController.getActiveDataService() ?? undefined,
       });
@@ -721,7 +727,10 @@ suite('MDBExtensionController Test Suite', function () {
 
     test('mdb.dropCollection fails when the input doesnt match the collection name', async () => {
       const testCollectionTreeItem = getTestCollectionTreeItem({
-        collection: { name: 'orange', type: CollectionTypes.collection },
+        collection: {
+          name: 'orange',
+          type: CollectionTypes.collection,
+        } as unknown as CollectionDetailsType,
       });
       const inputBoxResolvesStub = sandbox.stub();
       inputBoxResolvesStub.onCall(0).resolves('apple');
@@ -832,7 +841,9 @@ suite('MDBExtensionController Test Suite', function () {
           storageLocation: StorageLocation.NONE,
         };
 
-      const testTreeItem = getTestConnectionTreeItem();
+      const testTreeItem = getTestConnectionTreeItem({
+        connectionId: 'blueBerryPancakesAndTheSmellOfBacon',
+      });
 
       const inputBoxResolvesStub = sandbox.stub();
       inputBoxResolvesStub.onCall(0).resolves(/* Return undefined. */);
@@ -860,7 +871,9 @@ suite('MDBExtensionController Test Suite', function () {
           storageLocation: StorageLocation.NONE,
         };
 
-      const testTreeItem = getTestConnectionTreeItem();
+      const testTreeItem = getTestConnectionTreeItem({
+        connectionId: 'blueBerryPancakesAndTheSmellOfBacon',
+      });
       const inputBoxResolvesStub = sandbox.stub();
       inputBoxResolvesStub.onCall(0).resolves('orange juice');
       sandbox.replace(vscode.window, 'showInputBox', inputBoxResolvesStub);
@@ -1274,7 +1287,7 @@ suite('MDBExtensionController Test Suite', function () {
         collection: {
           name: 'pineapple',
           type: CollectionTypes.collection,
-        },
+        } as unknown as CollectionDetailsType,
         databaseName: 'plants',
       });
       const fakeCreatePlaygroundForInsertDocument = sandbox.fake();

--- a/src/test/suite/mdbExtensionController.test.ts
+++ b/src/test/suite/mdbExtensionController.test.ts
@@ -28,6 +28,87 @@ import { VIEW_COLLECTION_SCHEME } from '../../editors/collectionDocumentsProvide
 
 const testDatabaseURI = 'mongodb://localhost:27018';
 
+function getTestConnectionTreeItem() {
+  return new ConnectionTreeItem({
+    connectionId: 'tasty_sandwhich',
+    collapsibleState: vscode.TreeItemCollapsibleState.None,
+    isExpanded: false,
+    connectionController:
+      mdbTestExtension.testExtensionController._connectionController,
+    cacheIsUpToDate: false,
+    childrenCache: {},
+  });
+}
+
+function getTestCollectionTreeItem(
+  options?: Partial<ConstructorParameters<typeof CollectionTreeItem>[0]>
+) {
+  return new CollectionTreeItem({
+    collection: {
+      name: 'testColName',
+      type: CollectionTypes.collection,
+    },
+    databaseName: 'testDbName',
+    dataService: {} as DataService,
+    isExpanded: false,
+    cacheIsUpToDate: false,
+    cachedDocumentCount: null,
+    ...options,
+  });
+}
+
+function getTestDatabaseTreeItem(
+  options?: Partial<ConstructorParameters<typeof CollectionTreeItem>[0]>
+) {
+  return new DatabaseTreeItem({
+    databaseName: 'zebra',
+    dataService: {} as DataService,
+    isExpanded: false,
+    cacheIsUpToDate: false,
+    childrenCache: {},
+    ...options,
+  });
+}
+
+function getTestFieldTreeItem() {
+  return new FieldTreeItem({
+    field: {
+      name: 'dolphins are sentient',
+      probability: 1,
+      type: 'String',
+      types: [],
+    },
+    isExpanded: false,
+    existingCache: {},
+  });
+}
+
+function getTestSchemaTreeItem() {
+  return new SchemaTreeItem({
+    databaseName: 'zebraWearwolf',
+    collectionName: 'giraffeVampire',
+    dataService: {} as DataService,
+    isExpanded: false,
+    hasClickedShowMoreFields: false,
+    hasMoreFieldsToShow: false,
+    cacheIsUpToDate: false,
+    childrenCache: {},
+  });
+}
+
+function getTestDocumentTreeItem(
+  options?: Partial<ConstructorParameters<typeof DocumentTreeItem>[0]>
+) {
+  return new DocumentTreeItem({
+    document: {},
+    namespace: 'waffle.house',
+    documentIndexInTree: 0,
+    dataService: {} as DataService,
+    resetDocumentListCache: () => Promise.resolve(),
+    ...options,
+  });
+}
+
 suite('MDBExtensionController Test Suite', function () {
   this.timeout(10000);
 
@@ -47,14 +128,7 @@ suite('MDBExtensionController Test Suite', function () {
     });
 
     test('mdb.addDatabase command fails when not connected to the connection', async () => {
-      const testTreeItem = new ConnectionTreeItem(
-        'tasty_sandwhich',
-        vscode.TreeItemCollapsibleState.None,
-        false,
-        mdbTestExtension.testExtensionController._connectionController,
-        false,
-        {}
-      );
+      const testTreeItem = getTestConnectionTreeItem();
       const addDatabaseSucceeded = await vscode.commands.executeCommand(
         'mdb.addDatabase',
         testTreeItem
@@ -109,17 +183,7 @@ suite('MDBExtensionController Test Suite', function () {
     });
 
     test('mdb.viewCollectionDocuments command should call onViewCollectionDocuments on the editor controller with the collection namespace', async () => {
-      const textCollectionTree = new CollectionTreeItem(
-        {
-          name: 'testColName',
-          type: CollectionTypes.collection,
-        },
-        'testDbName',
-        {},
-        false,
-        false,
-        null
-      );
+      const textCollectionTree = getTestCollectionTreeItem();
       await vscode.commands.executeCommand(
         'mdb.viewCollectionDocuments',
         textCollectionTree
@@ -143,17 +207,7 @@ suite('MDBExtensionController Test Suite', function () {
     });
 
     test('mdb.viewCollectionDocuments command should also work with the documents list', async () => {
-      const textCollectionTree = new CollectionTreeItem(
-        {
-          name: 'testColName',
-          type: CollectionTypes.collection,
-        },
-        'testDbName',
-        {},
-        false,
-        false,
-        null
-      );
+      const textCollectionTree = getTestCollectionTreeItem();
       await vscode.commands.executeCommand(
         'mdb.viewCollectionDocuments',
         textCollectionTree
@@ -197,14 +251,7 @@ suite('MDBExtensionController Test Suite', function () {
     });
 
     test('mdb.refreshConnection command should reset the cache on a connection tree item', async () => {
-      const testTreeItem = new ConnectionTreeItem(
-        'test',
-        vscode.TreeItemCollapsibleState.None,
-        false,
-        mdbTestExtension.testExtensionController._connectionController,
-        false,
-        {}
-      );
+      const testTreeItem = getTestConnectionTreeItem();
       testTreeItem.cacheIsUpToDate = true;
 
       const fakeRefresh = sandbox.fake();
@@ -230,14 +277,7 @@ suite('MDBExtensionController Test Suite', function () {
     });
 
     test('mdb.treeItemRemoveConnection command should call removeMongoDBConnection on the connection controller with the tree item connection id', async () => {
-      const testTreeItem = new ConnectionTreeItem(
-        'craving_for_pancakes_with_maple_syrup',
-        vscode.TreeItemCollapsibleState.None,
-        false,
-        mdbTestExtension.testExtensionController._connectionController,
-        false,
-        {}
-      );
+      const testTreeItem = getTestConnectionTreeItem();
       const fakeRemoveMongoDBConnection = sandbox.fake();
       sandbox.replace(
         mdbTestExtension.testExtensionController._connectionController,
@@ -256,14 +296,7 @@ suite('MDBExtensionController Test Suite', function () {
     });
 
     test('mdb.copyConnectionString command should try to copy the driver url to the vscode env clipboard', async () => {
-      const testTreeItem = new ConnectionTreeItem(
-        'craving_for_pancakes_with_maple_syrup',
-        vscode.TreeItemCollapsibleState.None,
-        false,
-        mdbTestExtension.testExtensionController._connectionController,
-        false,
-        {}
-      );
+      const testTreeItem = getTestConnectionTreeItem();
       const fakeWriteText = sandbox.fake();
       sandbox.replaceGetter(vscode.env, 'clipboard', () => ({
         writeText: fakeWriteText,
@@ -285,13 +318,7 @@ suite('MDBExtensionController Test Suite', function () {
     });
 
     test('mdb.copyDatabaseName command should try to copy the database name to the vscode env clipboard', async () => {
-      const testTreeItem = new DatabaseTreeItem(
-        'isClubMateTheBestDrinkEver',
-        {},
-        false,
-        false,
-        {}
-      );
+      const testTreeItem = getTestDatabaseTreeItem();
       const fakeWriteText = sandbox.fake();
       sandbox.replaceGetter(vscode.env, 'clipboard', () => ({
         writeText: fakeWriteText,
@@ -302,24 +329,11 @@ suite('MDBExtensionController Test Suite', function () {
         testTreeItem
       );
       assert.strictEqual(fakeWriteText.calledOnce, true);
-      assert.strictEqual(
-        fakeWriteText.firstCall.args[0],
-        'isClubMateTheBestDrinkEver'
-      );
+      assert.strictEqual(fakeWriteText.firstCall.args[0], 'zebra');
     });
 
     test('mdb.copyCollectionName command should try to copy the collection name to the vscode env clipboard', async () => {
-      const testTreeItem = new CollectionTreeItem(
-        {
-          name: 'waterBuffalo',
-          type: CollectionTypes.collection,
-        },
-        'airZebra',
-        {},
-        false,
-        false,
-        null
-      );
+      const testTreeItem = getTestCollectionTreeItem();
       const fakeWriteText = sandbox.fake();
       sandbox.replaceGetter(vscode.env, 'clipboard', () => ({
         writeText: fakeWriteText,
@@ -329,27 +343,12 @@ suite('MDBExtensionController Test Suite', function () {
         'mdb.copyCollectionName',
         testTreeItem
       );
-      assert(
-        fakeWriteText.called,
-        'Expected "writeText" to be called on "vscode.env.clipboard".'
-      );
-      assert(
-        fakeWriteText.firstCall.args[0] === 'waterBuffalo',
-        `Expected the clipboard to be sent the uri string "waterBuffalo", found ${fakeWriteText.firstCall.args[0]}.`
-      );
+      assert.strictEqual(fakeWriteText.called, true);
+      assert.strictEqual(fakeWriteText.firstCall.args[0], 'testColName');
     });
 
     test('mdb.copySchemaFieldName command should try to copy the field name to the vscode env clipboard', async () => {
-      const testTreeItem = new FieldTreeItem(
-        {
-          name: 'dolphins are sentient',
-          probability: 1,
-          type: 'String',
-          types: [],
-        },
-        false,
-        {}
-      );
+      const testTreeItem = getTestFieldTreeItem();
       const fakeWriteText = sandbox.fake();
       sandbox.replaceGetter(vscode.env, 'clipboard', () => ({
         writeText: fakeWriteText,
@@ -360,24 +359,15 @@ suite('MDBExtensionController Test Suite', function () {
         testTreeItem
       );
       assert(commandResult);
-      assert(
-        fakeWriteText.called,
-        'Expected "writeText" to be called on "vscode.env.clipboard".'
-      );
-      assert(
-        fakeWriteText.firstCall.args[0] === 'dolphins are sentient',
-        `Expected the clipboard to be sent the schema field name "dolphins are sentient", found ${fakeWriteText.firstCall.args[0]}.`
+      assert.strictEqual(fakeWriteText.called, true);
+      assert.strictEqual(
+        fakeWriteText.firstCall.args[0],
+        'dolphins are sentient'
       );
     });
 
     test('mdb.refreshDatabase command should reset the cache on the database tree item', async () => {
-      const testTreeItem = new DatabaseTreeItem(
-        'pinkLemonade',
-        {},
-        false,
-        false,
-        {}
-      );
+      const testTreeItem = getTestDatabaseTreeItem();
       testTreeItem.cacheIsUpToDate = true;
 
       const fakeRefresh = sandbox.fake();
@@ -399,17 +389,7 @@ suite('MDBExtensionController Test Suite', function () {
     });
 
     test('mdb.refreshCollection command should reset the expanded state of its children and call to refresh the explorer controller', async () => {
-      const testTreeItem = new CollectionTreeItem(
-        {
-          name: 'iSawACatThatLookedLikeALionToday',
-          type: CollectionTypes.collection,
-        },
-        'airZebra',
-        {},
-        false,
-        false,
-        null
-      );
+      const testTreeItem = getTestCollectionTreeItem();
       testTreeItem.isExpanded = true;
 
       // Set expanded.
@@ -438,17 +418,11 @@ suite('MDBExtensionController Test Suite', function () {
 
     test('mdb.refreshDocumentList command should update the document count and call to refresh the explorer controller', async () => {
       let count = 9000;
-      const testTreeItem = new CollectionTreeItem(
-        {
-          name: 'iSawACatThatLookedLikeALionToday',
-          type: CollectionTypes.collection,
-        },
-        'airZebra',
-        { estimatedCount: () => Promise.resolve(count) },
-        false,
-        false,
-        null
-      );
+      const testTreeItem = getTestCollectionTreeItem({
+        dataService: {
+          estimatedCount: { estimatedCount: () => Promise.resolve(count) },
+        } as unknown as DataService,
+      });
       await testTreeItem.onDidExpand();
 
       const collectionChildren = await testTreeItem.getChildren();
@@ -468,31 +442,13 @@ suite('MDBExtensionController Test Suite', function () {
         'mdb.refreshDocumentList',
         docListTreeItem
       );
-      assert(
-        docListTreeItem.cacheIsUpToDate === false,
-        'Expected document list cache to be out of date.'
-      );
-      assert(
-        testTreeItem.documentCount === 10000,
-        `Expected document count to be 10000, found ${testTreeItem.documentCount}.`
-      );
-      assert(
-        fakeRefresh.called === true,
-        'Expected explorer controller refresh to be called.'
-      );
+      assert.strictEqual(docListTreeItem.cacheIsUpToDate, false);
+      assert.strictEqual(testTreeItem.documentCount, 10000);
+      assert.strictEqual(fakeRefresh.called, true);
     });
 
     test('mdb.refreshSchema command should reset its cache and call to refresh the explorer controller', async () => {
-      const testTreeItem = new SchemaTreeItem(
-        'zebraWearwolf',
-        'giraffeVampire',
-        {} as DataService,
-        false,
-        false,
-        false,
-        false,
-        {}
-      );
+      const testTreeItem = getTestSchemaTreeItem();
 
       // Set cached.
       testTreeItem.cacheIsUpToDate = true;
@@ -504,14 +460,8 @@ suite('MDBExtensionController Test Suite', function () {
         fakeRefresh
       );
       await vscode.commands.executeCommand('mdb.refreshSchema', testTreeItem);
-      assert(
-        !testTreeItem.cacheIsUpToDate,
-        'Expected schema field cache to be not up to date.'
-      );
-      assert(
-        fakeRefresh.called === true,
-        'Expected explorer controller refresh to be called.'
-      );
+      assert.strictEqual(testTreeItem.cacheIsUpToDate, false);
+      assert.strictEqual(fakeRefresh.called, true);
     });
 
     test('mdb.refreshIndexes command should reset its cache and call to refresh the explorer controller', async () => {
@@ -545,14 +495,7 @@ suite('MDBExtensionController Test Suite', function () {
     });
 
     test('mdb.addDatabase should create a MongoDB playground with create collection template', async () => {
-      const testTreeItem = new ConnectionTreeItem(
-        'tasty_sandwhich',
-        vscode.TreeItemCollapsibleState.None,
-        false,
-        mdbTestExtension.testExtensionController._connectionController,
-        false,
-        {}
-      );
+      const testTreeItem = getTestConnectionTreeItem();
       await vscode.commands.executeCommand('mdb.addDatabase', testTreeItem);
 
       const content = fakeCreatePlaygroundFileWithContent.firstCall.args[0];
@@ -562,18 +505,12 @@ suite('MDBExtensionController Test Suite', function () {
     });
 
     test('mdb.addCollection should create a MongoDB playground with create collection template', async () => {
-      const testTreeItem = new DatabaseTreeItem(
-        'iceCreamDB',
-        {},
-        false,
-        false,
-        {}
-      );
+      const testTreeItem = getTestDatabaseTreeItem();
       await vscode.commands.executeCommand('mdb.addCollection', testTreeItem);
 
       const content = fakeCreatePlaygroundFileWithContent.firstCall.args[0];
       assert(content.includes('// The current database to use.'));
-      assert(content.includes('iceCreamDB'));
+      assert(content.includes('zebra'));
       assert(content.includes('NEW_COLLECTION_NAME'));
       assert(!content.includes('time-series'));
     });
@@ -635,14 +572,7 @@ suite('MDBExtensionController Test Suite', function () {
     });
 
     test('mdb.addDatabase command fails when disconnecting', async () => {
-      const testTreeItem = new ConnectionTreeItem(
-        'tasty_sandwhich',
-        vscode.TreeItemCollapsibleState.None,
-        false,
-        mdbTestExtension.testExtensionController._connectionController,
-        false,
-        {}
-      );
+      const testTreeItem = getTestConnectionTreeItem();
       const inputBoxResolvesStub = sandbox.stub();
       inputBoxResolvesStub.onCall(0).resolves('theDbName');
       inputBoxResolvesStub.onCall(1).resolves('theCollectionName');
@@ -673,14 +603,7 @@ suite('MDBExtensionController Test Suite', function () {
     });
 
     test('mdb.addDatabase command fails when connecting', async () => {
-      const testTreeItem = new ConnectionTreeItem(
-        'tasty_sandwhich',
-        vscode.TreeItemCollapsibleState.None,
-        false,
-        mdbTestExtension.testExtensionController._connectionController,
-        false,
-        {}
-      );
+      const testTreeItem = getTestConnectionTreeItem();
       const inputBoxResolvesStub = sandbox.stub();
       inputBoxResolvesStub.onCall(0).resolves('theDbName');
       inputBoxResolvesStub.onCall(1).resolves('theCollectionName');
@@ -710,13 +633,7 @@ suite('MDBExtensionController Test Suite', function () {
     });
 
     test('mdb.addCollection command fails when disconnecting', async () => {
-      const testTreeItem = new DatabaseTreeItem(
-        'iceCreamDB',
-        {},
-        false,
-        false,
-        {}
-      );
+      const testTreeItem = getTestDatabaseTreeItem();
       const inputBoxResolvesStub = sandbox.stub();
       inputBoxResolvesStub.onCall(0).resolves('mintChocolateChips');
       sandbox.replace(vscode.window, 'showInputBox', inputBoxResolvesStub);
@@ -732,34 +649,26 @@ suite('MDBExtensionController Test Suite', function () {
         'mdb.addCollection',
         testTreeItem
       );
-      assert(
-        addCollectionSucceeded === false,
-        'Expected the add collection command handler to return a false succeeded response'
-      );
+      assert.strictEqual(addCollectionSucceeded, false);
       const expectedMessage =
         'Unable to add collection: currently disconnecting.';
-      assert(
-        showErrorMessageStub.firstCall.args[0] === expectedMessage,
-        `Expected "${expectedMessage}" when adding a database to a not connected connection, recieved "${showErrorMessageStub.firstCall.args[0]}"`
+      assert.strictEqual(
+        showErrorMessageStub.firstCall.args[0],
+        expectedMessage
       );
     });
 
     // https://code.visualstudio.com/api/references/contribution-points#Sorting-of-groups
     test('mdb.dropCollection calls data service to drop the collection after inputting the collection name', async () => {
       let calledNamespace = '';
-      const testCollectionTreeItem = new CollectionTreeItem(
-        { name: 'testColName', type: CollectionTypes.collection },
-        'testDbName',
-        {
+      const testCollectionTreeItem = getTestCollectionTreeItem({
+        dataService: {
           dropCollection: (namespace): Promise<boolean> => {
             calledNamespace = namespace;
             return Promise.resolve(true);
           },
-        },
-        false,
-        false,
-        null
-      );
+        } as unknown as DataService,
+      });
 
       const inputBoxResolvesStub = sandbox.stub();
       inputBoxResolvesStub.onCall(0).resolves('testColName');
@@ -769,25 +678,25 @@ suite('MDBExtensionController Test Suite', function () {
         'mdb.dropCollection',
         testCollectionTreeItem
       );
-      assert(successfullyDropped);
+      assert.strictEqual(successfullyDropped, true);
       assert.strictEqual(calledNamespace, 'testDbName.testColName');
     });
 
-    test('mdb.dropCollection fails when a collection doesnt exist', async () => {
+    test('mdb.dropCollection fails when a collection does not exist', async () => {
       const testConnectionController =
         mdbTestExtension.testExtensionController._connectionController;
       await testConnectionController.addNewConnectionStringAndConnect(
         testDatabaseURI
       );
 
-      const testCollectionTreeItem = new CollectionTreeItem(
-        { name: 'doesntExistColName', type: CollectionTypes.collection },
-        'doesntExistDBName',
-        testConnectionController.getActiveDataService(),
-        false,
-        false,
-        null
-      );
+      const testCollectionTreeItem = getTestCollectionTreeItem({
+        collection: {
+          name: 'doesntExistColName',
+          type: CollectionTypes.collection,
+        },
+        dataService:
+          testConnectionController.getActiveDataService() ?? undefined,
+      });
       const inputBoxResolvesStub = sandbox.stub();
       inputBoxResolvesStub.onCall(0).resolves('doesntExistColName');
       sandbox.replace(vscode.window, 'showInputBox', inputBoxResolvesStub);
@@ -811,14 +720,9 @@ suite('MDBExtensionController Test Suite', function () {
     });
 
     test('mdb.dropCollection fails when the input doesnt match the collection name', async () => {
-      const testCollectionTreeItem = new CollectionTreeItem(
-        { name: 'orange', type: CollectionTypes.collection },
-        'fruitsThatAreTasty',
-        {},
-        false,
-        false,
-        null
-      );
+      const testCollectionTreeItem = getTestCollectionTreeItem({
+        collection: { name: 'orange', type: CollectionTypes.collection },
+      });
       const inputBoxResolvesStub = sandbox.stub();
       inputBoxResolvesStub.onCall(0).resolves('apple');
       sandbox.replace(vscode.window, 'showInputBox', inputBoxResolvesStub);
@@ -827,21 +731,11 @@ suite('MDBExtensionController Test Suite', function () {
         'mdb.dropCollection',
         testCollectionTreeItem
       );
-      assert(
-        successfullyDropped === false,
-        'Expected the drop collection command handler to return a false succeeded response'
-      );
+      assert.strictEqual(successfullyDropped, false);
     });
 
     test('mdb.dropCollection fails when the collection name input is empty', async () => {
-      const testCollectionTreeItem = new CollectionTreeItem(
-        { name: 'orange', type: CollectionTypes.view },
-        'fruitsThatAreTasty',
-        {},
-        false,
-        false,
-        null
-      );
+      const testCollectionTreeItem = getTestCollectionTreeItem();
       const inputBoxResolvesStub = sandbox.stub();
       inputBoxResolvesStub.onCall(0).resolves(/* Return undefined. */);
       sandbox.replace(vscode.window, 'showInputBox', inputBoxResolvesStub);
@@ -850,26 +744,20 @@ suite('MDBExtensionController Test Suite', function () {
         'mdb.dropCollection',
         testCollectionTreeItem
       );
-      assert(
-        successfullyDropped === false,
-        'Expected the drop collection command handler to return a false succeeded response'
-      );
+      assert.strictEqual(successfullyDropped, false);
     });
 
-    test('mdb.dropDatabase calls dataservice to drop the database after inputting the database name', async () => {
+    test('mdb.dropDatabase calls DataService to drop the database after inputting the database name', async () => {
       let calledDatabaseName = '';
-      const testDatabaseTreeItem = new DatabaseTreeItem(
-        'iMissTangerineAltoids',
-        {
+      const testDatabaseTreeItem = getTestDatabaseTreeItem({
+        databaseName: 'iMissTangerineAltoids',
+        dataService: {
           dropDatabase: (dbName): Promise<boolean> => {
             calledDatabaseName = dbName;
             return Promise.resolve(true);
           },
-        },
-        false,
-        false,
-        {}
-      );
+        } as unknown as DataService,
+      });
 
       const inputBoxResolvesStub = sandbox.stub();
       inputBoxResolvesStub.onCall(0).resolves('iMissTangerineAltoids');
@@ -890,13 +778,11 @@ suite('MDBExtensionController Test Suite', function () {
         testDatabaseURI
       );
 
-      const testDatabaseTreeItem = new DatabaseTreeItem(
-        'narnia____a',
-        testConnectionController.getActiveDataService(),
-        false,
-        false,
-        {}
-      );
+      const testDatabaseTreeItem = getTestDatabaseTreeItem({
+        databaseName: 'narnia____a',
+        dataService:
+          testConnectionController.getActiveDataService() ?? undefined,
+      });
       const inputBoxResolvesStub = sandbox.stub();
       inputBoxResolvesStub.onCall(0).resolves('narnia____a');
       sandbox.replace(vscode.window, 'showInputBox', inputBoxResolvesStub);
@@ -905,24 +791,14 @@ suite('MDBExtensionController Test Suite', function () {
         'mdb.dropDatabase',
         testDatabaseTreeItem
       );
-      assert(
-        successfullyDropped,
-        'Expected the drop database command handler to return a successful boolean response'
-      );
-      assert(
-        showErrorMessageStub.called === false,
-        'Expected no error messages'
-      );
+      assert.strictEqual(successfullyDropped, true);
+      assert.strictEqual(showErrorMessageStub.called, false);
     });
 
     test('mdb.dropDatabase fails when the input doesnt match the database name', async () => {
-      const testDatabaseTreeItem = new DatabaseTreeItem(
-        'cinnamonToastCrunch',
-        {},
-        false,
-        false,
-        {}
-      );
+      const testDatabaseTreeItem = getTestDatabaseTreeItem({
+        databaseName: 'orange',
+      });
       const inputBoxResolvesStub = sandbox.stub();
       inputBoxResolvesStub.onCall(0).resolves('apple');
       sandbox.replace(vscode.window, 'showInputBox', inputBoxResolvesStub);
@@ -931,20 +807,11 @@ suite('MDBExtensionController Test Suite', function () {
         'mdb.dropDatabase',
         testDatabaseTreeItem
       );
-      assert(
-        successfullyDropped === false,
-        'Expected the drop database command handler to return a false succeeded response'
-      );
+      assert.strictEqual(successfullyDropped, false);
     });
 
     test('mdb.dropDatabase fails when the database name input is empty', async () => {
-      const testDatabaseTreeItem = new DatabaseTreeItem(
-        'blueBerryPancakesAndTheSmellOfBacon',
-        {},
-        false,
-        false,
-        {}
-      );
+      const testDatabaseTreeItem = getTestDatabaseTreeItem();
       const inputBoxResolvesStub = sandbox.stub();
       inputBoxResolvesStub.onCall(0).resolves(/* Return undefined. */);
       sandbox.replace(vscode.window, 'showInputBox', inputBoxResolvesStub);
@@ -953,10 +820,7 @@ suite('MDBExtensionController Test Suite', function () {
         'mdb.dropDatabase',
         testDatabaseTreeItem
       );
-      assert(
-        successfullyDropped === false,
-        'Expected the drop database command handler to return a false succeeded response'
-      );
+      assert.strictEqual(successfullyDropped, false);
     });
 
     test('mdb.renameConnection fails when the name input is empty', async () => {
@@ -968,14 +832,7 @@ suite('MDBExtensionController Test Suite', function () {
           storageLocation: StorageLocation.NONE,
         };
 
-      const testTreeItem = new ConnectionTreeItem(
-        'blueBerryPancakesAndTheSmellOfBacon',
-        vscode.TreeItemCollapsibleState.None,
-        false,
-        mdbTestExtension.testExtensionController._connectionController,
-        false,
-        {}
-      );
+      const testTreeItem = getTestConnectionTreeItem();
 
       const inputBoxResolvesStub = sandbox.stub();
       inputBoxResolvesStub.onCall(0).resolves(/* Return undefined. */);
@@ -985,14 +842,11 @@ suite('MDBExtensionController Test Suite', function () {
         'mdb.renameConnection',
         testTreeItem
       );
-      assert(
-        successfullyRenamed === false,
-        'Expected the rename connection command handler to return a false succeeded response'
-      );
-      assert(
+      assert.strictEqual(successfullyRenamed, false);
+      assert.strictEqual(
         mdbTestExtension.testExtensionController._connectionController
-          ._connections.blueBerryPancakesAndTheSmellOfBacon.name === 'NAAAME',
-        'Expected connection not to be ranamed.'
+          ._connections.blueBerryPancakesAndTheSmellOfBacon.name,
+        'NAAAME'
       );
       mdbTestExtension.testExtensionController._connectionController.clearAllConnections();
     });
@@ -1006,14 +860,7 @@ suite('MDBExtensionController Test Suite', function () {
           storageLocation: StorageLocation.NONE,
         };
 
-      const testTreeItem = new ConnectionTreeItem(
-        'blueBerryPancakesAndTheSmellOfBacon',
-        vscode.TreeItemCollapsibleState.None,
-        false,
-        mdbTestExtension.testExtensionController._connectionController,
-        false,
-        {}
-      );
+      const testTreeItem = getTestConnectionTreeItem();
       const inputBoxResolvesStub = sandbox.stub();
       inputBoxResolvesStub.onCall(0).resolves('orange juice');
       sandbox.replace(vscode.window, 'showInputBox', inputBoxResolvesStub);
@@ -1081,13 +928,9 @@ suite('MDBExtensionController Test Suite', function () {
         fakeGetActiveDataService
       );
 
-      const documentItem = new DocumentTreeItem(
-        mockDocument,
-        'waffle.house',
-        0,
-        {} as DataService,
-        () => Promise.resolve()
-      );
+      const documentItem = getTestDocumentTreeItem({
+        document: mockDocument,
+      });
       await vscode.commands.executeCommand(
         'mdb.openMongoDBDocumentFromTree',
         documentItem
@@ -1132,13 +975,9 @@ suite('MDBExtensionController Test Suite', function () {
           $time: '12345',
         },
       };
-      const documentItem = new DocumentTreeItem(
-        mockDocument,
-        'waffle.house',
-        0,
-        {} as DataService,
-        () => Promise.resolve()
-      );
+      const documentItem = getTestDocumentTreeItem({
+        document: mockDocument,
+      });
       const fakeFetchDocument = sandbox.fake.resolves(null);
       sandbox.replace(
         mdbTestExtension.testExtensionController._editorsController
@@ -1357,13 +1196,10 @@ suite('MDBExtensionController Test Suite', function () {
           return Promise.resolve([mockDocument]);
         },
       } as Pick<DataService, 'find'> as unknown as DataService;
-      const documentTreeItem = new DocumentTreeItem(
-        mockDocument,
-        'waffle.house',
-        0,
-        dataServiceStub,
-        () => Promise.resolve()
-      );
+      const documentTreeItem = getTestDocumentTreeItem({
+        dataService: dataServiceStub,
+      });
+
       const fakeWriteText = sandbox.fake();
       sandbox.replaceGetter(vscode.env, 'clipboard', () => ({
         writeText: fakeWriteText,
@@ -1399,13 +1235,10 @@ suite('MDBExtensionController Test Suite', function () {
           return Promise.resolve([mockDocument]);
         },
       } as unknown as DataService;
-      const documentTreeItem = new DocumentTreeItem(
-        mockDocument,
-        'waffle.house',
-        0,
-        dataServiceStub,
-        () => Promise.resolve()
-      );
+      const documentTreeItem = getTestDocumentTreeItem({
+        document: mockDocument,
+        dataService: dataServiceStub,
+      });
       const fakeCreatePlaygroundForCloneDocument = sandbox.fake();
       sandbox.replace(
         mdbTestExtension.testExtensionController._playgroundController,
@@ -1437,17 +1270,13 @@ suite('MDBExtensionController Test Suite', function () {
     });
 
     test('mdb.insertDocumentFromTreeView opens a playground with an insert document template', async () => {
-      const collectionTreeItem = new CollectionTreeItem(
-        {
+      const collectionTreeItem = getTestCollectionTreeItem({
+        collection: {
           name: 'pineapple',
           type: CollectionTypes.collection,
         },
-        'plants',
-        {},
-        false,
-        false,
-        null
-      );
+        databaseName: 'plants',
+      });
       const fakeCreatePlaygroundForInsertDocument = sandbox.fake();
       sandbox.replace(
         mdbTestExtension.testExtensionController._playgroundController,
@@ -1489,13 +1318,10 @@ suite('MDBExtensionController Test Suite', function () {
           });
         },
       } as unknown as DataService;
-      const documentTreeItem = new DocumentTreeItem(
-        mockDocument,
-        'waffle.house',
-        0,
-        dataServiceStub,
-        () => Promise.resolve()
-      );
+      const documentTreeItem = getTestDocumentTreeItem({
+        document: mockDocument,
+        dataService: dataServiceStub,
+      });
       const result = await vscode.commands.executeCommand(
         'mdb.deleteDocumentFromTreeView',
         documentTreeItem
@@ -1528,13 +1354,10 @@ suite('MDBExtensionController Test Suite', function () {
           });
         },
       } as unknown as DataService;
-      const documentTreeItem = new DocumentTreeItem(
-        mockDocument,
-        'waffle.house',
-        0,
-        dataServiceStub,
-        () => Promise.resolve()
-      );
+      const documentTreeItem = getTestDocumentTreeItem({
+        document: mockDocument,
+        dataService: dataServiceStub,
+      });
       const result = await vscode.commands.executeCommand(
         'mdb.deleteDocumentFromTreeView',
         documentTreeItem

--- a/src/test/suite/telemetry/telemetryService.test.ts
+++ b/src/test/suite/telemetry/telemetryService.test.ts
@@ -571,13 +571,13 @@ suite('Telemetry Controller Test Suite', () => {
     });
 
     test('track on create collection', async () => {
-      const testDatabaseTreeItem = new DatabaseTreeItem(
-        'databaseName',
-        new DataServiceStub(),
-        false,
-        false,
-        {}
-      );
+      const testDatabaseTreeItem = new DatabaseTreeItem({
+        databaseName: 'databaseName',
+        dataService: new DataServiceStub() as unknown as DataService,
+        isExpanded: false,
+        cacheIsUpToDate: false,
+        childrenCache: {},
+      });
       await vscode.commands.executeCommand(
         'mdb.addCollection',
         testDatabaseTreeItem
@@ -643,13 +643,13 @@ suite('Telemetry Controller Test Suite', () => {
           return Promise.resolve([mockDocument]);
         },
       } as Pick<DataService, 'find'> as unknown as DataService;
-      const documentItem = new DocumentTreeItem(
-        mockDocument,
-        'waffle.house',
-        0,
-        dataServiceStub,
-        () => Promise.resolve()
-      );
+      const documentItem = new DocumentTreeItem({
+        document: mockDocument,
+        namespace: 'waffle.house',
+        documentIndexInTree: 0,
+        dataService: dataServiceStub,
+        resetDocumentListCache: () => Promise.resolve(),
+      });
       await vscode.commands.executeCommand(
         'mdb.cloneDocumentFromTreeView',
         documentItem

--- a/src/test/suite/views/webviewController.test.ts
+++ b/src/test/suite/views/webviewController.test.ts
@@ -40,11 +40,14 @@ suite('Webview Test Suite', () => {
       fakeVSCodeCreateWebviewPanel
     );
 
-    const testWebviewController = new WebviewController(
-      mdbTestExtension.testExtensionController._connectionController,
-      mdbTestExtension.testExtensionController._storageController,
-      mdbTestExtension.testExtensionController._telemetryService
-    );
+    const testWebviewController = new WebviewController({
+      connectionController:
+        mdbTestExtension.testExtensionController._connectionController,
+      storageController:
+        mdbTestExtension.testExtensionController._storageController,
+      telemetryService:
+        mdbTestExtension.testExtensionController._telemetryService,
+    });
 
     void testWebviewController.openWebview(
       mdbTestExtension.extensionContextStub
@@ -121,11 +124,11 @@ suite('Webview Test Suite', () => {
       testStorageController,
       extensionContextStub
     );
-    const testConnectionController = new ConnectionController(
-      new StatusView(extensionContextStub),
-      testStorageController,
-      testTelemetryService
-    );
+    const testConnectionController = new ConnectionController({
+      statusView: new StatusView(extensionContextStub),
+      storageController: testStorageController,
+      telemetryService: testTelemetryService,
+    });
     let messageReceivedSet = false;
     let messageReceived;
     const fakeWebview = {
@@ -157,11 +160,11 @@ suite('Webview Test Suite', () => {
       fakeVSCodeCreateWebviewPanel
     );
 
-    const testWebviewController = new WebviewController(
-      testConnectionController,
-      testStorageController,
-      testTelemetryService
-    );
+    const testWebviewController = new WebviewController({
+      connectionController: testConnectionController,
+      storageController: testStorageController,
+      telemetryService: testTelemetryService,
+    });
 
     void testWebviewController.openWebview(
       mdbTestExtension.extensionContextStub
@@ -190,11 +193,11 @@ suite('Webview Test Suite', () => {
       testStorageController,
       extensionContextStub
     );
-    const testConnectionController = new ConnectionController(
-      new StatusView(extensionContextStub),
-      testStorageController,
-      testTelemetryService
-    );
+    const testConnectionController = new ConnectionController({
+      statusView: new StatusView(extensionContextStub),
+      storageController: testStorageController,
+      telemetryService: testTelemetryService,
+    });
     let messageReceivedSet = false;
     let messageReceived;
     const fakeWebview = {
@@ -226,11 +229,11 @@ suite('Webview Test Suite', () => {
       fakeVSCodeCreateWebviewPanel
     );
 
-    const testWebviewController = new WebviewController(
-      testConnectionController,
-      testStorageController,
-      testTelemetryService
-    );
+    const testWebviewController = new WebviewController({
+      connectionController: testConnectionController,
+      storageController: testStorageController,
+      telemetryService: testTelemetryService,
+    });
 
     void testWebviewController.openWebview(
       mdbTestExtension.extensionContextStub
@@ -259,11 +262,11 @@ suite('Webview Test Suite', () => {
       testStorageController,
       extensionContextStub
     );
-    const testConnectionController = new ConnectionController(
-      new StatusView(extensionContextStub),
-      testStorageController,
-      testTelemetryService
-    );
+    const testConnectionController = new ConnectionController({
+      statusView: new StatusView(extensionContextStub),
+      storageController: testStorageController,
+      telemetryService: testTelemetryService,
+    });
     let messageReceived;
     const fakeWebview = {
       html: '',
@@ -289,11 +292,11 @@ suite('Webview Test Suite', () => {
       fakeVSCodeCreateWebviewPanel
     );
 
-    const testWebviewController = new WebviewController(
-      testConnectionController,
-      testStorageController,
-      testTelemetryService
-    );
+    const testWebviewController = new WebviewController({
+      connectionController: testConnectionController,
+      storageController: testStorageController,
+      telemetryService: testTelemetryService,
+    });
 
     void testWebviewController.openWebview(
       mdbTestExtension.extensionContextStub
@@ -318,11 +321,11 @@ suite('Webview Test Suite', () => {
       testStorageController,
       extensionContextStub
     );
-    const testConnectionController = new ConnectionController(
-      new StatusView(extensionContextStub),
-      testStorageController,
-      testTelemetryService
-    );
+    const testConnectionController = new ConnectionController({
+      statusView: new StatusView(extensionContextStub),
+      storageController: testStorageController,
+      telemetryService: testTelemetryService,
+    });
     let messageReceived;
     const fakeWebview = {
       html: '',
@@ -350,11 +353,11 @@ suite('Webview Test Suite', () => {
       'createWebviewPanel',
       fakeVSCodeCreateWebviewPanel
     );
-    const testWebviewController = new WebviewController(
-      testConnectionController,
-      testStorageController,
-      testTelemetryService
-    );
+    const testWebviewController = new WebviewController({
+      connectionController: testConnectionController,
+      storageController: testStorageController,
+      telemetryService: testTelemetryService,
+    });
     void testWebviewController.openWebview(
       mdbTestExtension.extensionContextStub
     );
@@ -383,11 +386,11 @@ suite('Webview Test Suite', () => {
       testStorageController,
       extensionContextStub
     );
-    const testConnectionController = new ConnectionController(
-      new StatusView(extensionContextStub),
-      testStorageController,
-      testTelemetryService
-    );
+    const testConnectionController = new ConnectionController({
+      statusView: new StatusView(extensionContextStub),
+      storageController: testStorageController,
+      telemetryService: testTelemetryService,
+    });
     const fakeVSCodeOpenDialog = sinon.fake.resolves({
       path: '/somefilepath/test.text',
     });
@@ -419,11 +422,11 @@ suite('Webview Test Suite', () => {
 
     sinon.replace(vscode.window, 'showOpenDialog', fakeVSCodeOpenDialog);
 
-    const testWebviewController = new WebviewController(
-      testConnectionController,
-      testStorageController,
-      testTelemetryService
-    );
+    const testWebviewController = new WebviewController({
+      connectionController: testConnectionController,
+      storageController: testStorageController,
+      telemetryService: testTelemetryService,
+    });
 
     void testWebviewController.openWebview(
       mdbTestExtension.extensionContextStub
@@ -443,11 +446,11 @@ suite('Webview Test Suite', () => {
       testStorageController,
       extensionContextStub
     );
-    const testConnectionController = new ConnectionController(
-      new StatusView(extensionContextStub),
-      testStorageController,
-      testTelemetryService
-    );
+    const testConnectionController = new ConnectionController({
+      statusView: new StatusView(extensionContextStub),
+      storageController: testStorageController,
+      telemetryService: testTelemetryService,
+    });
     let messageReceived;
     const fakeWebview = {
       html: '',
@@ -486,11 +489,11 @@ suite('Webview Test Suite', () => {
 
     sinon.replace(vscode.window, 'showOpenDialog', fakeVSCodeOpenDialog);
 
-    const testWebviewController = new WebviewController(
-      testConnectionController,
-      testStorageController,
-      testTelemetryService
-    );
+    const testWebviewController = new WebviewController({
+      connectionController: testConnectionController,
+      storageController: testStorageController,
+      telemetryService: testTelemetryService,
+    });
 
     void testWebviewController.openWebview(
       mdbTestExtension.extensionContextStub
@@ -509,11 +512,11 @@ suite('Webview Test Suite', () => {
       testStorageController,
       extensionContextStub
     );
-    const testConnectionController = new ConnectionController(
-      new StatusView(extensionContextStub),
-      testStorageController,
-      testTelemetryService
-    );
+    const testConnectionController = new ConnectionController({
+      statusView: new StatusView(extensionContextStub),
+      storageController: testStorageController,
+      telemetryService: testTelemetryService,
+    });
     let messageReceived;
     const fakeWebview = {
       html: '',
@@ -536,11 +539,11 @@ suite('Webview Test Suite', () => {
       fakeVSCodeCreateWebviewPanel
     );
 
-    const testWebviewController = new WebviewController(
-      testConnectionController,
-      testStorageController,
-      testTelemetryService
-    );
+    const testWebviewController = new WebviewController({
+      connectionController: testConnectionController,
+      storageController: testStorageController,
+      telemetryService: testTelemetryService,
+    });
 
     void testWebviewController.openWebview(
       mdbTestExtension.extensionContextStub
@@ -567,11 +570,11 @@ suite('Webview Test Suite', () => {
       testStorageController,
       extensionContextStub
     );
-    const testConnectionController = new ConnectionController(
-      new StatusView(extensionContextStub),
-      testStorageController,
-      testTelemetryService
-    );
+    const testConnectionController = new ConnectionController({
+      statusView: new StatusView(extensionContextStub),
+      storageController: testStorageController,
+      telemetryService: testTelemetryService,
+    });
     let messageReceived;
     const fakeWebview = {
       html: '',
@@ -597,11 +600,11 @@ suite('Webview Test Suite', () => {
       fakeVSCodeCreateWebviewPanel
     );
 
-    const testWebviewController = new WebviewController(
-      testConnectionController,
-      testStorageController,
-      testTelemetryService
-    );
+    const testWebviewController = new WebviewController({
+      connectionController: testConnectionController,
+      storageController: testStorageController,
+      telemetryService: testTelemetryService,
+    });
 
     void testWebviewController.openWebview(
       mdbTestExtension.extensionContextStub
@@ -620,11 +623,11 @@ suite('Webview Test Suite', () => {
       testStorageController,
       extensionContextStub
     );
-    const testConnectionController = new ConnectionController(
-      new StatusView(extensionContextStub),
-      testStorageController,
-      testTelemetryService
-    );
+    const testConnectionController = new ConnectionController({
+      statusView: new StatusView(extensionContextStub),
+      storageController: testStorageController,
+      telemetryService: testTelemetryService,
+    });
     let messageReceived;
     const fakeWebview = {
       html: '',
@@ -651,11 +654,11 @@ suite('Webview Test Suite', () => {
       fakeVSCodeCreateWebviewPanel
     );
 
-    const testWebviewController = new WebviewController(
-      testConnectionController,
-      testStorageController,
-      testTelemetryService
-    );
+    const testWebviewController = new WebviewController({
+      connectionController: testConnectionController,
+      storageController: testStorageController,
+      telemetryService: testTelemetryService,
+    });
 
     void testWebviewController.openWebview(
       mdbTestExtension.extensionContextStub
@@ -678,11 +681,11 @@ suite('Webview Test Suite', () => {
       testStorageController,
       extensionContextStub
     );
-    const testConnectionController = new ConnectionController(
-      new StatusView(extensionContextStub),
-      testStorageController,
-      testTelemetryService
-    );
+    const testConnectionController = new ConnectionController({
+      statusView: new StatusView(extensionContextStub),
+      storageController: testStorageController,
+      telemetryService: testTelemetryService,
+    });
     let messageReceived;
     const fakeWebview = {
       html: '',
@@ -710,11 +713,11 @@ suite('Webview Test Suite', () => {
       mockRenameConnectionOnConnectionController
     );
 
-    const testWebviewController = new WebviewController(
-      testConnectionController,
-      testStorageController,
-      testTelemetryService
-    );
+    const testWebviewController = new WebviewController({
+      connectionController: testConnectionController,
+      storageController: testStorageController,
+      telemetryService: testTelemetryService,
+    });
 
     void testWebviewController.openWebview(
       mdbTestExtension.extensionContextStub
@@ -753,11 +756,11 @@ suite('Webview Test Suite', () => {
     let testWebviewController;
 
     beforeEach(() => {
-      testConnectionController = new ConnectionController(
-        new StatusView(extensionContextStub),
-        testStorageController,
-        testTelemetryService
-      );
+      testConnectionController = new ConnectionController({
+        statusView: new StatusView(extensionContextStub),
+        storageController: testStorageController,
+        telemetryService: testTelemetryService,
+      });
 
       fakeWebview = {
         html: '',
@@ -777,11 +780,11 @@ suite('Webview Test Suite', () => {
         fakeVSCodeCreateWebviewPanel
       );
 
-      testWebviewController = new WebviewController(
-        testConnectionController,
-        testStorageController,
-        testTelemetryService
-      );
+      testWebviewController = new WebviewController({
+        connectionController: testConnectionController,
+        storageController: testStorageController,
+        telemetryService: testTelemetryService,
+      });
 
       testWebviewController.openWebview(mdbTestExtension.extensionContextStub);
     });

--- a/src/views/webviewController.ts
+++ b/src/views/webviewController.ts
@@ -81,11 +81,15 @@ export default class WebviewController {
   _storageController: StorageController;
   _telemetryService: TelemetryService;
 
-  constructor(
-    connectionController: ConnectionController,
-    storageController: StorageController,
-    telemetryService: TelemetryService
-  ) {
+  constructor({
+    connectionController,
+    storageController,
+    telemetryService,
+  }: {
+    connectionController: ConnectionController;
+    storageController: StorageController;
+    telemetryService: TelemetryService;
+  }) {
     this._connectionController = connectionController;
     this._storageController = storageController;
     this._telemetryService = telemetryService;


### PR DESCRIPTION
VSCODE-441

In a good number of classes in the extension's source we pass a lot of arguments in the constructors. To make things easier to refactor and reason about, this pr updates those classes instead pass an object we deconstruct in these places.

A bit of drive-by test cleanup and refactoring as well with the goal of making things simpler. Still a whole lot we could do here, this should help a bit.