### PR TITLE
chore: added migration step to migrate keytar secrets to vscode SecretStorage - VSCODE-435

### DIFF
--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -166,7 +166,7 @@ export default class ConnectionController {
 
     if (connectionsWithSecretsInKeytar.length) {
       log.error(
-        'Could not migrate secrets for a few connections',
+        `Could not migrate secrets for ${connectionsWithSecretsInKeytar.length} connections`,
         connectionsWithSecretsInKeytar
       );
       this._telemetryService.track(
@@ -178,7 +178,7 @@ export default class ConnectionController {
       );
       void vscode.window.showInformationMessage(
         [
-          'Could not migrate secrets for a few connections. Please review the following connections:',
+          `Could not migrate secrets for ${connectionsWithSecretsInKeytar.length} connections. Please review the following connections:`,
           connectionsWithSecretsInKeytar
             .map(({ connectionName }) => connectionName)
             .join(', '),

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -4,7 +4,6 @@ import {
   ConnectionInfo,
   ConnectionOptions,
   getConnectionTitle,
-  ConnectionSecrets,
   extractSecrets,
   mergeSecrets,
   connect,
@@ -22,11 +21,13 @@ import formatError from './utils/formatError';
 import LegacyConnectionModel from './views/webview-app/connection-model/legacy-connection-model';
 import {
   StorageLocation,
-  ConnectionsFromStorage,
+  SecretStorageLocation,
 } from './storage/storageController';
 import { StorageController, StorageVariables } from './storage';
 import { StatusView } from './views';
-import TelemetryService from './telemetry/telemetryService';
+import TelemetryService, {
+  TelemetryEventTypes,
+} from './telemetry/telemetryService';
 import LINKS from './utils/links';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const packageJSON = require('../package.json');
@@ -50,6 +51,7 @@ export interface StoreConnectionInfo {
   id: string; // Connection model id or a new uuid.
   name: string; // Possibly user given name, not unique.
   storageLocation: StorageLocation;
+  secretStorageLocation?: SecretStorageLocation;
   connectionOptions?: ConnectionOptions;
   connectionModel?: LegacyConnectionModel;
 }
@@ -69,20 +71,24 @@ interface ConnectionQuickPicks {
   data: { type: NewConnectionType; connectionId?: string };
 }
 
-interface ConnectionSecretsInfo {
-  connectionId: string;
-  secrets: ConnectionSecrets;
-}
+type StoreConnectionInfoWithConnectionModel = StoreConnectionInfo &
+  Required<Pick<StoreConnectionInfo, 'connectionModel'>>;
 
 type StoreConnectionInfoWithConnectionOptions = StoreConnectionInfo &
   Required<Pick<StoreConnectionInfo, 'connectionOptions'>>;
+
+type MigratedStoreConnectionInfo = StoreConnectionInfo &
+  Required<Pick<StoreConnectionInfo, 'secretStorageLocation'>>;
+
+type MigratedStoreConnectionInfoWithConnectionOptions =
+  StoreConnectionInfoWithConnectionOptions & MigratedStoreConnectionInfo;
 
 export default class ConnectionController {
   // This is a map of connection ids to their configurations.
   // These connections can be saved on the session (runtime),
   // on the workspace, or globally in vscode.
   _connections: {
-    [connectionId: string]: StoreConnectionInfoWithConnectionOptions;
+    [connectionId: string]: MigratedStoreConnectionInfoWithConnectionOptions;
   } = {};
   _activeDataService: DataService | null = null;
   _storageController: StorageController;
@@ -116,142 +122,185 @@ export default class ConnectionController {
     this._telemetryService = telemetryService;
   }
 
-  async _migratePreviouslySavedConnection(
-    savedConnectionInfo: StoreConnectionInfo
-  ): Promise<StoreConnectionInfoWithConnectionOptions> {
-    if (!savedConnectionInfo.connectionModel) {
-      throw new Error(
-        'The connectionModel object is missing in saved connection info.'
+  async loadSavedConnections(): Promise<void> {
+    const globalAndWorkspaceConnections = {
+      ...this._storageController.get(
+        StorageVariables.GLOBAL_SAVED_CONNECTIONS,
+        StorageLocation.GLOBAL
+      ),
+      ...this._storageController.get(
+        StorageVariables.WORKSPACE_SAVED_CONNECTIONS,
+        StorageLocation.WORKSPACE
+      ),
+    };
+
+    let connectionsDidChange = false;
+    const connectionsWithSecretsInKeytar: Array<{
+      connectionId: string;
+      connectionName: string;
+    }> = [];
+    const totalConnectionEntries = Object.entries(
+      globalAndWorkspaceConnections
+    );
+    for (const [connectionId, connectionInfo] of totalConnectionEntries) {
+      const connectionInfoWithSecret = await this._getConnectionInfoWithSecrets(
+        connectionInfo
       );
+
+      if (connectionInfoWithSecret) {
+        connectionsDidChange = true;
+        this._connections[connectionId] = connectionInfoWithSecret;
+
+        if (
+          connectionInfoWithSecret.secretStorageLocation ===
+          SecretStorageLocation.Keytar
+        ) {
+          connectionsWithSecretsInKeytar.push({
+            connectionId,
+            connectionName: connectionInfo.name,
+          });
+        }
+      }
     }
 
+    if (connectionsDidChange) {
+      this.eventEmitter.emit(DataServiceEventTypes.CONNECTIONS_DID_CHANGE);
+    }
+
+    if (connectionsWithSecretsInKeytar.length) {
+      log.error('Could not migrate secrets for a few connections', connectionsWithSecretsInKeytar);
+      this._telemetryService.track(
+        TelemetryEventTypes.KEYTAR_SECRETS_MIGRATION_FAILED,
+        {
+          totalConnections: totalConnectionEntries.length,
+          connectionsWithSecretsInKeytar: connectionsWithSecretsInKeytar.length,
+        }
+      );
+      void vscode.window.showInformationMessage(
+        [
+          'Could not migrate secrets for a few connections. Please review the following connections:',
+          connectionsWithSecretsInKeytar
+            .map(({ connectionName }) => connectionName)
+            .join(', '),
+        ].join('\n')
+      );
+    }
+  }
+
+  async _getConnectionInfoWithSecrets(
+    connectionInfo: StoreConnectionInfo
+  ): Promise<MigratedStoreConnectionInfoWithConnectionOptions | undefined> {
+    try {
+      if (connectionInfo.connectionModel) {
+        return this._migratePreviouslySavedConnection(
+          connectionInfo as StoreConnectionInfoWithConnectionModel
+        );
+      }
+
+      if (!connectionInfo.secretStorageLocation) {
+        return this._migrateKeytarSecrets(
+          connectionInfo as StoreConnectionInfoWithConnectionOptions
+        );
+      }
+
+      // We tried migrating this connection earlier but failed because Keytar was not
+      // available. So we return simply the connection without secrets.
+      if (
+        connectionInfo.secretStorageLocation === SecretStorageLocation.Keytar
+      ) {
+        return connectionInfo as MigratedStoreConnectionInfoWithConnectionOptions;
+      }
+
+      const unparsedSecrets =
+        (await this._storageController.getSecret(connectionInfo.id)) ?? '';
+
+      return this._mergedConnectionInfoWithSecrets(
+        connectionInfo as MigratedStoreConnectionInfoWithConnectionOptions,
+        unparsedSecrets
+      );
+    } catch (error) {
+      log.error('Error while retrieving connection info', error);
+      return undefined;
+    }
+  }
+
+  async _migratePreviouslySavedConnection(
+    savedConnectionInfo: StoreConnectionInfoWithConnectionModel
+  ): Promise<MigratedStoreConnectionInfoWithConnectionOptions | undefined> {
     // Transform a raw connection model from storage to an ampersand model.
     const newConnectionInfoWithSecrets = convertConnectionModelToInfo(
       savedConnectionInfo.connectionModel
     );
 
-    // Further use connectionOptions instead of connectionModel.
-    const newSavedConnectionInfoWithSecrets = {
+    const connectionInfoWithSecret = {
       id: savedConnectionInfo.id,
       name: savedConnectionInfo.name,
       storageLocation: savedConnectionInfo.storageLocation,
+      secretStorageLocation: SecretStorageLocation.SecretStorage,
       connectionOptions: newConnectionInfoWithSecrets.connectionOptions,
     };
 
-    await this._saveConnection(newSavedConnectionInfoWithSecrets);
-
-    return newSavedConnectionInfoWithSecrets;
+    await this._saveConnectionWithSecret(connectionInfoWithSecret);
+    return connectionInfoWithSecret;
   }
 
-  async _getConnectionInfoWithSecrets(
-    savedConnectionInfo: StoreConnectionInfo
-  ): Promise<StoreConnectionInfoWithConnectionOptions | undefined> {
-    // Migrate previously saved connections to a new format.
-    // Save only secrets to keychain.
-    // Remove connectionModel and use connectionOptions instead.
-    if (savedConnectionInfo.connectionModel) {
-      try {
-        return await this._migratePreviouslySavedConnection(
-          savedConnectionInfo
-        );
-      } catch (error) {
-        // Here we're lenient when loading connections in case their
-        // connections have become corrupted.
-        log.error('Migrating previously saved connections failed', error);
-        return;
-      }
-    }
-
-    // If connection has a new format already and keytar module is undefined.
-    // Return saved connection as it is.
+  async _migrateKeytarSecrets(
+    savedConnectionInfo: StoreConnectionInfoWithConnectionOptions
+  ): Promise<MigratedStoreConnectionInfoWithConnectionOptions | undefined> {
+    // If the Keytar module is not available, we simply mark the connections
+    // storage as Keytar and return
     if (!ext.keytarModule) {
-      log.error(
-        'Getting connection info with secrets failed because VSCode extension keytar module is undefined'
+      log.error('Could not migrate Keytar secrets, module not found');
+      return await this._storageController.saveConnection<MigratedStoreConnectionInfoWithConnectionOptions>(
+        {
+          ...savedConnectionInfo,
+          secretStorageLocation: SecretStorageLocation.Keytar,
+        }
       );
-      return savedConnectionInfo as StoreConnectionInfoWithConnectionOptions;
     }
 
-    try {
-      const unparsedSecrets = await ext.keytarModule.getPassword(
+    // If there is nothing in keytar, we will save an empty object as secrets in
+    // new storage and mark this connection as migrated
+    const keytarSecrets =
+      (await ext.keytarModule.getPassword(
         this._serviceName,
         savedConnectionInfo.id
-      );
+      )) || '{}';
 
-      // Ignore empty secrets.
-      if (!unparsedSecrets) {
-        return savedConnectionInfo as StoreConnectionInfoWithConnectionOptions;
-      }
-
-      const secrets = JSON.parse(unparsedSecrets);
-      const connectionOptions = savedConnectionInfo.connectionOptions;
-      const connectionInfoWithSecrets = mergeSecrets(
+    const migratedConnectionInfoWithSecrets =
+      this._mergedConnectionInfoWithSecrets(
         {
-          id: savedConnectionInfo.id,
-          connectionOptions,
-        } as ConnectionInfo,
-        secrets
+          ...savedConnectionInfo,
+          secretStorageLocation: SecretStorageLocation.SecretStorage,
+        },
+        keytarSecrets
       );
 
-      return {
-        ...savedConnectionInfo,
-        connectionOptions: connectionInfoWithSecrets.connectionOptions,
-      };
-    } catch (error) {
-      // Here we're lenient when loading connections in case their
-      // connections have become corrupted.
-      log.error('Getting connection info with secrets failed', error);
-      return;
-    }
+    await this._saveConnectionWithSecret(migratedConnectionInfoWithSecrets);
+
+    return migratedConnectionInfoWithSecrets;
   }
 
-  private async _loadSavedConnectionsByStore(
-    savedConnections: ConnectionsFromStorage
-  ): Promise<void> {
-    if (!savedConnections || !Object.keys(savedConnections).length) {
-      return;
+  _mergedConnectionInfoWithSecrets<
+    T extends StoreConnectionInfoWithConnectionOptions
+  >(connectionInfo: T, unparsedSecrets: string) {
+    if (!unparsedSecrets) {
+      return connectionInfo;
     }
 
-    /** User connections are being saved both in:
-     * 1. Vscode global/workspace storage (without secrets) + keychain (secrets)
-     * 2. Memory of the extension (with secrets)
-     */
-    await Promise.all(
-      Object.keys(savedConnections).map(async (connectionId) => {
-        // Get connection info from vscode storage and merge with secrets.
-        const connectionInfoWithSecrets =
-          await this._getConnectionInfoWithSecrets(
-            savedConnections[connectionId]
-          );
-
-        // Save connection info with secrets to extension memory.
-        if (connectionInfoWithSecrets) {
-          this._connections[connectionId] = connectionInfoWithSecrets;
-        }
-
-        this.eventEmitter.emit(DataServiceEventTypes.CONNECTIONS_DID_CHANGE);
-      })
+    const secrets = JSON.parse(unparsedSecrets);
+    const connectionInfoWithSecrets = mergeSecrets(
+      {
+        id: connectionInfo.id,
+        connectionOptions: connectionInfo.connectionOptions,
+      } as ConnectionInfo,
+      secrets
     );
-  }
 
-  async loadSavedConnections(): Promise<void> {
-    await Promise.all([
-      (async () => {
-        // Try to pull in the connections previously saved in the global storage of vscode.
-        const existingGlobalConnections = this._storageController.get(
-          StorageVariables.GLOBAL_SAVED_CONNECTIONS,
-          StorageLocation.GLOBAL
-        );
-        await this._loadSavedConnectionsByStore(existingGlobalConnections);
-      })(),
-      (async () => {
-        // Try to pull in the connections previously saved in the workspace storage of vscode.
-        const existingWorkspaceConnections = this._storageController.get(
-          StorageVariables.WORKSPACE_SAVED_CONNECTIONS,
-          StorageLocation.WORKSPACE
-        );
-        await this._loadSavedConnectionsByStore(existingWorkspaceConnections);
-      })(),
-    ]);
+    return {
+      ...connectionInfo,
+      connectionOptions: connectionInfoWithSecrets.connectionOptions,
+    };
   }
 
   async connectWithURI(): Promise<boolean> {
@@ -353,26 +402,9 @@ export default class ConnectionController {
     });
   }
 
-  private async _saveSecretsToKeychain({
-    connectionId,
-    secrets,
-  }: ConnectionSecretsInfo): Promise<void> {
-    if (!ext.keytarModule) {
-      return;
-    }
-
-    const secretsAsString = JSON.stringify(secrets);
-
-    await ext.keytarModule.setPassword(
-      this._serviceName,
-      connectionId,
-      secretsAsString
-    );
-  }
-
-  private async _saveConnection(
-    newStoreConnectionInfoWithSecrets: StoreConnectionInfo
-  ): Promise<StoreConnectionInfo> {
+  private async _saveConnectionWithSecret(
+    newStoreConnectionInfoWithSecrets: MigratedStoreConnectionInfoWithConnectionOptions
+  ): Promise<MigratedStoreConnectionInfoWithConnectionOptions> {
     // We don't want to store secrets to disc.
     const { connectionInfo: safeConnectionInfo, secrets } = extractSecrets(
       newStoreConnectionInfoWithSecrets as ConnectionInfo
@@ -381,11 +413,10 @@ export default class ConnectionController {
       ...newStoreConnectionInfoWithSecrets,
       connectionOptions: safeConnectionInfo.connectionOptions, // The connection info without secrets.
     });
-
-    await this._saveSecretsToKeychain({
-      connectionId: savedConnectionInfo.id,
-      secrets, // Only secrets.
-    });
+    await this._storageController.setSecret(
+      savedConnectionInfo.id,
+      JSON.stringify(secrets)
+    );
 
     return savedConnectionInfo;
   }
@@ -401,10 +432,13 @@ export default class ConnectionController {
       // To begin we just store it on the session, the storage controller
       // handles changing this based on user preference.
       storageLocation: StorageLocation.NONE,
+      secretStorageLocation: SecretStorageLocation.SecretStorage,
       connectionOptions: originalConnectionInfo.connectionOptions,
     };
 
-    const savedConnectionInfo = await this._saveConnection(newConnectionInfo);
+    const savedConnectionInfo = await this._saveConnectionWithSecret(
+      newConnectionInfo
+    );
 
     this._connections[savedConnectionInfo.id] = {
       ...savedConnectionInfo,
@@ -596,9 +630,15 @@ export default class ConnectionController {
   }
 
   private async _removeSecretsFromKeychain(connectionId: string) {
+    // Even though we migrated to SecretStorage from keytar, we are still removing
+    // secrets from keytar to make sure that we don't leave any left-overs when a
+    // connection is removed. This block can safely be removed after our migration
+    // has been out for some time.
     if (ext.keytarModule) {
       await ext.keytarModule.deletePassword(this._serviceName, connectionId);
     }
+
+    await this._storageController.deleteSecret(connectionId);
   }
 
   async removeSavedConnection(connectionId: string): Promise<void> {

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -134,7 +134,6 @@ export default class ConnectionController {
       ),
     });
 
-    let connectionsDidChange = false;
     const connectionsWithSecretsInKeytar: Array<{
       connectionId: string;
       connectionName: string;
@@ -145,7 +144,6 @@ export default class ConnectionController {
       );
 
       if (connectionInfoWithSecret) {
-        connectionsDidChange = true;
         this._connections[connectionId] = connectionInfoWithSecret;
 
         if (
@@ -160,7 +158,7 @@ export default class ConnectionController {
       }
     }
 
-    if (connectionsDidChange) {
+    if (Object.keys(this._connections).length) {
       this.eventEmitter.emit(DataServiceEventTypes.CONNECTIONS_DID_CHANGE);
     }
 

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -168,7 +168,10 @@ export default class ConnectionController {
     }
 
     if (connectionsWithSecretsInKeytar.length) {
-      log.error('Could not migrate secrets for a few connections', connectionsWithSecretsInKeytar);
+      log.error(
+        'Could not migrate secrets for a few connections',
+        connectionsWithSecretsInKeytar
+      );
       this._telemetryService.track(
         TelemetryEventTypes.KEYTAR_SECRETS_MIGRATION_FAILED,
         {

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -192,13 +192,13 @@ export default class ConnectionController {
   ): Promise<MigratedStoreConnectionInfoWithConnectionOptions | undefined> {
     try {
       if (connectionInfo.connectionModel) {
-        return this._migratePreviouslySavedConnection(
+        return this._migrateConnectionsWithConnectionModel(
           connectionInfo as StoreConnectionInfoWithConnectionModel
         );
       }
 
       if (!connectionInfo.secretStorageLocation) {
-        return this._migrateKeytarSecrets(
+        return this._migrateConnectionsWithKeytarSecrets(
           connectionInfo as StoreConnectionInfoWithConnectionOptions
         );
       }
@@ -224,7 +224,7 @@ export default class ConnectionController {
     }
   }
 
-  async _migratePreviouslySavedConnection(
+  async _migrateConnectionsWithConnectionModel(
     savedConnectionInfo: StoreConnectionInfoWithConnectionModel
   ): Promise<MigratedStoreConnectionInfoWithConnectionOptions | undefined> {
     // Transform a raw connection model from storage to an ampersand model.
@@ -244,7 +244,7 @@ export default class ConnectionController {
     return connectionInfoWithSecret;
   }
 
-  async _migrateKeytarSecrets(
+  async _migrateConnectionsWithKeytarSecrets(
     savedConnectionInfo: StoreConnectionInfoWithConnectionOptions
   ): Promise<MigratedStoreConnectionInfoWithConnectionOptions | undefined> {
     // If the Keytar module is not available, we simply mark the connections

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -630,6 +630,7 @@ export default class ConnectionController {
   }
 
   private async _removeSecretsFromKeychain(connectionId: string) {
+    await this._storageController.deleteSecret(connectionId);
     // Even though we migrated to SecretStorage from keytar, we are still removing
     // secrets from keytar to make sure that we don't leave any left-overs when a
     // connection is removed. This block can safely be removed after our migration
@@ -637,8 +638,6 @@ export default class ConnectionController {
     if (ext.keytarModule) {
       await ext.keytarModule.deletePassword(this._serviceName, connectionId);
     }
-
-    await this._storageController.deleteSecret(connectionId);
   }
 
   async removeSavedConnection(connectionId: string): Promise<void> {

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -21,6 +21,7 @@ import formatError from './utils/formatError';
 import LegacyConnectionModel from './views/webview-app/connection-model/legacy-connection-model';
 import {
   StorageLocation,
+  SecretStorageLocationType,
   SecretStorageLocation,
 } from './storage/storageController';
 import { StorageController, StorageVariables } from './storage';
@@ -51,7 +52,7 @@ export interface StoreConnectionInfo {
   id: string; // Connection model id or a new uuid.
   name: string; // Possibly user given name, not unique.
   storageLocation: StorageLocation;
-  secretStorageLocation?: SecretStorageLocation;
+  secretStorageLocation?: SecretStorageLocationType;
   connectionOptions?: ConnectionOptions;
   connectionModel?: LegacyConnectionModel;
 }

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -123,7 +123,7 @@ export default class ConnectionController {
   }
 
   async loadSavedConnections(): Promise<void> {
-    const globalAndWorkspaceConnections = {
+    const globalAndWorkspaceConnections = Object.entries({
       ...this._storageController.get(
         StorageVariables.GLOBAL_SAVED_CONNECTIONS,
         StorageLocation.GLOBAL
@@ -132,17 +132,14 @@ export default class ConnectionController {
         StorageVariables.WORKSPACE_SAVED_CONNECTIONS,
         StorageLocation.WORKSPACE
       ),
-    };
+    });
 
     let connectionsDidChange = false;
     const connectionsWithSecretsInKeytar: Array<{
       connectionId: string;
       connectionName: string;
     }> = [];
-    const totalConnectionEntries = Object.entries(
-      globalAndWorkspaceConnections
-    );
-    for (const [connectionId, connectionInfo] of totalConnectionEntries) {
+    for (const [connectionId, connectionInfo] of globalAndWorkspaceConnections) {
       const connectionInfoWithSecret = await this._getConnectionInfoWithSecrets(
         connectionInfo
       );
@@ -175,7 +172,7 @@ export default class ConnectionController {
       this._telemetryService.track(
         TelemetryEventTypes.KEYTAR_SECRETS_MIGRATION_FAILED,
         {
-          totalConnections: totalConnectionEntries.length,
+          totalConnections: globalAndWorkspaceConnections.length,
           connectionsWithSecretsInKeytar: connectionsWithSecretsInKeytar.length,
         }
       );

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -90,6 +90,17 @@ type FailedMigrationConnectionDescriptor = {
   connectionName: string;
 };
 
+export const keytarMigrationFailedMessage = (failedConnections: number) => {
+  // Writing the message this way to keep it readable.
+  return [
+    `Unable to migrate ${failedConnections} of your cluster connections from the deprecated Keytar to the VS Code SecretStorage.`,
+    'Keytar is officially archived and not being maintained.',
+    'In an effort to promote good security practices by not depending on an archived piece of software, VS Code removes Keytar shim in favour of built-in storage utility for secrets.',
+    'Please review your connections and delete or recreate those with missing secrets.',
+    'You can still access your secrets via OS keychain.',
+  ].join(' ');
+};
+
 export default class ConnectionController {
   // This is a map of connection ids to their configurations.
   // These connections can be saved on the session (runtime),
@@ -205,12 +216,7 @@ export default class ConnectionController {
         }
       );
       void vscode.window.showInformationMessage(
-        [
-          `Could not migrate secrets for ${connectionsThatDidNotMigrate.length} connections. Please review the following connections:`,
-          connectionsThatDidNotMigrate
-            .map(({ connectionName }) => connectionName)
-            .join(', '),
-        ].join('\n')
+        keytarMigrationFailedMessage(connectionsThatDidNotMigrate.length)
       );
     }
   }

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -89,7 +89,7 @@ export default class ConnectionController {
   // on the workspace, or globally in vscode.
   _connections: {
     [connectionId: string]: MigratedStoreConnectionInfoWithConnectionOptions;
-  } = {};
+  } = Object.create(null);
   _activeDataService: DataService | null = null;
   _storageController: StorageController;
 

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -220,13 +220,13 @@ export default class ConnectionController {
   ): Promise<MigratedStoreConnectionInfoWithConnectionOptions | undefined> {
     try {
       if (connectionInfo.connectionModel) {
-        return this._migrateConnectionWithConnectionModel(
+        return await this._migrateConnectionWithConnectionModel(
           connectionInfo as StoreConnectionInfoWithConnectionModel
         );
       }
 
       if (!connectionInfo.secretStorageLocation) {
-        return this._migrateConnectionWithKeytarSecrets(
+        return await this._migrateConnectionWithKeytarSecrets(
           connectionInfo as StoreConnectionInfoWithConnectionOptions
         );
       }

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -78,11 +78,12 @@ type StoreConnectionInfoWithConnectionModel = StoreConnectionInfo &
 type StoreConnectionInfoWithConnectionOptions = StoreConnectionInfo &
   Required<Pick<StoreConnectionInfo, 'connectionOptions'>>;
 
-type MigratedStoreConnectionInfo = StoreConnectionInfo &
+type StoreConnectionInfoWithSecretStorageLocation = StoreConnectionInfo &
   Required<Pick<StoreConnectionInfo, 'secretStorageLocation'>>;
 
 type MigratedStoreConnectionInfoWithConnectionOptions =
-  StoreConnectionInfoWithConnectionOptions & MigratedStoreConnectionInfo;
+  StoreConnectionInfoWithConnectionOptions &
+    StoreConnectionInfoWithSecretStorageLocation;
 
 type FailedMigrationConnectionDescriptor = {
   connectionId: string;
@@ -662,8 +663,10 @@ export default class ConnectionController {
     // secrets from keytar to make sure that we don't leave any left-overs when a
     // connection is removed. This block can safely be removed after our migration
     // has been out for some time.
-    if (ext.keytarModule) {
-      await ext.keytarModule.deletePassword(this._serviceName, connectionId);
+    try {
+      await ext.keytarModule?.deletePassword(this._serviceName, connectionId);
+    } catch (error) {
+      log.error('Failed to remove secret from keytar', error);
     }
   }
 

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -293,7 +293,7 @@ export default class ConnectionController {
       {
         id: connectionInfo.id,
         connectionOptions: connectionInfo.connectionOptions,
-      } as ConnectionInfo,
+      },
       secrets
     );
 

--- a/src/storage/storageController.ts
+++ b/src/storage/storageController.ts
@@ -32,10 +32,14 @@ export type ConnectionsFromStorage = {
   [connectionId: string]: StoreConnectionInfo;
 };
 
-export enum SecretStorageLocation {
-  Keytar = 'vscode.Keytar',
-  SecretStorage = 'vscode.SecretStorage',
-}
+export const SecretStorageLocation = {
+  Keytar: 'vscode.Keytar',
+  SecretStorage: 'vscode.SecretStorage',
+} as const;
+
+export type SecretStorageLocationType =
+  | typeof SecretStorageLocation.Keytar
+  | typeof SecretStorageLocation.SecretStorage;
 
 interface StorageVariableContents {
   [StorageVariables.GLOBAL_USER_ID]: string;

--- a/src/storage/storageController.ts
+++ b/src/storage/storageController.ts
@@ -32,6 +32,11 @@ export type ConnectionsFromStorage = {
   [connectionId: string]: StoreConnectionInfo;
 };
 
+export enum SecretStorageLocation {
+  Keytar = 'vscode.Keytar',
+  SecretStorage = 'vscode.SecretStorage',
+}
+
 interface StorageVariableContents {
   [StorageVariables.GLOBAL_USER_ID]: string;
   [StorageVariables.GLOBAL_ANONYMOUS_ID]: string;
@@ -48,11 +53,14 @@ export default class StorageController {
     [StorageLocation.WORKSPACE]: vscode.Memento;
   };
 
+  _secretStorage: vscode.SecretStorage;
+
   constructor(context: vscode.ExtensionContext) {
     this._storage = {
       [StorageLocation.GLOBAL]: context.globalState,
       [StorageLocation.WORKSPACE]: context.workspaceState,
     };
+    this._secretStorage = context.secrets;
   }
 
   get<T extends StoredVariableName>(
@@ -123,9 +131,9 @@ export default class StorageController {
     );
   }
 
-  async saveConnection(
-    storeConnectionInfo: StoreConnectionInfo
-  ): Promise<StoreConnectionInfo> {
+  async saveConnection<T extends StoreConnectionInfo>(
+    storeConnectionInfo: T
+  ): Promise<T> {
     const dontShowSaveLocationPrompt = vscode.workspace
       .getConfiguration('mdb.connectionSaving')
       .get('hideOptionToChooseWhereToSaveNewConnections');
@@ -242,5 +250,18 @@ export default class StorageController {
     }
 
     return StorageLocation.NONE;
+  }
+
+  async getSecret(key: string): Promise<string | null> {
+    return (await this._secretStorage.get(key)) ?? null;
+  }
+
+  async deleteSecret(key: string): Promise<boolean> {
+    await this._secretStorage.delete(key);
+    return true;
+  }
+
+  async setSecret(key: string, value: string): Promise<void> {
+    await this._secretStorage.store(key, value);
   }
 }

--- a/src/telemetry/telemetryService.ts
+++ b/src/telemetry/telemetryService.ts
@@ -70,7 +70,7 @@ type PlaygroundLoadedTelemetryEventProperties = {
 
 type KeytarSecretsMigrationFailedProperties = {
   totalConnections: number;
-  connectionsWithSecretsInKeytar: number;
+  connectionsWithFailedKeytarMigration: number;
 };
 
 export type TelemetryEventProperties =

--- a/src/telemetry/telemetryService.ts
+++ b/src/telemetry/telemetryService.ts
@@ -68,6 +68,11 @@ type PlaygroundLoadedTelemetryEventProperties = {
   file_type?: string;
 };
 
+type KeytarSecretsMigrationFailedProperties = {
+  totalConnections: number;
+  connectionsWithSecretsInKeytar: number;
+};
+
 export type TelemetryEventProperties =
   | PlaygroundTelemetryEventProperties
   | LinkClickedTelemetryEventProperties
@@ -78,7 +83,8 @@ export type TelemetryEventProperties =
   | QueryExportedTelemetryEventProperties
   | PlaygroundCreatedTelemetryEventProperties
   | PlaygroundSavedTelemetryEventProperties
-  | PlaygroundLoadedTelemetryEventProperties;
+  | PlaygroundLoadedTelemetryEventProperties
+  | KeytarSecretsMigrationFailedProperties;
 
 export enum TelemetryEventTypes {
   PLAYGROUND_CODE_EXECUTED = 'Playground Code Executed',
@@ -92,6 +98,7 @@ export enum TelemetryEventTypes {
   QUERY_EXPORTED = 'Query Exported',
   AGGREGATION_EXPORTED = 'Aggregation Exported',
   PLAYGROUND_CREATED = 'Playground Created',
+  KEYTAR_SECRETS_MIGRATION_FAILED = 'Keytar Secrets Migration Failed',
 }
 
 /**

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -1466,7 +1466,7 @@ suite('Connection Controller Test Suite', function () {
           );
         });
 
-        test.only('should be able to load other connections even if the _migrateConnectionWithKeytarSecrets throws', async () => {
+        test('should be able to load other connections even if the _migrateConnectionWithKeytarSecrets throws', async () => {
           // We replace the keytar module with our stub to make sure that later,
           // during migration, we are able to find the secrets in the correct
           // place
@@ -1510,7 +1510,7 @@ suite('Connection Controller Test Suite', function () {
           });
         });
 
-        test.only('should be able to re-attempt migration for connections that failed in previous load and were not marked migrated', async () => {
+        test('should be able to re-attempt migration for connections that failed in previous load and were not marked migrated', async () => {
           // We replace the keytar module with our stub to make sure that later,
           // during migration, we are able to find the secrets in the correct
           // place

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -1296,9 +1296,9 @@ suite('Connection Controller Test Suite', function () {
               await testStorageController.getSecret(savedConnection.id),
               expectedSecret
             );
-            assert(
-              updatedConnection.secretStorageLocation ===
-                SecretStorageLocation.SecretStorage
+            assert.strictEqual(
+              updatedConnection.secretStorageLocation,
+              SecretStorageLocation.SecretStorage
             );
           });
         });
@@ -1358,9 +1358,9 @@ suite('Connection Controller Test Suite', function () {
             await testStorageController.getSecret(savedConnection.id),
             '{}'
           );
-          assert(
-            updatedConnection.secretStorageLocation ===
-              SecretStorageLocation.SecretStorage
+          assert.strictEqual(
+            updatedConnection.secretStorageLocation,
+            SecretStorageLocation.SecretStorage
           );
         });
 
@@ -1403,9 +1403,9 @@ suite('Connection Controller Test Suite', function () {
             await testStorageController.getSecret(savedConnection.id),
             null
           );
-          assert(
-            updatedConnection.secretStorageLocation ===
-              SecretStorageLocation.Keytar
+          assert.strictEqual(
+            updatedConnection.secretStorageLocation,
+            SecretStorageLocation.Keytar
           );
         });
       }
@@ -1426,11 +1426,12 @@ suite('Connection Controller Test Suite', function () {
 
         // By default the connection secrets are already stored in SecretStorage
         const savedConnections = testConnectionController.getSavedConnections();
-        assert(
+        assert.strictEqual(
           savedConnections.every(
             ({ secretStorageLocation }) =>
               secretStorageLocation === SecretStorageLocation.SecretStorage
-          )
+          ),
+          true
         );
 
         await testConnectionController.disconnect();
@@ -1445,10 +1446,11 @@ suite('Connection Controller Test Suite', function () {
         );
 
         // Additionally make sure that we are retrieving secrets properly
-        assert(
+        assert.strictEqual(
           savedConnectionsAfterFreshLoad[1].connectionOptions?.connectionString.includes(
             TEST_USER_PASSWORD
-          )
+          ),
+          true
         );
       });
     });
@@ -1470,7 +1472,7 @@ suite('Connection Controller Test Suite', function () {
       );
 
       await testConnectionController.loadSavedConnections();
-      assert(isConnectionChanged);
+      assert.strictEqual(isConnectionChanged, true);
     });
 
     test('should track and also notify the users of failed keytar secrets migration', async () => {
@@ -1497,7 +1499,7 @@ suite('Connection Controller Test Suite', function () {
       await testConnectionController.loadSavedConnections();
 
       // Notified to user
-      assert(showInformationMessageStub.calledOnce);
+      assert.strictEqual(showInformationMessageStub.calledOnce, true);
       assert.deepStrictEqual(showInformationMessageStub.lastCall.args, [
         [
           'Could not migrate secrets for a few connections. Please review the following connections:',
@@ -1506,7 +1508,7 @@ suite('Connection Controller Test Suite', function () {
       ]);
 
       // Tracked
-      assert(fakeTrack.calledOnce);
+      assert.strictEqual(fakeTrack.calledOnce, true);
       assert.deepStrictEqual(fakeTrack.lastCall.args, [
         'Keytar Secrets Migration Failed',
         { totalConnections: 1, connectionsWithSecretsInKeytar: 1 },

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -9,6 +9,7 @@ import { connect } from 'mongodb-data-service';
 import AUTH_STRATEGY_VALUES from '../../views/webview-app/connection-model/constants/auth-strategies';
 import ConnectionController, {
   DataServiceEventTypes,
+  keytarMigrationFailedMessage,
 } from '../../connectionController';
 import formatError from '../../utils/formatError';
 import { StorageController, StorageVariables } from '../../storage';
@@ -1682,16 +1683,11 @@ suite('Connection Controller Test Suite', function () {
       // Clear any connections and load so we get our stubbed connections from above.
       testConnectionController.clearAllConnections();
       await testConnectionController.loadSavedConnections();
-      const [, secondConnection] =
-        testConnectionController.getSavedConnections();
 
       // Notified to user
       assert.strictEqual(showInformationMessageStub.calledOnce, true);
       assert.deepStrictEqual(showInformationMessageStub.lastCall.args, [
-        [
-          'Could not migrate secrets for 1 connections. Please review the following connections:',
-          secondConnection.name,
-        ].join('\n'),
+        keytarMigrationFailedMessage(1),
       ]);
 
       // Tracked

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -797,7 +797,7 @@ suite('Connection Controller Test Suite', function () {
     assert.strictEqual(testConnectionController.isCurrentlyConnected(), false);
   });
 
-  test('_migratePreviouslySavedConnection converts an old previously saved connection model without secrets to a new connection info format', async () => {
+  test('_migrateConnectionsWithConnectionModel converts an old previously saved connection model without secrets to a new connection info format', async () => {
     const oldSavedConnectionInfo = {
       id: '1d700f37-ba57-4568-9552-0ea23effea89',
       name: 'localhost:27017',
@@ -821,7 +821,7 @@ suite('Connection Controller Test Suite', function () {
       },
     };
     const newSavedConnectionInfoWithSecrets =
-      await testConnectionController._migratePreviouslySavedConnection(
+      await testConnectionController._migrateConnectionsWithConnectionModel(
         oldSavedConnectionInfo
       );
 
@@ -837,7 +837,7 @@ suite('Connection Controller Test Suite', function () {
     });
   });
 
-  test('_migratePreviouslySavedConnection converts an old previously saved connection model with secrets to a new connection info format', async () => {
+  test('_migrateConnectionsWithConnectionModel converts an old previously saved connection model with secrets to a new connection info format', async () => {
     const oldSavedConnectionInfo = {
       id: 'fb210b47-f85d-4823-8552-aa6d7825156b',
       name: 'host.u88dd.test.test',
@@ -874,7 +874,7 @@ suite('Connection Controller Test Suite', function () {
     };
 
     const newSavedConnectionInfoWithSecrets =
-      await testConnectionController._migratePreviouslySavedConnection(
+      await testConnectionController._migrateConnectionsWithConnectionModel(
         oldSavedConnectionInfo
       );
 
@@ -890,7 +890,7 @@ suite('Connection Controller Test Suite', function () {
     });
   });
 
-  test('_migratePreviouslySavedConnection does not store secrets to disc', async () => {
+  test('_migrateConnectionsWithConnectionModel does not store secrets to disc', async () => {
     const oldSavedConnectionInfo = {
       id: 'fb210b47-f85d-4823-8552-aa6d7825156b',
       name: 'host.u88dd.test.test',
@@ -935,7 +935,7 @@ suite('Connection Controller Test Suite', function () {
       fakeSaveConnection
     );
 
-    await testConnectionController._migratePreviouslySavedConnection(
+    await testConnectionController._migrateConnectionsWithConnectionModel(
       oldSavedConnectionInfo
     );
 
@@ -982,7 +982,7 @@ suite('Connection Controller Test Suite', function () {
 
     sandbox.replace(
       testConnectionController,
-      '_migratePreviouslySavedConnection',
+      '_migrateConnectionsWithConnectionModel',
       fakeMigratePreviouslySavedConnection
     );
 
@@ -1017,7 +1017,7 @@ suite('Connection Controller Test Suite', function () {
 
     sandbox.replace(
       testConnectionController,
-      '_migratePreviouslySavedConnection',
+      '_migrateConnectionsWithConnectionModel',
       fakeMigratePreviouslySavedConnection
     );
 

--- a/src/test/suite/editors/collectionDocumentsProvider.test.ts
+++ b/src/test/suite/editors/collectionDocumentsProvider.test.ts
@@ -13,7 +13,10 @@ import ConnectionController from '../../../connectionController';
 import EditDocumentCodeLensProvider from '../../../editors/editDocumentCodeLensProvider';
 import { StatusView } from '../../../views';
 import { StorageController } from '../../../storage';
-import { StorageLocation } from '../../../storage/storageController';
+import {
+  SecretStorageLocation,
+  StorageLocation,
+} from '../../../storage/storageController';
 import TelemetryService from '../../../telemetry/telemetryService';
 import { TEST_DATABASE_URI } from '../dbTestHelper';
 import { ExtensionContextStub, mockTextEditor } from '../stubs';
@@ -480,12 +483,14 @@ suite('Collection Documents Provider Test Suite', () => {
         name: 'localhost',
         connectionOptions: { connectionString: TEST_DATABASE_URI },
         storageLocation: StorageLocation.NONE,
+        secretStorageLocation: SecretStorageLocation.SecretStorage,
       },
       [secondConnectionId]: {
         id: secondConnectionId,
         name: 'compass',
         connectionOptions: { connectionString: TEST_DATABASE_URI },
         storageLocation: StorageLocation.NONE,
+        secretStorageLocation: SecretStorageLocation.SecretStorage,
       },
     };
 

--- a/src/test/suite/explorer/explorerController.test.ts
+++ b/src/test/suite/explorer/explorerController.test.ts
@@ -5,6 +5,7 @@ import sinon from 'sinon';
 
 import {
   DefaultSavingLocations,
+  SecretStorageLocation,
   StorageLocation,
 } from '../../../storage/storageController';
 import { mdbTestExtension } from '../stubbableMdbExtension';
@@ -59,6 +60,7 @@ suite('Explorer Controller Test Suite', function () {
         connectionOptions: { connectionString: 'mongodb://localhost' },
         name: 'testConnectionName',
         storageLocation: StorageLocation.NONE,
+        secretStorageLocation: SecretStorageLocation.SecretStorage,
       },
     };
     testConnectionController.setConnnecting(true);
@@ -198,6 +200,7 @@ suite('Explorer Controller Test Suite', function () {
       name: 'aaa',
       id: 'aaa',
       storageLocation: StorageLocation.WORKSPACE,
+      secretStorageLocation: SecretStorageLocation.SecretStorage,
     };
 
     testConnectionController._connections.zzz = {
@@ -206,6 +209,7 @@ suite('Explorer Controller Test Suite', function () {
       name: 'zzz',
       id: 'zzz',
       storageLocation: StorageLocation.WORKSPACE,
+      secretStorageLocation: SecretStorageLocation.SecretStorage,
     };
 
     const connectionsItems = await treeController.getChildren();

--- a/src/test/suite/mdbExtensionController.test.ts
+++ b/src/test/suite/mdbExtensionController.test.ts
@@ -21,6 +21,7 @@ import IndexListTreeItem from '../../explorer/indexListTreeItem';
 import { mdbTestExtension } from './stubbableMdbExtension';
 import { mockTextEditor } from './stubs';
 import {
+  SecretStorageLocation,
   StorageLocation,
   StorageVariables,
 } from '../../storage/storageController';
@@ -966,6 +967,7 @@ suite('MDBExtensionController Test Suite', function () {
           connectionOptions: { connectionString: 'mongodb://localhost' },
           name: 'NAAAME',
           storageLocation: StorageLocation.NONE,
+          secretStorageLocation: SecretStorageLocation.SecretStorage,
         };
 
       const testTreeItem = new ConnectionTreeItem(
@@ -1004,6 +1006,7 @@ suite('MDBExtensionController Test Suite', function () {
           name: 'NAAAME',
           connectionOptions: { connectionString: 'mongodb://localhost' },
           storageLocation: StorageLocation.NONE,
+          secretStorageLocation: SecretStorageLocation.SecretStorage,
         };
 
       const testTreeItem = new ConnectionTreeItem(

--- a/src/test/suite/stubs.ts
+++ b/src/test/suite/stubs.ts
@@ -34,6 +34,7 @@ class ExtensionContextStub implements vscode.ExtensionContext {
   storageUri;
   globalStorageUri;
   logUri;
+  _secrets: Record<string, string> = {};
   secrets;
   extension;
 
@@ -45,7 +46,17 @@ class ExtensionContextStub implements vscode.ExtensionContext {
     this.globalStoragePath = '';
     this.logPath = '';
     this.subscriptions = [];
-    this.secrets = {};
+    this.secrets = {
+      get: (key: string) => {
+        return this._secrets[key];
+      },
+      store: (key: string, value: string) => {
+        this._secrets[key] = value;
+      },
+      delete: (key: string) => {
+        delete this._secrets[key];
+      },
+    };
     this.extension = '';
     this.workspaceState = {
       keys: (): readonly string[] => {


### PR DESCRIPTION
## Description
In this PR, we added a migration step to migrate secrets one by one, earlier stored using keytar to VsCode's SecretStorage. The pseudo-code followed here is the following:

```
## Migration process
- Extension activates
- Initiate a call to fetch saved connections
  - Get all the connections from our connection storage
  - For each connection
    - perform the old connection modal to new connection info migration
    - return connection info merged with secrets
      - Check if we have `secretStorageLocation` key set in root of connection info object
      - Yes? (We attempted a migration already for this connection)
        - Is `secretStorageLocation` === `vscode.Keytar`? (We tried migrating but failed, keytar was unavailable)
          - Return the connection info without merging the secrets
        - Is `secretStorageLocation` === `vscode.SecretStorage`?
          - Fetch the secret from `vscode.SecretStorage`
          - Merge it with connection info and return the merged connection info
      - No? (The connection is yet to be migrated)
        - Check if keytar is available
        - No?
          - Set `secretStorageLocation` key to `vscode.Keytar`
          - Log as migration error that keytar is unavailable
          - Return the connection info as it is
        - Yes?
          - Check if credentials are in keytar
          - Yes?
            - Copy the credentials over to `vscode.SecretStorage`
            - Set `secretStorageLocation` key on connection info to `vscode.SecretStorage`
            - Return connection info merged with retrieved secrets
          - No?
            - Set `secretStorageLocation` key to `vscode.SecretStorageLocation`
            - Save '{}' to vscode.SecretStorageLocation for this connection
            - Return connection info merged with empty object for secret
  - Check if there were any connections that we could not migrate and notify the user of them and also track the telemetry event
```

If we fail to migrate for any connection, we notify the user using vscode's information message API. An example here:

![image (2)](https://github.com/mongodb-js/vscode/assets/16307679/6e0f0e89-022e-4a2d-846f-3d182d050a3f)

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->
Caused by: https://github.com/mongodb-js/vscode/issues/546
Resolves: https://github.com/mongodb-js/vscode/issues/476

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
