### PR TITLE
chore: only load keytar during the migration process VSCODE-450

### DIFF
--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -13,7 +13,7 @@ import ConnectionString from 'mongodb-connection-string-url';
 import { EventEmitter } from 'events';
 import type { MongoClientOptions } from 'mongodb';
 import { v4 as uuidv4 } from 'uuid';
-
+import { createKeytar } from './utils/keytar';
 import { CONNECTION_STATUS } from './views/webview-app/extension-app-message-constants';
 import { createLogger } from './logging';
 import { ext } from './extensionConstants';
@@ -296,6 +296,13 @@ export default class ConnectionController {
   async _migrateConnectionWithKeytarSecrets(
     savedConnectionInfo: StoreConnectionInfoWithConnectionOptions
   ): Promise<MigratedStoreConnectionInfoWithConnectionOptions | undefined> {
+    try {
+      ext.keytarModule =
+        ext.keytarModule === undefined ? createKeytar() : ext.keytarModule;
+    } catch (err) {
+      // Couldn't load keytar, proceed without storing & loading connections.
+    }
+
     // If the Keytar module is not available, we simply mark the connections
     // storage as Keytar and return
     if (!ext.keytarModule) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,6 @@
 import * as vscode from 'vscode';
 
 import { ext } from './extensionConstants';
-import { createKeytar } from './utils/keytar';
 import { createLogger } from './logging';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { version } = require('../package.json');
@@ -30,14 +29,6 @@ export async function activate(
   context: vscode.ExtensionContext
 ): Promise<void> {
   ext.context = context;
-  let hasKeytar = false;
-
-  try {
-    ext.keytarModule = createKeytar();
-    hasKeytar = true;
-  } catch (err) {
-    // Couldn't load keytar, proceed without storing & loading connections.
-  }
 
   const defaultConnectionSavingLocation = vscode.workspace
     .getConfiguration('mdb.connectionSaving')
@@ -53,7 +44,6 @@ export async function activate(
     workspaceStoragePath: context.storageUri?.path,
     globalStoragePath: context.globalStorageUri.path,
     defaultConnectionSavingLocation,
-    hasKeytar,
     buildInfo: {
       nodeVersion: process.version,
       runtimePlatform: process.platform,


### PR DESCRIPTION
Only load keytar during the migration of stored connections to process to the new SecretStorageAPI, maintained by the VSCode team. This is a requirement specified in VSCODE-450. This is related to #546.

## Description

Keytar is removed from the activation of the plugin, and only loaded when the migration process starts. 

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

Please, see #546 for more information.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
