### PR TITLE
test: fix test failure on dropCollection for server 7.0

### DIFF
--- a/src/test/suite/mdbExtensionController.test.ts
+++ b/src/test/suite/mdbExtensionController.test.ts
@@ -697,7 +697,9 @@ suite('MDBExtensionController Test Suite', function () {
       assert.strictEqual(calledNamespace, 'testDbName.testColName');
     });
 
-    test('mdb.dropCollection fails when a collection does not exist', async () => {
+    // Starting server 7.0, the outcome of dropping nonexistent collections is successful SERVER-43894
+    // TODO: update or delete the test according to VSCODE-461
+    test.skip('mdb.dropCollection fails when a collection does not exist', async () => {
       const testConnectionController =
         mdbTestExtension.testExtensionController._connectionController;
       await testConnectionController.addNewConnectionStringAndConnect(
@@ -720,11 +722,16 @@ suite('MDBExtensionController Test Suite', function () {
         'mdb.dropCollection',
         testCollectionTreeItem
       );
+      assert(
+        successfullyDropped === false,
+        'Expected the drop collection command handler to return a false succeeded response'
+      );
 
-      // Starting server 7.0, the outcome of dropping nonexistent collections is successful SERVER-43894
-      // TODO: update or delete the test according to VSCODE-461
-      assert(typeof successfullyDropped, 'boolean');
-
+      const expectedMessage = 'Drop collection failed: ns not found';
+      assert(
+        showErrorMessageStub.firstCall.args[0] === expectedMessage,
+        `Expected "${expectedMessage}" when dropping a collection that doesn't exist, recieved "${showErrorMessageStub.firstCall.args[0]}"`
+      );
       await testConnectionController.disconnect();
       testConnectionController.clearAllConnections();
     });

--- a/src/test/suite/mdbExtensionController.test.ts
+++ b/src/test/suite/mdbExtensionController.test.ts
@@ -722,8 +722,7 @@ suite('MDBExtensionController Test Suite', function () {
       );
 
       // Starting server 7.0, the outcome of dropping nonexistent collections is successful SERVER-43894
-      // TODO: triage how to proceed with the server change.
-      // Probably follow the server behavior and allow deletion of nonexistent collections.
+      // TODO: update or delete the test according to VSCODE-461
       assert(typeof successfullyDropped, 'boolean');
 
       await testConnectionController.disconnect();

--- a/src/test/suite/mdbExtensionController.test.ts
+++ b/src/test/suite/mdbExtensionController.test.ts
@@ -720,16 +720,12 @@ suite('MDBExtensionController Test Suite', function () {
         'mdb.dropCollection',
         testCollectionTreeItem
       );
-      assert(
-        successfullyDropped === false,
-        'Expected the drop collection command handler to return a false succeeded response'
-      );
 
-      const expectedMessage = 'Drop collection failed: ns not found';
-      assert(
-        showErrorMessageStub.firstCall.args[0] === expectedMessage,
-        `Expected "${expectedMessage}" when dropping a collection that doesn't exist, recieved "${showErrorMessageStub.firstCall.args[0]}"`
-      );
+      // Starting server 7.0, the outcome of dropping nonexistent collections is successful SERVER-43894
+      // TODO: triage how to proceed with the server change.
+      // Probably follow the server behavior and allow deletion of nonexistent collections.
+      assert(typeof successfullyDropped, 'boolean');
+
       await testConnectionController.disconnect();
       testConnectionController.clearAllConnections();
     });


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. VSCODE-1111: updates ace editor width in agg pipeline view -->
<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
Starting server 7.0, the outcome of dropping nonexistent collections is successful ([SERVER-43894](https://jira.mongodb.org/browse/SERVER-43894)). Skip the test for now and update or delete as part of [VSCODE-461](https://jira.mongodb.org/browse/VSCODE-461).

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
