### PR TITLE
fix: disable Saved Connections Loaded event

### DIFF
--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -222,7 +222,9 @@ export default class ConnectionController {
       this.eventEmitter.emit(DataServiceEventTypes.CONNECTIONS_DID_CHANGE);
     }
 
-    this._telemetryService.trackSavedConnectionsLoaded({
+    // TODO: re-enable with fewer 'Saved Connections Loaded' events
+    // https://jira.mongodb.org/browse/VSCODE-462
+    /* this._telemetryService.trackSavedConnectionsLoaded({
       saved_connections: globalAndWorkspaceConnections.length,
       loaded_connections: loadedConnections.length,
       connections_with_secrets_in_keytar: loadedConnections.filter(
@@ -234,7 +236,7 @@ export default class ConnectionController {
           connection.secretStorageLocation ===
           SecretStorageLocation.SecretStorage
       ).length,
-    });
+    }); */
 
     if (connectionsThatDidNotMigrate.length) {
       log.error(

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -1762,7 +1762,7 @@ suite('Connection Controller Test Suite', function () {
       assert.strictEqual(trackStub.notCalled, true);
     });
 
-    test('should track SAVED_CONNECTIONS_LOADED event on load of saved connections', async () => {
+    test.skip('should track SAVED_CONNECTIONS_LOADED event on load of saved connections', async () => {
       testSandbox.replace(testStorageController, 'get', (key, storage) => {
         if (
           storage === StorageLocation.WORKSPACE ||

--- a/src/test/suite/telemetry/telemetryService.test.ts
+++ b/src/test/suite/telemetry/telemetryService.test.ts
@@ -717,7 +717,7 @@ suite('Telemetry Controller Test Suite', () => {
     });
   });
 
-  test('track saved connections loaded', () => {
+  test.skip('track saved connections loaded', () => {
     testTelemetryService.trackSavedConnectionsLoaded({
       saved_connections: 3,
       loaded_connections: 3,


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. VSCODE-1111: updates ace editor width in agg pipeline view -->
<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
Disable the "Saved Connections Loaded" event, since it is being triggered more than once when the extension is being activated.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
