### PR TITLE
fix(playgrounds): stringify non-string types for playground output VSCODE-466

### DIFF
--- a/src/editors/playgroundController.ts
+++ b/src/editors/playgroundController.ts
@@ -5,6 +5,7 @@ import { ProgressLocation } from 'vscode';
 import vm from 'vm';
 import os from 'os';
 import transpiler from 'bson-transpilers';
+import util from 'util';
 
 import type ActiveConnectionCodeLensProvider from './activeConnectionCodeLensProvider';
 import type PlaygroundSelectedCodeActionProvider from './playgroundSelectedCodeActionProvider';
@@ -110,8 +111,8 @@ export default class PlaygroundController {
 
   _isPartialRun = false;
 
+  _outputChannel: OutputChannel;
   private _activeConnectionCodeLensProvider: ActiveConnectionCodeLensProvider;
-  private _outputChannel: OutputChannel;
   private _playgroundResultViewColumn?: vscode.ViewColumn;
   private _playgroundResultTextDocument?: vscode.TextDocument;
   private _statusView: StatusView;
@@ -576,7 +577,7 @@ export default class PlaygroundController {
         this._outputChannel.appendLine(
           typeof line.content === 'string'
             ? line.content
-            : JSON.stringify(line.content)
+            : util.inspect(line.content)
         );
       }
 

--- a/src/editors/playgroundController.ts
+++ b/src/editors/playgroundController.ts
@@ -573,7 +573,11 @@ export default class PlaygroundController {
 
     if (evaluateResponse?.outputLines?.length) {
       for (const line of evaluateResponse.outputLines) {
-        this._outputChannel.appendLine(line.content);
+        this._outputChannel.appendLine(
+          typeof line.content === 'string'
+            ? line.content
+            : JSON.stringify(line.content)
+        );
       }
 
       this._outputChannel.show(true);


### PR DESCRIPTION
[VSCODE-466](https://jira.mongodb.org/browse/VSCODE-466)

Happens with both `console.log` and `print`.
Using the following example:
```
console.log('test');
console.log({a: 2});
console.log(['a', {a: 3}])
```
| before | after |
| - | - |
| <img width="353" alt="Screenshot 2023-09-01 at 12 35 06 PM" src="https://github.com/mongodb-js/vscode/assets/1791149/a9361a1c-523e-40aa-9994-c40fcce1f598"> | <img width="246" alt="Screenshot 2023-09-01 at 12 33 07 PM" src="https://github.com/mongodb-js/vscode/assets/1791149/8145dd63-24bb-470b-a427-99ee02665829"> |
