### PR TITLE
fix: resolve SRV hostname before passing it to mongodb-cloud-info VSCODE-442

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "react-dom": "^17.0.2",
         "react-redux": "^8.1.1",
         "redux": "^4.2.1",
+        "resolve-mongodb-srv": "^1.1.2",
         "ts-log": "^2.2.5",
         "uuid": "^8.3.2",
         "vscode-languageclient": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -1005,6 +1005,7 @@
     "react-dom": "^17.0.2",
     "react-redux": "^8.1.1",
     "redux": "^4.2.1",
+    "resolve-mongodb-srv": "^1.1.2",
     "ts-log": "^2.2.5",
     "uuid": "^8.3.2",
     "vscode-languageclient": "^8.1.0",


### PR DESCRIPTION
Right now, we are passing the first hostname from the connection string to mongodb-cloud-info, regardless of whether the connection string is a `mongodb://` connection string or a `mongodb+srv://` one.

In the latter case, telemetry gathering fails, because mongodb-cloud-info expects the name of an actual host with associated A or AAAA records (so that it can look up the host’s IP address), not a SRV one.

Using resolve-mongodb-srv first matches what Compass does and solves this issue.

<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. VSCODE-1111: updates ace editor width in agg pipeline view -->
<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
