### PR TITLE
fix(deps): bump bson to resolve playground error VSCODE-473

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@mongosh/service-provider-server": "^2.0.0",
         "@mongosh/shell-api": "^2.0.0",
         "analytics-node": "^6.2.0",
-        "bson": "^5.3.0",
+        "bson": "^6.1.0",
         "bson-transpilers": "^2.0.4",
         "classnames": "^2.3.2",
         "debug": "^4.3.4",
@@ -2603,14 +2603,6 @@
       },
       "optionalDependencies": {
         "mongodb-client-encryption": "^6.0.0"
-      }
-    },
-    "node_modules/@mongosh/service-provider-core/node_modules/bson": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.0.0.tgz",
-      "integrity": "sha512-FoWvdELfF2wQaUo8S/a1Rh2BDwJEUancDDnzdTpYymJTZjmvRpLWoqRPelKn+XSeh5D4YddWDG66cLtEhGGvcg==",
-      "engines": {
-        "node": ">=16.20.1"
       }
     },
     "node_modules/@mongosh/service-provider-server": {
@@ -5716,11 +5708,11 @@
       }
     },
     "node_modules/bson": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-5.4.0.tgz",
-      "integrity": "sha512-WRZ5SQI5GfUuKnPTNmAYPiKIof3ORXAF4IRU5UcgmivNIon01rWQlw5RUH954dpu8yGL8T59YShVddIPaU/gFA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.1.0.tgz",
+      "integrity": "sha512-yiQ3KxvpVoRpx1oD1uPz4Jit9tAVTJgjdmjDKtUErkOoL9VNoF8Dd58qtAOL5E40exx2jvAT9sqdRSK/r+SHlA==",
       "engines": {
-        "node": ">=14.20.1"
+        "node": ">=16.20.1"
       }
     },
     "node_modules/bson-transpilers": {
@@ -14876,6 +14868,15 @@
         "mongodb-runner": "bin/runner.js"
       }
     },
+    "node_modules/mongodb-runner/node_modules/bson": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.5.0.tgz",
+      "integrity": "sha512-B+QB4YmDx9RStKv8LLSl/aVIEV3nYJc3cJNNTK2Cd1TL+7P+cNpw9mAPeCgc5K+j01Dv6sxUzcITXDx7ZU3F0w==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.20.1"
+      }
+    },
     "node_modules/mongodb-runner/node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -14987,6 +14988,15 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "optional": true
     },
+    "node_modules/mongodb-schema/node_modules/bson": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.5.0.tgz",
+      "integrity": "sha512-B+QB4YmDx9RStKv8LLSl/aVIEV3nYJc3cJNNTK2Cd1TL+7P+cNpw9mAPeCgc5K+j01Dv6sxUzcITXDx7ZU3F0w==",
+      "optional": true,
+      "engines": {
+        "node": ">=14.20.1"
+      }
+    },
     "node_modules/mongodb-schema/node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -15079,14 +15089,6 @@
       "optional": true,
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/mongodb/node_modules/bson": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.0.0.tgz",
-      "integrity": "sha512-FoWvdELfF2wQaUo8S/a1Rh2BDwJEUancDDnzdTpYymJTZjmvRpLWoqRPelKn+XSeh5D4YddWDG66cLtEhGGvcg==",
-      "engines": {
-        "node": ">=16.20.1"
       }
     },
     "node_modules/mongodb3": {
@@ -23936,13 +23938,6 @@
         "mongodb": "^6.0.0",
         "mongodb-build-info": "^1.6.2",
         "mongodb-client-encryption": "^6.0.0"
-      },
-      "dependencies": {
-        "bson": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-6.0.0.tgz",
-          "integrity": "sha512-FoWvdELfF2wQaUo8S/a1Rh2BDwJEUancDDnzdTpYymJTZjmvRpLWoqRPelKn+XSeh5D4YddWDG66cLtEhGGvcg=="
-        }
       }
     },
     "@mongosh/service-provider-server": {
@@ -26451,9 +26446,9 @@
       }
     },
     "bson": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-5.4.0.tgz",
-      "integrity": "sha512-WRZ5SQI5GfUuKnPTNmAYPiKIof3ORXAF4IRU5UcgmivNIon01rWQlw5RUH954dpu8yGL8T59YShVddIPaU/gFA=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.1.0.tgz",
+      "integrity": "sha512-yiQ3KxvpVoRpx1oD1uPz4Jit9tAVTJgjdmjDKtUErkOoL9VNoF8Dd58qtAOL5E40exx2jvAT9sqdRSK/r+SHlA=="
     },
     "bson-transpilers": {
       "version": "2.0.4",
@@ -33159,13 +33154,6 @@
         "@mongodb-js/saslprep": "^1.1.0",
         "bson": "^6.0.0",
         "mongodb-connection-string-url": "^2.6.0"
-      },
-      "dependencies": {
-        "bson": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-6.0.0.tgz",
-          "integrity": "sha512-FoWvdELfF2wQaUo8S/a1Rh2BDwJEUancDDnzdTpYymJTZjmvRpLWoqRPelKn+XSeh5D4YddWDG66cLtEhGGvcg=="
-        }
       }
     },
     "mongodb-build-info": {
@@ -33498,6 +33486,12 @@
         "yargs": "^17.7.2"
       },
       "dependencies": {
+        "bson": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-5.5.0.tgz",
+          "integrity": "sha512-B+QB4YmDx9RStKv8LLSl/aVIEV3nYJc3cJNNTK2Cd1TL+7P+cNpw9mAPeCgc5K+j01Dv6sxUzcITXDx7ZU3F0w==",
+          "dev": true
+        },
         "cliui": {
           "version": "8.0.1",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -33566,6 +33560,12 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
           "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "optional": true
+        },
+        "bson": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-5.5.0.tgz",
+          "integrity": "sha512-B+QB4YmDx9RStKv8LLSl/aVIEV3nYJc3cJNNTK2Cd1TL+7P+cNpw9mAPeCgc5K+j01Dv6sxUzcITXDx7ZU3F0w==",
           "optional": true
         },
         "cliui": {

--- a/package.json
+++ b/package.json
@@ -986,7 +986,7 @@
     "@mongosh/service-provider-server": "^2.0.0",
     "@mongosh/shell-api": "^2.0.0",
     "analytics-node": "^6.2.0",
-    "bson": "^5.3.0",
+    "bson": "^6.1.0",
     "bson-transpilers": "^2.0.4",
     "classnames": "^2.3.2",
     "debug": "^4.3.4",


### PR DESCRIPTION
VSCODE-473

We could really use a test that runs a playground with the all types document. It would catch this. Going to add that in a follow up so we don't block this release: https://jira.mongodb.org/browse/VSCODE-474