### PR TITLE
feat: enable language server logs to be opened as a log file VSCODE-429

### DIFF
--- a/src/language/languageServerController.ts
+++ b/src/language/languageServerController.ts
@@ -77,7 +77,9 @@ export default class LanguageServerController {
         // Notify the server about file changes in the workspace.
         fileEvents: workspace.createFileSystemWatcher('**/*'),
       },
-      outputChannel: vscode.window.createOutputChannel(languageServerName),
+      outputChannel: vscode.window.createOutputChannel(languageServerName, {
+        log: true,
+      }),
     };
 
     log.info('Creating MongoDB Language Server...', {


### PR DESCRIPTION

## Description

This PR sends the language server logs to a `LogOutputChannel` so that they can be opened with the `Developer: Open Logfile` command.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
