### PR TITLE
fix: add explicit ordering for stream processor context menu actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -644,15 +644,18 @@
         },
         {
           "command": "mdb.startStreamProcessor",
-          "when": "view == mongoDBConnectionExplorer && viewItem == streamProcessorTreeItem"
+          "when": "view == mongoDBConnectionExplorer && viewItem == streamProcessorTreeItem",
+          "group": "6@1"
         },
         {
           "command": "mdb.stopStreamProcessor",
-          "when": "view == mongoDBConnectionExplorer && viewItem == streamProcessorTreeItem"
+          "when": "view == mongoDBConnectionExplorer && viewItem == streamProcessorTreeItem",
+          "group": "6@2"
         },
         {
           "command": "mdb.dropStreamProcessor",
-          "when": "view == mongoDBConnectionExplorer && viewItem == streamProcessorTreeItem"
+          "when": "view == mongoDBConnectionExplorer && viewItem == streamProcessorTreeItem",
+          "group": "6@3"
         }
       ],
       "editor/title": [


### PR DESCRIPTION
[VSCODE-510](https://jira.mongodb.org/browse/VSCODE-510)

## Description
The order of context menus on the stream processor were ordered alphabetically. This PR adds explicit ordering to ensure the order is 'Start -> Stop -> Drop'. 

This follows the existing ordering pattern which uses numbers (1, 2, 3 etc) as group name identifiers. 

<img width="457" alt="Screenshot 2024-01-11 at 4 27 15 pm" src="https://github.com/mongodb-js/vscode/assets/156152710/7bd3fb08-9d39-4cda-af05-5c72fe06828e">

