### PR TITLE
fix: ensure extension output populates ObjectIds in stream

### DIFF
--- a/src/language/worker.ts
+++ b/src/language/worker.ts
@@ -57,7 +57,7 @@ const execute = async (
       onPrint(values: EvaluationResult[]) {
         parentPort?.postMessage({
           name: ServerCommands.SHOW_CONSOLE_OUTPUT,
-          payload: values.map((v) => v.printable),
+          payload: values.map((v) => JSON.parse(EJSON.stringify(v.printable))),
         });
       },
     });

--- a/src/language/worker.ts
+++ b/src/language/worker.ts
@@ -9,6 +9,7 @@ import type {
   WorkerEvaluate,
   MongoClientOptions,
 } from '../types/playgroundType';
+import util from 'util';
 
 interface EvaluationResult {
   printable: any;
@@ -57,7 +58,11 @@ const execute = async (
       onPrint(values: EvaluationResult[]) {
         parentPort?.postMessage({
           name: ServerCommands.SHOW_CONSOLE_OUTPUT,
-          payload: values.map((v) => JSON.parse(EJSON.stringify(v.printable))),
+          payload: values.map((v) => {
+            return typeof v.printable === 'string'
+              ? v.printable
+              : util.inspect(v.printable);
+          }),
         });
       },
     });

--- a/src/test/suite/language/mongoDBService.test.ts
+++ b/src/test/suite/language/mongoDBService.test.ts
@@ -2981,12 +2981,13 @@ suite('MongoDBService Test Suite', () => {
         const result = await testMongoDBService.evaluate(
           {
             connectionId: 'pineapple',
-            codeToEvaluate: 'print("Hello"); console.log(1,2,3); 42',
+            codeToEvaluate:
+              'print("Hello"); console.log(1,2,3); console.log(true); 42',
           },
           source.token
         );
 
-        const expectedConsoleOutputs = ['Hello', 1, 2, 3];
+        const expectedConsoleOutputs = ['Hello', '1', '2', '3', 'true'];
         expect(consoleOutputs).to.deep.equal(expectedConsoleOutputs);
 
         const expectedResult = {

--- a/src/test/suite/language/mongoDBService.test.ts
+++ b/src/test/suite/language/mongoDBService.test.ts
@@ -2977,17 +2977,24 @@ suite('MongoDBService Test Suite', () => {
 
       test('sends print() and console.log() output continuously', async () => {
         const source = new CancellationTokenSource();
+        const hexString = '65a482edbf4fc24c5255a8fa';
 
         const result = await testMongoDBService.evaluate(
           {
             connectionId: 'pineapple',
-            codeToEvaluate:
-              'print("Hello"); console.log(1,2,3); console.log(true); 42',
+            codeToEvaluate: `print("Hello"); console.log(1,2,3); console.log(true); console.log(ObjectId(\'${hexString}\')); 42`,
           },
           source.token
         );
 
-        const expectedConsoleOutputs = ['Hello', '1', '2', '3', 'true'];
+        const expectedConsoleOutputs = [
+          'Hello',
+          '1',
+          '2',
+          '3',
+          'true',
+          `ObjectId(\'${hexString}\')`,
+        ];
         expect(consoleOutputs).to.deep.equal(expectedConsoleOutputs);
 
         const expectedResult = {


### PR DESCRIPTION
[VSCODE-511](https://jira.mongodb.org/browse/VSCODE-511)
## Description
The console output from the extension wasn't returning the correct representations for ObjectIds so they weren't being printed.

This PR udpates the worker to perform the evaluation of the payload as a string before passing it to the listener to print. 