### PR TITLE
chore: set browser auth without github actions for mongosh int tests

### DIFF
--- a/.github/workflows/actions/test-and-build/action.yaml
+++ b/.github/workflows/actions/test-and-build/action.yaml
@@ -69,15 +69,7 @@ runs:
       if: ${{ runner.os != 'Windows' }}
       shell: bash
 
-    - name: Set BROWSER_AUTH_COMMAND
-      run: |
-        BROWSER_AUTH_COMMAND=$(echo "$(which node) $(pwd)/src/test/fixture/curl.js")
-        echo "BROWSER_AUTH_COMMAND=$BROWSER_AUTH_COMMAND" >> $GITHUB_ENV
-      shell: bash
-
     - name: Run Tests
-      env:
-        BROWSER_AUTH_COMMAND: ${{ env.BROWSER_AUTH_COMMAND }}
       run: |
         npm run test
       shell: bash

--- a/src/test/suite/oidc.test.ts
+++ b/src/test/suite/oidc.test.ts
@@ -32,7 +32,7 @@ function hash(input: string): string {
 
 // Need to be provided via CI env because we can't get a hold for node.js exec
 // path in our tests - they run inside a vscode process in the built dir.
-const browserShellCommand = `echo "$(which node) ${__dirname}/../../../src/test/fixture/curl.js"`;
+const browserShellCommand = `$(echo "$(which node) ${__dirname}/../../../src/test/fixture/curl.js")`;
 
 const UNIQUE_TASK_ID =
   process.env.GITHUB_RUN_ID && process.env.GITHUB_RUN_NUMBER

--- a/src/test/suite/oidc.test.ts
+++ b/src/test/suite/oidc.test.ts
@@ -31,8 +31,8 @@ function hash(input: string): string {
 }
 
 // Need to be provided via CI env because we can't get a hold for node.js exec
-// path in our tests - they run inside a vscode process
-const browserShellCommand = process.env.BROWSER_AUTH_COMMAND;
+// path in our tests - they run inside a vscode process in the built dir.
+const browserShellCommand = `echo "$(which node) ${__dirname}/../../../src/test/fixture/curl.js"`;
 
 const UNIQUE_TASK_ID =
   process.env.GITHUB_RUN_ID && process.env.GITHUB_RUN_NUMBER


### PR DESCRIPTION
Hopefully this fixes the failing evergreen CI mongosh tests that run the VSCode tests. 

The browser command wouldn't be set in those tests as we set them in our actions. This updates the test to not use the environment variable so we can run the OIDC tests without the github env test setup. If this doesn't work because we're not using a deployment that supports OIDC in mongosh evergreen I might make a separate pr that disables these tests when not run in github actions.