### PR TITLE
feat: add export to Rust and PHP VSCODE-411

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Select queries and aggregations within your Playground files and translate them 
  * Python 3
  * Ruby
  * Go
+ * Rust
+ * PHP
 
 ![Export to language](resources/screenshots/export-to-language.gif)
 

--- a/package.json
+++ b/package.json
@@ -247,6 +247,14 @@
         "title": "MongoDB: Export To Go"
       },
       {
+        "command": "mdb.exportToRust",
+        "title": "MongoDB: Export To Rust"
+      },
+      {
+        "command": "mdb.exportToPHP",
+        "title": "MongoDB: Export To PHP"
+      },
+      {
         "command": "mdb.addConnection",
         "title": "Add MongoDB Connection",
         "icon": {
@@ -718,6 +726,14 @@
         },
         {
           "command": "mdb.exportToGo",
+          "when": "mdb.isPlayground == true && mdb.connectedToMongoDB == true && mdb.isAtlasStreams == false"
+        },
+        {
+          "command": "mdb.exportToRust",
+          "when": "mdb.isPlayground == true && mdb.connectedToMongoDB == true && mdb.isAtlasStreams == false"
+        },
+        {
+          "command": "mdb.exportToPHP",
           "when": "mdb.isPlayground == true && mdb.connectedToMongoDB == true && mdb.isAtlasStreams == false"
         },
         {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -23,6 +23,8 @@ enum EXTENSION_COMMANDS {
   MDB_EXPORT_TO_NODE = 'mdb.exportToNode',
   MDB_EXPORT_TO_RUBY = 'mdb.exportToRuby',
   MDB_EXPORT_TO_GO = 'mdb.exportToGo',
+  MDB_EXPORT_TO_RUST = 'mdb.exportToRust',
+  MDB_EXPORT_TO_PHP = 'mdb.exportToPHP',
   MDB_CHANGE_EXPORT_TO_LANGUAGE_ADDONS = 'mdb.changeExportToLanguageAddons',
 
   MDB_OPEN_MONGODB_DOCUMENT_FROM_CODE_LENS = 'mdb.openMongoDBDocumentFromCodeLens',

--- a/src/editors/playgroundSelectedCodeActionProvider.ts
+++ b/src/editors/playgroundSelectedCodeActionProvider.ts
@@ -133,6 +133,28 @@ export default class PlaygroundSelectedCodeActionProvider
         tooltip: 'Export To Go',
       };
       codeActions.push(exportToGoCommand);
+
+      const exportToRustCommand = new vscode.CodeAction(
+        'Export To Rust',
+        vscode.CodeActionKind.Empty
+      );
+      exportToRustCommand.command = {
+        command: EXTENSION_COMMANDS.MDB_EXPORT_TO_RUST,
+        title: 'Export To Rust',
+        tooltip: 'Export To Rust',
+      };
+      codeActions.push(exportToRustCommand);
+
+      const exportToPHPCommand = new vscode.CodeAction(
+        'Export To PHP',
+        vscode.CodeActionKind.Empty
+      );
+      exportToPHPCommand.command = {
+        command: EXTENSION_COMMANDS.MDB_EXPORT_TO_PHP,
+        title: 'Export To PHP',
+        tooltip: 'Export To PHP',
+      };
+      codeActions.push(exportToPHPCommand);
     }
 
     return codeActions;

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -235,6 +235,12 @@ export default class MDBExtensionController implements vscode.Disposable {
     this.registerCommand(EXTENSION_COMMANDS.MDB_EXPORT_TO_GO, () =>
       this._playgroundController.exportToLanguage(ExportToLanguages.GO)
     );
+    this.registerCommand(EXTENSION_COMMANDS.MDB_EXPORT_TO_RUST, () =>
+      this._playgroundController.exportToLanguage(ExportToLanguages.RUST)
+    );
+    this.registerCommand(EXTENSION_COMMANDS.MDB_EXPORT_TO_PHP, () =>
+      this._playgroundController.exportToLanguage(ExportToLanguages.PHP)
+    );
 
     this.registerCommand(
       EXTENSION_COMMANDS.MDB_CHANGE_EXPORT_TO_LANGUAGE_ADDONS,

--- a/src/types/playgroundType.ts
+++ b/src/types/playgroundType.ts
@@ -46,6 +46,8 @@ export enum ExportToLanguages {
   JAVASCRIPT = 'javascript',
   RUBY = 'ruby',
   GO = 'go',
+  RUST = 'rust',
+  PHP = 'php',
 }
 
 export enum ExportToLanguageMode {


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. VSCODE-1111: updates ace editor width in agg pipeline view -->
<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->
## Description
Adding Rust and PHP to the language export commands & codeActions. I feel like the playground actions part could be refactored, but that can be a separate PR.

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
