### PR TITLE
fix: include export mode when retrieving import statements VSCODE-440

### DIFF
--- a/src/editors/playgroundController.ts
+++ b/src/editors/playgroundController.ts
@@ -97,6 +97,21 @@ const countAggregationStagesInString = (str: string) => {
     .length;
 };
 
+enum TranspilerExportMode {
+  PIPELINE = 'Pipeline',
+  QUERY = 'Query',
+  DELETE_QUERY = 'Delete Query',
+  UPDATE_QUERY = 'Update Query',
+}
+const exportModeMapping: Record<
+  ExportToLanguageMode,
+  TranspilerExportMode | undefined
+> = {
+  [ExportToLanguageMode.AGGREGATION]: TranspilerExportMode.PIPELINE,
+  [ExportToLanguageMode.QUERY]: TranspilerExportMode.QUERY,
+  [ExportToLanguageMode.OTHER]: undefined,
+};
+
 /**
  * This controller manages playground.
  */
@@ -807,7 +822,13 @@ export default class PlaygroundController {
       let imports = '';
 
       if (importStatements) {
-        imports = transpiler.shell[language].getImports(driverSyntax);
+        const exportMode = this._playgroundSelectedCodeActionProvider.mode
+          ? exportModeMapping[this._playgroundSelectedCodeActionProvider.mode]
+          : undefined;
+        imports = transpiler.shell[language].getImports(
+          exportMode,
+          driverSyntax
+        );
       }
 
       this._playgroundResult = {

--- a/src/test/suite/editors/playgroundSelectedCodeActionProvider.test.ts
+++ b/src/test/suite/editors/playgroundSelectedCodeActionProvider.test.ts
@@ -368,11 +368,6 @@ suite('Playground Selected CodeAction Provider Test Suite', function () {
 
           const driverSyntaxRawQuery =
             'Bson filter = new Document("name", "22");';
-          console.log(
-            'CONTENT DRIVER',
-            mdbTestExtension.testExtensionController._playgroundController
-              ._playgroundResult?.content
-          );
           expect(
             mdbTestExtension.testExtensionController._playgroundController
               ._playgroundResult?.content

--- a/src/test/suite/editors/playgroundSelectedCodeActionProvider.test.ts
+++ b/src/test/suite/editors/playgroundSelectedCodeActionProvider.test.ts
@@ -195,7 +195,7 @@ suite('Playground Selected CodeAction Provider Test Suite', function () {
       }
     });
 
-    test('exports to java and includes builders', async () => {
+    test('exports to java and includes builders and import statements', async () => {
       const textFromEditor = "{ name: '22' }";
       const selection = {
         start: { line: 0, character: 0 },
@@ -256,6 +256,26 @@ suite('Playground Selected CodeAction Provider Test Suite', function () {
             mdbTestExtension.testExtensionController._playgroundController
               ._playgroundResult
           ).to.be.deep.equal(expectedResult);
+
+          await vscode.commands.executeCommand(
+            'mdb.changeExportToLanguageAddons',
+            {
+              ...mdbTestExtension.testExtensionController._playgroundController
+                ._exportToLanguageCodeLensProvider._exportToLanguageAddons,
+              driverSyntax: true,
+              importStatements: true,
+            }
+          );
+
+          // Java includes generic import statements
+          const mongoClientImport = 'import com.mongodb.MongoClient;';
+          // but also import statements which depend on the exportToLanguageMode. the following is for QUERY
+          const queryImport = 'import com.mongodb.client.FindIterable;';
+          const content =
+            mdbTestExtension.testExtensionController._playgroundController
+              ._playgroundResult?.content;
+          expect(content).to.include(mongoClientImport);
+          expect(content).to.include(queryImport);
         }
       }
     });

--- a/src/test/suite/editors/playgroundSelectedCodeActionProvider.test.ts
+++ b/src/test/suite/editors/playgroundSelectedCodeActionProvider.test.ts
@@ -240,280 +240,410 @@ suite('Playground Selected CodeAction Provider Test Suite', function () {
 
       test('include builders (only)', async () => {
         const codeActions = testCodeActionProvider.provideCodeActions();
-        expect(codeActions).to.exist;
 
-        if (codeActions) {
-          expect(codeActions.length).to.be.equal(TOTAL_CODEACTIONS_COUNT);
-          const actionCommand = codeActions[2].command;
-
-          if (actionCommand) {
-            expect(actionCommand.command).to.be.equal('mdb.exportToJava');
-            expect(actionCommand.title).to.be.equal('Export To Java');
-
-            await vscode.commands.executeCommand(actionCommand.command);
-
-            const codeLenses =
-              mdbTestExtension.testExtensionController._playgroundController._exportToLanguageCodeLensProvider.provideCodeLenses();
-            expect(codeLenses.length).to.be.equal(3);
-            const lensesObj = { lenses: codeLenses };
-            expect(lensesObj).to.have.nested.property(
-              'lenses[0].command.title',
-              'Include Import Statements'
-            );
-            expect(lensesObj).to.have.nested.property(
-              'lenses[1].command.title',
-              'Include Driver Syntax'
-            );
-            expect(lensesObj).to.have.nested.property(
-              'lenses[2].command.title',
-              'Use Builders'
-            );
-          }
-
-          // Only java queries supports builders.
-          await vscode.commands.executeCommand(
-            'mdb.changeExportToLanguageAddons',
-            {
-              ...mdbTestExtension.testExtensionController._playgroundController
-                ._exportToLanguageCodeLensProvider._exportToLanguageAddons,
-              builders: true,
-              importStatements: false,
-              driverSyntax: false,
-            }
-          );
-
-          const codeLenses =
-            mdbTestExtension.testExtensionController._playgroundController._exportToLanguageCodeLensProvider.provideCodeLenses();
-          const lensesObj = { lenses: codeLenses };
-          expect(lensesObj).to.have.nested.property(
-            'lenses[0].command.title',
-            'Include Import Statements'
-          );
-          expect(lensesObj).to.have.nested.property(
-            'lenses[1].command.title',
-            'Include Driver Syntax'
-          );
-          expect(lensesObj).to.have.nested.property(
-            'lenses[2].command.title',
-            'Use Raw Query'
-          );
-
-          expectedResult.content = 'eq("name", "22")';
-          expect(
-            mdbTestExtension.testExtensionController._playgroundController
-              ._playgroundResult
-          ).to.be.deep.equal(expectedResult);
+        if (!codeActions) {
+          expect.fail('No code actions');
+          return false;
         }
+
+        expect(codeActions.length).to.be.equal(TOTAL_CODEACTIONS_COUNT);
+        const actionCommand = codeActions[2].command;
+
+        if (!actionCommand) {
+          expect.fail('Action command not found');
+          return false;
+        }
+
+        expect(actionCommand.command).to.be.equal('mdb.exportToJava');
+        expect(actionCommand.title).to.be.equal('Export To Java');
+
+        await vscode.commands.executeCommand(actionCommand.command);
+
+        let codeLenses =
+          mdbTestExtension.testExtensionController._playgroundController._exportToLanguageCodeLensProvider.provideCodeLenses();
+        expect(codeLenses.length).to.be.equal(3);
+        let lensesObj = { lenses: codeLenses };
+        expect(lensesObj).to.have.nested.property(
+          'lenses[0].command.title',
+          'Include Import Statements'
+        );
+        expect(lensesObj).to.have.nested.property(
+          'lenses[1].command.title',
+          'Include Driver Syntax'
+        );
+        expect(lensesObj).to.have.nested.property(
+          'lenses[2].command.title',
+          'Use Builders'
+        );
+
+        // Only java queries supports builders.
+        await vscode.commands.executeCommand(
+          'mdb.changeExportToLanguageAddons',
+          {
+            ...mdbTestExtension.testExtensionController._playgroundController
+              ._exportToLanguageCodeLensProvider._exportToLanguageAddons,
+            builders: true,
+            importStatements: false,
+            driverSyntax: false,
+          }
+        );
+
+        codeLenses =
+          mdbTestExtension.testExtensionController._playgroundController._exportToLanguageCodeLensProvider.provideCodeLenses();
+        lensesObj = { lenses: codeLenses };
+        expect(lensesObj).to.have.nested.property(
+          'lenses[0].command.title',
+          'Include Import Statements'
+        );
+        expect(lensesObj).to.have.nested.property(
+          'lenses[1].command.title',
+          'Include Driver Syntax'
+        );
+        expect(lensesObj).to.have.nested.property(
+          'lenses[2].command.title',
+          'Use Raw Query'
+        );
+
+        expectedResult.content = 'eq("name", "22")';
+        expect(
+          mdbTestExtension.testExtensionController._playgroundController
+            ._playgroundResult
+        ).to.be.deep.equal(expectedResult);
       });
 
       test('include driver syntax (only)', async () => {
         const codeActions = testCodeActionProvider.provideCodeActions();
-        expect(codeActions).to.exist;
 
-        if (codeActions) {
-          expect(codeActions.length).to.be.equal(TOTAL_CODEACTIONS_COUNT);
-          const actionCommand = codeActions[2].command;
-
-          if (actionCommand) {
-            expect(actionCommand.command).to.be.equal('mdb.exportToJava');
-            expect(actionCommand.title).to.be.equal('Export To Java');
-
-            await vscode.commands.executeCommand(actionCommand.command);
-
-            const codeLenses =
-              mdbTestExtension.testExtensionController._playgroundController._exportToLanguageCodeLensProvider.provideCodeLenses();
-            expect(codeLenses.length).to.be.equal(3);
-            const lensesObj = { lenses: codeLenses };
-            expect(lensesObj).to.have.nested.property(
-              'lenses[0].command.title',
-              'Include Import Statements'
-            );
-            expect(lensesObj).to.have.nested.property(
-              'lenses[1].command.title',
-              'Include Driver Syntax'
-            );
-            expect(lensesObj).to.have.nested.property(
-              'lenses[2].command.title',
-              'Use Builders'
-            );
-          }
-
-          // Only java queries supports builders.
-          await vscode.commands.executeCommand(
-            'mdb.changeExportToLanguageAddons',
-            {
-              ...mdbTestExtension.testExtensionController._playgroundController
-                ._exportToLanguageCodeLensProvider._exportToLanguageAddons,
-              builders: false,
-              importStatements: false,
-              driverSyntax: true,
-            }
-          );
-
-          const codeLenses =
-            mdbTestExtension.testExtensionController._playgroundController._exportToLanguageCodeLensProvider.provideCodeLenses();
-          const lensesObj = { lenses: codeLenses };
-          expect(lensesObj).to.have.nested.property(
-            'lenses[0].command.title',
-            'Include Import Statements'
-          );
-          expect(lensesObj).to.have.nested.property(
-            'lenses[1].command.title',
-            'Exclude Driver Syntax'
-          );
-          expect(lensesObj).to.have.nested.property(
-            'lenses[2].command.title',
-            'Use Builders'
-          );
-
-          const driverSyntaxRawQuery =
-            'Bson filter = new Document("name", "22");';
-          expect(
-            mdbTestExtension.testExtensionController._playgroundController
-              ._playgroundResult?.content
-          ).to.include(driverSyntaxRawQuery);
+        if (!codeActions) {
+          expect.fail('No code actions');
+          return false;
         }
+
+        expect(codeActions.length).to.be.equal(TOTAL_CODEACTIONS_COUNT);
+        const actionCommand = codeActions[2].command;
+
+        if (!actionCommand) {
+          expect.fail('Action command not found');
+          return false;
+        }
+
+        expect(actionCommand.command).to.be.equal('mdb.exportToJava');
+        expect(actionCommand.title).to.be.equal('Export To Java');
+
+        await vscode.commands.executeCommand(actionCommand.command);
+
+        let codeLenses =
+          mdbTestExtension.testExtensionController._playgroundController._exportToLanguageCodeLensProvider.provideCodeLenses();
+        expect(codeLenses.length).to.be.equal(3);
+        let lensesObj = { lenses: codeLenses };
+        expect(lensesObj).to.have.nested.property(
+          'lenses[0].command.title',
+          'Include Import Statements'
+        );
+        expect(lensesObj).to.have.nested.property(
+          'lenses[1].command.title',
+          'Include Driver Syntax'
+        );
+        expect(lensesObj).to.have.nested.property(
+          'lenses[2].command.title',
+          'Use Builders'
+        );
+
+        await vscode.commands.executeCommand(
+          'mdb.changeExportToLanguageAddons',
+          {
+            ...mdbTestExtension.testExtensionController._playgroundController
+              ._exportToLanguageCodeLensProvider._exportToLanguageAddons,
+            builders: false,
+            importStatements: false,
+            driverSyntax: true,
+          }
+        );
+
+        codeLenses =
+          mdbTestExtension.testExtensionController._playgroundController._exportToLanguageCodeLensProvider.provideCodeLenses();
+        lensesObj = { lenses: codeLenses };
+        expect(lensesObj).to.have.nested.property(
+          'lenses[0].command.title',
+          'Include Import Statements'
+        );
+        expect(lensesObj).to.have.nested.property(
+          'lenses[1].command.title',
+          'Exclude Driver Syntax'
+        );
+        expect(lensesObj).to.have.nested.property(
+          'lenses[2].command.title',
+          'Use Builders'
+        );
+
+        const driverSyntaxRawQuery =
+          'Bson filter = new Document("name", "22");';
+        expect(
+          mdbTestExtension.testExtensionController._playgroundController
+            ._playgroundResult?.content
+        ).to.include(driverSyntaxRawQuery);
       });
 
       test('include import statements (only)', async () => {
         const codeActions = testCodeActionProvider.provideCodeActions();
-        expect(codeActions).to.exist;
 
-        if (codeActions) {
-          expect(codeActions.length).to.be.equal(TOTAL_CODEACTIONS_COUNT);
-          const actionCommand = codeActions[2].command;
-
-          if (actionCommand) {
-            expect(actionCommand.command).to.be.equal('mdb.exportToJava');
-            expect(actionCommand.title).to.be.equal('Export To Java');
-
-            await vscode.commands.executeCommand(actionCommand.command);
-
-            const codeLenses =
-              mdbTestExtension.testExtensionController._playgroundController._exportToLanguageCodeLensProvider.provideCodeLenses();
-            expect(codeLenses.length).to.be.equal(3);
-            const lensesObj = { lenses: codeLenses };
-            expect(lensesObj).to.have.nested.property(
-              'lenses[0].command.title',
-              'Include Import Statements'
-            );
-            expect(lensesObj).to.have.nested.property(
-              'lenses[1].command.title',
-              'Include Driver Syntax'
-            );
-            expect(lensesObj).to.have.nested.property(
-              'lenses[2].command.title',
-              'Use Builders'
-            );
-          }
-
-          // Only java queries supports builders.
-          await vscode.commands.executeCommand(
-            'mdb.changeExportToLanguageAddons',
-            {
-              ...mdbTestExtension.testExtensionController._playgroundController
-                ._exportToLanguageCodeLensProvider._exportToLanguageAddons,
-              builders: false,
-              importStatements: true,
-              driverSyntax: false,
-            }
-          );
-
-          const codeLenses =
-            mdbTestExtension.testExtensionController._playgroundController._exportToLanguageCodeLensProvider.provideCodeLenses();
-          const lensesObj = { lenses: codeLenses };
-          expect(lensesObj).to.have.nested.property(
-            'lenses[0].command.title',
-            'Exclude Import Statements'
-          );
-          expect(lensesObj).to.have.nested.property(
-            'lenses[1].command.title',
-            'Include Driver Syntax'
-          );
-          expect(lensesObj).to.have.nested.property(
-            'lenses[2].command.title',
-            'Use Builders'
-          );
-
-          const rawQueryWithImport =
-            'import org.bson.Document;\n\nnew Document("name", "22")';
-          expect(
-            mdbTestExtension.testExtensionController._playgroundController
-              ._playgroundResult?.content
-          ).to.deep.equal(rawQueryWithImport);
+        if (!codeActions) {
+          expect.fail('No code actions');
+          return false;
         }
+
+        expect(codeActions.length).to.be.equal(TOTAL_CODEACTIONS_COUNT);
+        const actionCommand = codeActions[2].command;
+
+        if (!actionCommand) {
+          expect.fail('Action command not found');
+          return false;
+        }
+
+        expect(actionCommand.command).to.be.equal('mdb.exportToJava');
+        expect(actionCommand.title).to.be.equal('Export To Java');
+
+        await vscode.commands.executeCommand(actionCommand.command);
+
+        let codeLenses =
+          mdbTestExtension.testExtensionController._playgroundController._exportToLanguageCodeLensProvider.provideCodeLenses();
+        expect(codeLenses.length).to.be.equal(3);
+        let lensesObj = { lenses: codeLenses };
+        expect(lensesObj).to.have.nested.property(
+          'lenses[0].command.title',
+          'Include Import Statements'
+        );
+        expect(lensesObj).to.have.nested.property(
+          'lenses[1].command.title',
+          'Include Driver Syntax'
+        );
+        expect(lensesObj).to.have.nested.property(
+          'lenses[2].command.title',
+          'Use Builders'
+        );
+
+        await vscode.commands.executeCommand(
+          'mdb.changeExportToLanguageAddons',
+          {
+            ...mdbTestExtension.testExtensionController._playgroundController
+              ._exportToLanguageCodeLensProvider._exportToLanguageAddons,
+            builders: false,
+            importStatements: true,
+            driverSyntax: false,
+          }
+        );
+
+        codeLenses =
+          mdbTestExtension.testExtensionController._playgroundController._exportToLanguageCodeLensProvider.provideCodeLenses();
+        lensesObj = { lenses: codeLenses };
+        expect(lensesObj).to.have.nested.property(
+          'lenses[0].command.title',
+          'Exclude Import Statements'
+        );
+        expect(lensesObj).to.have.nested.property(
+          'lenses[1].command.title',
+          'Include Driver Syntax'
+        );
+        expect(lensesObj).to.have.nested.property(
+          'lenses[2].command.title',
+          'Use Builders'
+        );
+
+        // imports without driver syntax are limited
+        const rawQueryWithImport =
+          'import org.bson.Document;\n\nnew Document("name", "22")';
+        expect(
+          mdbTestExtension.testExtensionController._playgroundController
+            ._playgroundResult?.content
+        ).to.deep.equal(rawQueryWithImport);
       });
 
-      test('include driver syntax and import statements', async () => {
+      test('include driver syntax and import statements (in a single export)', async () => {
         const codeActions = testCodeActionProvider.provideCodeActions();
-        expect(codeActions).to.exist;
 
-        if (codeActions) {
-          expect(codeActions.length).to.be.equal(TOTAL_CODEACTIONS_COUNT);
-          const actionCommand = codeActions[2].command;
-
-          if (actionCommand) {
-            expect(actionCommand.command).to.be.equal('mdb.exportToJava');
-            expect(actionCommand.title).to.be.equal('Export To Java');
-
-            await vscode.commands.executeCommand(actionCommand.command);
-
-            const codeLenses =
-              mdbTestExtension.testExtensionController._playgroundController._exportToLanguageCodeLensProvider.provideCodeLenses();
-            expect(codeLenses.length).to.be.equal(3);
-            const lensesObj = { lenses: codeLenses };
-            expect(lensesObj).to.have.nested.property(
-              'lenses[0].command.title',
-              'Include Import Statements'
-            );
-            expect(lensesObj).to.have.nested.property(
-              'lenses[1].command.title',
-              'Include Driver Syntax'
-            );
-            expect(lensesObj).to.have.nested.property(
-              'lenses[2].command.title',
-              'Use Builders'
-            );
-          }
-
-          // Only java queries supports builders.
-          await vscode.commands.executeCommand(
-            'mdb.changeExportToLanguageAddons',
-            {
-              ...mdbTestExtension.testExtensionController._playgroundController
-                ._exportToLanguageCodeLensProvider._exportToLanguageAddons,
-              builders: false,
-              importStatements: true,
-              driverSyntax: true,
-            }
-          );
-
-          const codeLenses =
-            mdbTestExtension.testExtensionController._playgroundController._exportToLanguageCodeLensProvider.provideCodeLenses();
-          const lensesObj = { lenses: codeLenses };
-          expect(lensesObj).to.have.nested.property(
-            'lenses[0].command.title',
-            'Exclude Import Statements'
-          );
-          expect(lensesObj).to.have.nested.property(
-            'lenses[1].command.title',
-            'Exclude Driver Syntax'
-          );
-          expect(lensesObj).to.have.nested.property(
-            'lenses[2].command.title',
-            'Use Builders'
-          );
-
-          // Java includes generic import statements
-          const mongoClientImport = 'import com.mongodb.MongoClient;';
-          // but also import statements which depend on the exportToLanguageMode. the following is for QUERY
-          const queryImport = 'import com.mongodb.client.FindIterable;';
-          const content =
-            mdbTestExtension.testExtensionController._playgroundController
-              ._playgroundResult?.content;
-          expect(content).to.include(mongoClientImport);
-          expect(content).to.include(queryImport);
+        if (!codeActions) {
+          expect.fail('No code actions');
+          return false;
         }
+
+        expect(codeActions.length).to.be.equal(TOTAL_CODEACTIONS_COUNT);
+        const actionCommand = codeActions[2].command;
+
+        if (!actionCommand) {
+          expect.fail('Action command not found');
+          return false;
+        }
+
+        expect(actionCommand.command).to.be.equal('mdb.exportToJava');
+        expect(actionCommand.title).to.be.equal('Export To Java');
+
+        await vscode.commands.executeCommand(actionCommand.command);
+
+        let codeLenses =
+          mdbTestExtension.testExtensionController._playgroundController._exportToLanguageCodeLensProvider.provideCodeLenses();
+        expect(codeLenses.length).to.be.equal(3);
+        let lensesObj = { lenses: codeLenses };
+        expect(lensesObj).to.have.nested.property(
+          'lenses[0].command.title',
+          'Include Import Statements'
+        );
+        expect(lensesObj).to.have.nested.property(
+          'lenses[1].command.title',
+          'Include Driver Syntax'
+        );
+        expect(lensesObj).to.have.nested.property(
+          'lenses[2].command.title',
+          'Use Builders'
+        );
+        await vscode.commands.executeCommand(
+          'mdb.changeExportToLanguageAddons',
+          {
+            ...mdbTestExtension.testExtensionController._playgroundController
+              ._exportToLanguageCodeLensProvider._exportToLanguageAddons,
+            builders: false,
+            importStatements: true,
+            driverSyntax: true,
+          }
+        );
+
+        codeLenses =
+          mdbTestExtension.testExtensionController._playgroundController._exportToLanguageCodeLensProvider.provideCodeLenses();
+        lensesObj = { lenses: codeLenses };
+        expect(lensesObj).to.have.nested.property(
+          'lenses[0].command.title',
+          'Exclude Import Statements'
+        );
+        expect(lensesObj).to.have.nested.property(
+          'lenses[1].command.title',
+          'Exclude Driver Syntax'
+        );
+        expect(lensesObj).to.have.nested.property(
+          'lenses[2].command.title',
+          'Use Builders'
+        );
+
+        // With driver syntax, java includes generic import statements
+        const mongoClientImport = 'import com.mongodb.MongoClient;';
+        // as well as import statements which depend on the exportToLanguageMode. the following is for QUERY
+        const queryImport = 'import com.mongodb.client.FindIterable;';
+        const content =
+          mdbTestExtension.testExtensionController._playgroundController
+            ._playgroundResult?.content;
+        expect(content).to.include(mongoClientImport);
+        expect(content).to.include(queryImport);
+      });
+
+      test('include driver syntax and then import statements in a subsequent export', async () => {
+        const codeActions = testCodeActionProvider.provideCodeActions();
+
+        if (!codeActions) {
+          expect.fail('No code actions');
+          return false;
+        }
+
+        expect(codeActions.length).to.be.equal(TOTAL_CODEACTIONS_COUNT);
+        const actionCommand = codeActions[2].command;
+
+        if (!actionCommand) {
+          expect.fail('Action command not found');
+          return false;
+        }
+
+        expect(actionCommand.command).to.be.equal('mdb.exportToJava');
+        expect(actionCommand.title).to.be.equal('Export To Java');
+
+        /* 1st export - we'll select drivers only */
+        await vscode.commands.executeCommand(actionCommand.command);
+
+        let codeLenses =
+          mdbTestExtension.testExtensionController._playgroundController._exportToLanguageCodeLensProvider.provideCodeLenses();
+        expect(codeLenses.length).to.be.equal(3);
+        let lensesObj = { lenses: codeLenses };
+        expect(lensesObj).to.have.nested.property(
+          'lenses[0].command.title',
+          'Include Import Statements'
+        );
+        expect(lensesObj).to.have.nested.property(
+          'lenses[1].command.title',
+          'Include Driver Syntax'
+        );
+        expect(lensesObj).to.have.nested.property(
+          'lenses[2].command.title',
+          'Use Builders'
+        );
+
+        await vscode.commands.executeCommand(
+          'mdb.changeExportToLanguageAddons',
+          {
+            ...mdbTestExtension.testExtensionController._playgroundController
+              ._exportToLanguageCodeLensProvider._exportToLanguageAddons,
+            builders: false,
+            importStatements: false,
+            driverSyntax: true,
+          }
+        );
+
+        codeLenses =
+          mdbTestExtension.testExtensionController._playgroundController._exportToLanguageCodeLensProvider.provideCodeLenses();
+        lensesObj = { lenses: codeLenses };
+        expect(lensesObj).to.have.nested.property(
+          'lenses[0].command.title',
+          'Include Import Statements'
+        );
+        expect(lensesObj).to.have.nested.property(
+          'lenses[1].command.title',
+          'Exclude Driver Syntax'
+        );
+        expect(lensesObj).to.have.nested.property(
+          'lenses[2].command.title',
+          'Use Builders'
+        );
+
+        /* 2nd export - this time we add import statements on top of drivers */
+        await vscode.commands.executeCommand(actionCommand.command);
+
+        codeLenses =
+          mdbTestExtension.testExtensionController._playgroundController._exportToLanguageCodeLensProvider.provideCodeLenses();
+        expect(codeLenses.length).to.be.equal(3);
+        lensesObj = { lenses: codeLenses };
+        // the state is persisted from the 1st export
+        expect(lensesObj).to.have.nested.property(
+          'lenses[1].command.title',
+          'Exclude Driver Syntax'
+        );
+
+        // We add import on top of the drivers
+        await vscode.commands.executeCommand(
+          'mdb.changeExportToLanguageAddons',
+          {
+            ...mdbTestExtension.testExtensionController._playgroundController
+              ._exportToLanguageCodeLensProvider._exportToLanguageAddons,
+            importStatements: true,
+          }
+        );
+
+        codeLenses =
+          mdbTestExtension.testExtensionController._playgroundController._exportToLanguageCodeLensProvider.provideCodeLenses();
+        expect(codeLenses.length).to.be.equal(3);
+        lensesObj = { lenses: codeLenses };
+        // the state is persisted from the 1st export
+        expect(lensesObj).to.have.nested.property(
+          'lenses[0].command.title',
+          'Exclude Import Statements'
+        );
+        expect(lensesObj).to.have.nested.property(
+          'lenses[1].command.title',
+          'Exclude Driver Syntax'
+        );
+
+        // The imports and driver syntax are both applied
+        const mongoClientImport = 'import com.mongodb.MongoClient;';
+        const queryImport = 'import com.mongodb.client.FindIterable;';
+        const content =
+          mdbTestExtension.testExtensionController._playgroundController
+            ._playgroundResult?.content;
+        expect(content).to.include(mongoClientImport);
+        expect(content).to.include(queryImport);
       });
     });
 


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. VSCODE-1111: updates ace editor width in agg pipeline view -->
<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->
## Description

The `getImports` transpiler method expects two arguments
- `mode: 'Pipeline' | 'Query' | 'Delete Query' | 'Update Query'`
- `driverSyntax: boolean`

source: https://github.com/mongodb-js/compass/blob/92f267e369d188c5f11c2450f3d65f73725558e4/packages/bson-transpilers/codegeneration/CodeGenerationVisitor.js#L94

In VSCode we have only two modes:
- when an array is selected -> aggregate ~ Pipeline
- when an object is selected -> find ~ Query

The main fix is sending two arguments (which allows for the second to be read correctly).

As far as I can tell, the exact mode only matters for Java. Given that the method applied is a wild guess, user might need to adjust the import together with the code anyway, but at least the imports now match the code.

### Steps to reproduce:
- select an object/array in the playground
- export to Java
- include Driver Syntax and Import Statements

### Current behaviour:
The import statements are only
```
import org.bson.Document;
``` 

### After the fix:
```
import org.bson.Document;
import com.mongodb.MongoClient;
import com.mongodb.MongoClientURI;
import com.mongodb.client.MongoCollection;
import com.mongodb.client.MongoDatabase;
import org.bson.conversions.Bson;
import java.util.concurrent.TimeUnit;
import org.bson.Document;
```

If you've selected an array, you'll also see -
```
import com.mongodb.client.AggregateIterable;
```
And for an object -
```
import com.mongodb.client.FindIterable;
```

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
I feel weird about the test placement, but this was the best I found.
I made an attempt to at least separate the test into three smaller pieces. I thought it would work since mocha runs the tests sequentially, but it didn't work and I gave up 😅 . I haven't worked with mocha for a long time, so maybe I'm missing something

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
