### PR TITLE
chore(dependabot): update dependabot to use the increase strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@
 version: 2
 updates:
   - package-ecosystem: npm
+    versioning-strategy: increase
     directory: /
     schedule:
       interval: daily


### PR DESCRIPTION
Use increase strategy to bump both `package.json` and `package-lock.json`