### PR TITLE
fix: remove userId COMPASS-7608

### DIFF
--- a/src/explorer/helpTree.ts
+++ b/src/explorer/helpTree.ts
@@ -120,11 +120,7 @@ export default class HelpTree
 
       const atlas = new HelpLinkTreeItem({
         title: 'Create Free Atlas Cluster',
-        url: LINKS.createAtlasCluster(
-          telemetryUserIdentity?.userId ??
-            telemetryUserIdentity?.anonymousId ??
-            ''
-        ),
+        url: LINKS.createAtlasCluster(telemetryUserIdentity?.anonymousId ?? ''),
         linkId: 'freeClusterCTA',
         iconName: 'atlas',
         useRedirect: true,

--- a/src/storage/storageController.ts
+++ b/src/storage/storageController.ts
@@ -90,22 +90,12 @@ export default class StorageController {
   }
 
   getUserIdentity() {
-    const userId = this.get(StorageVariables.GLOBAL_USER_ID);
     let anonymousId = this.get(StorageVariables.GLOBAL_ANONYMOUS_ID);
 
+    // The anonymousId becomes required with analytics-node v6.
     if (!anonymousId) {
       anonymousId = uuidv4();
       void this.update(StorageVariables.GLOBAL_ANONYMOUS_ID, anonymousId);
-    }
-
-    // Initially, we used `userId` as Segment user identifier, but this usage is being deprecated.
-    // The `anonymousId` should be used instead.
-    // We keep sending `userId` to Segment for old users though to preserve their analytics.
-    if (userId && typeof userId === 'string') {
-      return {
-        userId,
-        anonymousId, // The anonymousId becomes required with analytics-node v6.
-      };
     }
 
     return { anonymousId };

--- a/src/telemetry/telemetryService.ts
+++ b/src/telemetry/telemetryService.ts
@@ -25,7 +25,6 @@ type PlaygroundTelemetryEventProperties = {
 
 export type SegmentProperties = {
   event: string;
-  userId?: string;
   anonymousId: string;
   properties: Record<string, any>;
 };
@@ -128,7 +127,6 @@ export enum TelemetryEventTypes {
  */
 export default class TelemetryService {
   _segmentAnalytics?: SegmentAnalytics;
-  _segmentUserId?: string;
   _segmentAnonymousId: string;
   _segmentKey?: string; // The segment API write key.
 
@@ -140,10 +138,9 @@ export default class TelemetryService {
     context: vscode.ExtensionContext,
     shouldTrackTelemetry?: boolean
   ) {
-    const { userId, anonymousId } = storageController.getUserIdentity();
+    const { anonymousId } = storageController.getUserIdentity();
     this._context = context;
     this._shouldTrackTelemetry = shouldTrackTelemetry || false;
-    this._segmentUserId = userId;
     this._segmentAnonymousId = anonymousId;
     this._segmentKey = this._readSegmentKey();
   }
@@ -295,13 +292,6 @@ export default class TelemetryService {
   }
 
   getTelemetryUserIdentity() {
-    if (this._segmentUserId) {
-      return {
-        userId: this._segmentUserId,
-        anonymousId: this._segmentAnonymousId,
-      };
-    }
-
     return {
       anonymousId: this._segmentAnonymousId,
     };

--- a/src/test/suite/explorer/helpExplorer.test.ts
+++ b/src/test/suite/explorer/helpExplorer.test.ts
@@ -45,11 +45,11 @@ suite('Help Explorer Test Suite', function () {
 
     assert.strictEqual(atlasHelpItem.label, 'Create Free Atlas Cluster');
     assert.strictEqual(atlasHelpItem.url.includes('mongodb.com'), true);
-    const { userId, anonymousId } =
+    const { anonymousId } =
       mdbTestExtension.testExtensionController._telemetryService.getTelemetryUserIdentity();
     assert.strictEqual(
       new URL(atlasHelpItem.url).searchParams.get('ajs_aid'),
-      userId ?? anonymousId
+      anonymousId
     );
     assert.strictEqual(atlasHelpItem.iconName, 'atlas');
     assert.strictEqual(atlasHelpItem.linkId, 'freeClusterCTA');

--- a/src/test/suite/storage/storageController.test.ts
+++ b/src/test/suite/storage/storageController.test.ts
@@ -1,6 +1,4 @@
 import assert from 'assert';
-import { before } from 'mocha';
-import { v4 as uuidv4 } from 'uuid';
 
 import StorageController, {
   StorageVariables,
@@ -45,7 +43,7 @@ suite('Storage Controller Test Suite', () => {
     );
   });
 
-  suite('for a new user that does not have anonymousId or userId', () => {
+  suite('for a new user that does not have anonymousId', () => {
     const extensionContextStub = new ExtensionContextStub();
     extensionContextStub._globalState = {};
     const testStorageController = new StorageController(extensionContextStub);
@@ -55,34 +53,7 @@ suite('Storage Controller Test Suite', () => {
       const anonymousId = testStorageController.get(
         StorageVariables.GLOBAL_ANONYMOUS_ID
       );
-      const userId = testStorageController.get(StorageVariables.GLOBAL_USER_ID);
       assert.deepStrictEqual(userIdentity, { anonymousId });
-      assert(!userId);
-    });
-  });
-
-  suite('for an old user that does not have anonymousId but has userId', () => {
-    const extensionContextStub = new ExtensionContextStub();
-    extensionContextStub._globalState = {};
-    const testStorageController = new StorageController(extensionContextStub);
-    const id = uuidv4();
-
-    before(async () => {
-      await testStorageController.update(
-        StorageVariables.GLOBAL_USER_ID,
-        id,
-        StorageLocation.GLOBAL
-      );
-    });
-
-    test('getUserIdentity returns userId from the global storage and returns it to telemetry', () => {
-      const userIdentity = testStorageController.getUserIdentity();
-      const anonymousId = testStorageController.get(
-        StorageVariables.GLOBAL_ANONYMOUS_ID
-      );
-      const userId = testStorageController.get(StorageVariables.GLOBAL_USER_ID);
-      assert(userId === id);
-      assert.deepStrictEqual(userIdentity, { userId, anonymousId });
     });
   });
 });

--- a/src/views/webviewController.ts
+++ b/src/views/webviewController.ts
@@ -328,8 +328,7 @@ export default class WebviewController {
 
     panel.webview.html = getWebviewContent({
       extensionPath,
-      telemetryUserId:
-        telemetryUserIdentity.anonymousId || telemetryUserIdentity.userId,
+      telemetryUserId: telemetryUserIdentity.anonymousId,
       webview: panel.webview,
     });
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/COMPASS-7608

## Description

The main aim is to avoid sending `userId` to telemetry. But since `anonymousId` is always created when not present (for about a year as far as I can tell), I figured we should be able to drop the deprecated `userId` altogether. 
I might be wrong - the part that puzzles me is it's use in `createAtlasCluster`, where it was preferred to `anonymousId`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
See the description


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
