### PR TITLE
feat: show simpler uuid format VSCODE-470

### DIFF
--- a/src/editors/mongoDBDocumentService.ts
+++ b/src/editors/mongoDBDocumentService.ts
@@ -108,13 +108,9 @@ export default class MongoDBDocumentService {
     }
   }
 
+  // This is to revert the effects of simplifyEJSON
   extendEJSON(document: Document): Document {
     for (const [key, item] of Object.entries(document)) {
-      // UUIDs might be represented as {"$uuid": <canonical textual representation of a UUID>} in EJSON
-      // Binary subtypes 3 or 4 are used to represent UUIDs in BSON
-      // But, parsers MUST interpret the $uuid key as BSON Binary subtype 4
-      // For this reason, we are applying this representation for subtype 4 only
-      // see https://github.com/mongodb/specifications/blob/master/source/extended-json.rst#special-rules-for-parsing-uuid-fields
       if (item.hasOwnProperty('$uuid')) {
         const base64 = Buffer.from(
           item.$uuid.replaceAll('-', ''),

--- a/src/editors/mongoDBDocumentService.ts
+++ b/src/editors/mongoDBDocumentService.ts
@@ -120,8 +120,9 @@ export default class MongoDBDocumentService {
       // see https://github.com/mongodb/specifications/blob/master/source/extended-json.rst#special-rules-for-parsing-uuid-fields
       if (
         isObject(item) &&
-        item.hasOwnProperty('$binary') &&
-        item.$binary.subType === '04'
+        Object.prototype.hasOwnProperty.call(item, '$binary') &&
+        item.$binary?.subType === '04' &&
+        typeof item.$binary.base64 === 'string'
       ) {
         const hexString = Buffer.from(item.$binary.base64, 'base64').toString(
           'hex'

--- a/src/editors/mongoDBDocumentService.ts
+++ b/src/editors/mongoDBDocumentService.ts
@@ -111,7 +111,7 @@ export default class MongoDBDocumentService {
     }
   }
 
-  simplifyEJSON(document: Document): Document {
+  _simplifyEJSON(document: Document): Document {
     for (const [key, item] of Object.entries(document)) {
       // UUIDs might be represented as {"$uuid": <canonical textual representation of a UUID>} in EJSON
       // Binary subtypes 3 or 4 are used to represent UUIDs in BSON
@@ -177,7 +177,7 @@ export default class MongoDBDocumentService {
       }
 
       const ejson = JSON.parse(EJSON.stringify(documents[0]));
-      return this.simplifyEJSON(ejson);
+      return this._simplifyEJSON(ejson);
     } catch (error) {
       this._statusView.hideMessage();
 

--- a/src/editors/mongoDBDocumentService.ts
+++ b/src/editors/mongoDBDocumentService.ts
@@ -18,6 +18,9 @@ export const DOCUMENT_SOURCE_URI_IDENTIFIER = 'source';
 
 export const VIEW_DOCUMENT_SCHEME = 'VIEW_DOCUMENT_SCHEME';
 
+const isObject = (value: unknown) =>
+  value !== null && typeof value === 'object' && !Array.isArray(value);
+
 export default class MongoDBDocumentService {
   _context: vscode.ExtensionContext;
   _connectionController: ConnectionController;
@@ -111,7 +114,7 @@ export default class MongoDBDocumentService {
   // This is to revert the effects of simplifyEJSON
   extendEJSON(document: Document): Document {
     for (const [key, item] of Object.entries(document)) {
-      if (item.hasOwnProperty('$uuid')) {
+      if (isObject(item) && item.hasOwnProperty('$uuid')) {
         const base64 = Buffer.from(
           item.$uuid.replaceAll('-', ''),
           'hex'
@@ -134,7 +137,11 @@ export default class MongoDBDocumentService {
       // But, parsers MUST interpret the $uuid key as BSON Binary subtype 4
       // For this reason, we are applying this representation for subtype 4 only
       // see https://github.com/mongodb/specifications/blob/master/source/extended-json.rst#special-rules-for-parsing-uuid-fields
-      if (item.hasOwnProperty('$binary') && item.$binary.subType === '04') {
+      if (
+        isObject(item) &&
+        item.hasOwnProperty('$binary') &&
+        item.$binary.subType === '04'
+      ) {
         const hexString = Buffer.from(item.$binary.base64, 'base64').toString(
           'hex'
         );

--- a/src/editors/mongoDBDocumentService.ts
+++ b/src/editors/mongoDBDocumentService.ts
@@ -96,7 +96,7 @@ export default class MongoDBDocumentService {
       await dataService.findOneAndReplace(
         namespace,
         { _id: documentId },
-        this.extendEJSON(newDocument),
+        newDocument,
         {
           returnDocument: 'after',
         }
@@ -109,25 +109,6 @@ export default class MongoDBDocumentService {
 
       return this._saveDocumentFailed(formatError(error).message);
     }
-  }
-
-  // This is to revert the effects of simplifyEJSON
-  extendEJSON(document: Document): Document {
-    for (const [key, item] of Object.entries(document)) {
-      if (isObject(item) && item.hasOwnProperty('$uuid')) {
-        const base64 = Buffer.from(
-          item.$uuid.replaceAll('-', ''),
-          'hex'
-        ).toString('base64');
-        document[key] = {
-          $binary: {
-            base64,
-            subType: '04',
-          },
-        };
-      }
-    }
-    return document;
   }
 
   simplifyEJSON(document: Document): Document {

--- a/src/language/worker.ts
+++ b/src/language/worker.ts
@@ -1,5 +1,4 @@
 import { CliServiceProvider } from '@mongosh/service-provider-server';
-import { EJSON } from 'bson';
 import { ElectronRuntime } from '@mongosh/browser-runtime-electron';
 import { parentPort } from 'worker_threads';
 import { ServerCommands } from './serverCommands';
@@ -10,6 +9,7 @@ import type {
   MongoClientOptions,
 } from '../types/playgroundType';
 import util from 'util';
+import { getEJSON } from '../utils/ejson';
 
 interface EvaluationResult {
   printable: any;
@@ -18,12 +18,12 @@ interface EvaluationResult {
 
 const getContent = ({ type, printable }: EvaluationResult) => {
   if (type === 'Cursor' || type === 'AggregationCursor') {
-    return JSON.parse(EJSON.stringify(printable.documents));
+    return getEJSON(printable.documents);
   }
 
   return typeof printable !== 'object' || printable === null
     ? printable
-    : JSON.parse(EJSON.stringify(printable));
+    : getEJSON(printable);
 };
 
 const getLanguage = (evaluationResult: EvaluationResult) => {

--- a/src/test/suite/editors/mongoDBDocumentService.test.ts
+++ b/src/test/suite/editors/mongoDBDocumentService.test.ts
@@ -178,7 +178,7 @@ suite('MongoDB Document Service Test Suite', () => {
     expect(result).to.be.deep.equal(JSON.parse(EJSON.stringify(documents[0])));
   });
 
-  test('fetchDocument simplifies the uuid type', async () => {
+  test('fetchDocument calls find and returns a single document when connected - simplifying the uuid type', async () => {
     const namespace = 'waffle.house';
     const connectionId = 'tasty_sandwhich';
     const documentId = '93333a0d-83f6-4e6f-a575-af7ea6187a4a';

--- a/src/test/suite/editors/mongoDBDocumentService.test.ts
+++ b/src/test/suite/editors/mongoDBDocumentService.test.ts
@@ -175,7 +175,7 @@ suite('MongoDB Document Service Test Suite', () => {
       source,
     });
 
-    expect(result).to.be.deep.equal(JSON.parse(EJSON.stringify(documents[0])));
+    expect(result).to.be.deep.equal(EJSON.serialize(documents[0]));
   });
 
   test('fetchDocument calls find and returns a single document when connected - simplifying the uuid type', async () => {

--- a/src/test/suite/editors/mongoDBDocumentService.test.ts
+++ b/src/test/suite/editors/mongoDBDocumentService.test.ts
@@ -87,6 +87,57 @@ suite('MongoDB Document Service Test Suite', () => {
     expect(document).to.be.deep.equal(newDocument);
   });
 
+  test('replaceDocument calls findOneAndReplace and saves a document when connected - extending the uuid type', async () => {
+    const namespace = 'waffle.house';
+    const connectionId = 'tasty_sandwhich';
+    const documentId = '93333a0d-83f6-4e6f-a575-af7ea6187a4a';
+    const document: { _id: string; myUuid?: { $uuid: string } } = {
+      _id: '123',
+    };
+    const newDocument = {
+      _id: '123',
+      myUuid: {
+        $binary: {
+          base64: 'yO2rw/c4TKO2jauSqRR4ow==',
+          subType: '04',
+        },
+      },
+    };
+    const source = DocumentSource.DOCUMENT_SOURCE_TREEVIEW;
+
+    const fakeActiveConnectionId = sandbox.fake.returns('tasty_sandwhich');
+    sandbox.replace(
+      testConnectionController,
+      'getActiveConnectionId',
+      fakeActiveConnectionId
+    );
+
+    const fakeGetActiveDataService = sandbox.fake.returns({
+      findOneAndReplace: () => {
+        document.myUuid = { $uuid: 'c8edabc3-f738-4ca3-b68d-ab92a91478a3' };
+
+        return Promise.resolve(document);
+      },
+    });
+    sandbox.replace(
+      testConnectionController,
+      'getActiveDataService',
+      fakeGetActiveDataService
+    );
+    sandbox.stub(testStatusView, 'showMessage');
+    sandbox.stub(testStatusView, 'hideMessage');
+
+    await testMongoDBDocumentService.replaceDocument({
+      namespace,
+      documentId,
+      connectionId,
+      newDocument,
+      source,
+    });
+
+    expect(document).to.be.deep.equal(document);
+  });
+
   test('fetchDocument calls find and returns a single document when connected', async () => {
     const namespace = 'waffle.house';
     const connectionId = 'tasty_sandwhich';
@@ -97,7 +148,7 @@ suite('MongoDB Document Service Test Suite', () => {
 
     const fakeGetActiveDataService = sandbox.fake.returns({
       find: () => {
-        return Promise.resolve([{ _id: '123' }]);
+        return Promise.resolve(documents);
       },
     });
     sandbox.replace(
@@ -125,6 +176,59 @@ suite('MongoDB Document Service Test Suite', () => {
     });
 
     expect(result).to.be.deep.equal(JSON.parse(EJSON.stringify(documents[0])));
+  });
+
+  test('fetchDocument simplifies the uuid type', async () => {
+    const namespace = 'waffle.house';
+    const connectionId = 'tasty_sandwhich';
+    const documentId = '93333a0d-83f6-4e6f-a575-af7ea6187a4a';
+    const line = 1;
+    const documents = [
+      {
+        _id: '123',
+        myUuid: {
+          $binary: {
+            base64: 'yO2rw/c4TKO2jauSqRR4ow==',
+            subType: '04',
+          },
+        },
+      },
+    ];
+    const source = DocumentSource.DOCUMENT_SOURCE_PLAYGROUND;
+
+    const fakeGetActiveDataService = sandbox.fake.returns({
+      find: () => {
+        return Promise.resolve(documents);
+      },
+    });
+    sandbox.replace(
+      testConnectionController,
+      'getActiveDataService',
+      fakeGetActiveDataService
+    );
+
+    const fakeGetActiveConnectionId = sandbox.fake.returns(connectionId);
+    sandbox.replace(
+      testConnectionController,
+      'getActiveConnectionId',
+      fakeGetActiveConnectionId
+    );
+
+    sandbox.stub(testStatusView, 'showMessage');
+    sandbox.stub(testStatusView, 'hideMessage');
+
+    const result = await testMongoDBDocumentService.fetchDocument({
+      namespace,
+      documentId,
+      line,
+      connectionId,
+      source,
+    });
+
+    expect(result).to.be.deep.equal({
+      _id: '123',
+      myUuid: { $uuid: 'c8edabc3-f738-4ca3-b68d-ab92a91478a3' },
+    });
   });
 
   test("if a user is not connected, documents won't be saved to MongoDB", async () => {

--- a/src/test/suite/utils/ejson.test.ts
+++ b/src/test/suite/utils/ejson.test.ts
@@ -1,0 +1,98 @@
+import { expect } from 'chai';
+import { getEJSON } from '../../../utils/ejson';
+
+suite('getEJSON', function () {
+  suite('Valid uuid', function () {
+    const prettyUuid = {
+      $uuid: '63b985b8-e8dd-4bda-9087-e4402f1a3ff5',
+    };
+    const rawUuid = {
+      $binary: {
+        base64: 'Y7mFuOjdS9qQh+RALxo/9Q==',
+        subType: '04',
+      },
+    };
+
+    test('Simplifies top-level uuid', function () {
+      const ejson = getEJSON({ uuid: rawUuid });
+      expect(ejson).to.deep.equal({ uuid: prettyUuid });
+    });
+
+    test('Simplifies nested uuid', function () {
+      const ejson = getEJSON({
+        grandparent: {
+          parent: {
+            sibling: 1,
+            uuid: rawUuid,
+          },
+        },
+      });
+      expect(ejson).to.deep.equal({
+        grandparent: {
+          parent: {
+            sibling: 1,
+            uuid: prettyUuid,
+          },
+        },
+      });
+    });
+
+    test('Simplifies uuid in a nested array', function () {
+      const ejson = getEJSON({
+        items: [
+          {
+            parent: {
+              sibling: 1,
+              uuid: rawUuid,
+            },
+          },
+        ],
+      });
+      expect(ejson).to.deep.equal({
+        items: [
+          {
+            parent: {
+              sibling: 1,
+              uuid: prettyUuid,
+            },
+          },
+        ],
+      });
+    });
+  });
+
+  suite('Invalid uuid or not an uuid', function () {
+    test('Ignores another subtype', function () {
+      const document = {
+        $binary: {
+          base64: 'Y7mFuOjdS9qQh+RALxo/9Q==',
+          subType: '02',
+        },
+      };
+      const ejson = getEJSON(document);
+      expect(ejson).to.deep.equal(document);
+    });
+
+    test('Ignores invalid uuid', function () {
+      const document = {
+        $binary: {
+          base64: 'Y7m==',
+          subType: '04',
+        },
+      };
+      const ejson = getEJSON(document);
+      expect(ejson).to.deep.equal(document);
+    });
+
+    test('Ignores null', function () {
+      const document = {
+        $binary: {
+          base64: null,
+          subType: '04',
+        },
+      };
+      const ejson = getEJSON(document);
+      expect(ejson).to.deep.equal(document);
+    });
+  });
+});

--- a/src/utils/ejson.ts
+++ b/src/utils/ejson.ts
@@ -40,6 +40,6 @@ function simplifyEJSON(item: Document[] | Document): Document {
 }
 
 export function getEJSON(item: Document[] | Document) {
-  const ejson = JSON.parse(EJSON.stringify(item));
+  const ejson = EJSON.serialize(item);
   return simplifyEJSON(ejson);
 }

--- a/src/utils/ejson.ts
+++ b/src/utils/ejson.ts
@@ -1,0 +1,46 @@
+import { EJSON } from 'bson';
+import type { Document } from 'bson';
+
+const isObject = (value: unknown) =>
+  value !== null && typeof value === 'object';
+
+function simplifyEJSON(documents: Document[] | Document): Document {
+  if (!isObject(documents)) return documents;
+
+  if (Array.isArray(documents)) {
+    return documents.map((item) =>
+      isObject(item) ? simplifyEJSON(item) : item
+    );
+  }
+
+  // UUIDs might be represented as {"$uuid": <canonical textual representation of a UUID>} in EJSON
+  // Binary subtypes 3 or 4 are used to represent UUIDs in BSON
+  // But, parsers MUST interpret the $uuid key as BSON Binary subtype 4
+  // For this reason, we are applying this representation for subtype 4 only
+  // see https://github.com/mongodb/specifications/blob/master/source/extended-json.rst#special-rules-for-parsing-uuid-fields
+  if (
+    Object.prototype.hasOwnProperty.call(documents, '$binary') &&
+    documents.$binary?.subType === '04' &&
+    typeof documents.$binary.base64 === 'string'
+  ) {
+    const hexString = Buffer.from(documents.$binary.base64, 'base64').toString(
+      'hex'
+    );
+    const match = /^(.{8})(.{4})(.{4})(.{4})(.{12})$/.exec(hexString);
+    if (!match) return documents;
+    const asUUID = match.slice(1, 6).join('-');
+    return { $uuid: asUUID };
+  }
+
+  return Object.fromEntries(
+    Object.entries(documents).map(([key, value]) => [
+      key,
+      isObject(value) ? simplifyEJSON(value) : value,
+    ])
+  );
+}
+
+export function getEJSON(documents: Document[] | Document) {
+  const ejson = JSON.parse(EJSON.stringify(documents));
+  return simplifyEJSON(ejson);
+}


### PR DESCRIPTION
https://jira.mongodb.org/browse/VSCODE-470

## Description
Adding postprocessing in the Document Service, which replaces the extended `$binary` notation with `$uuid` notation when presenting the document. Originally I thought we should reverse this on `replaceDocument`, but it looks like this is not necessary - I assume this is handled by the driver. I left the test case for regression, but perhaps it's not necessary.

Aside of the new tests, I have tested this with the `all_types` collection of `compass-data-sets/test`. I added a couple of new fields to the first document - `nested_uuid` and `nested_array_uuid`
I tried
- opening a document from the left side panel
- playground results for `findOne()`
- playground results for `find()`

### Checklist
- [x] New tests and/or benchmarks are included

## Motivation and Context
- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
