### PR TITLE
Skunktendo 2024: automatically detect Local Atlas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "bson-transpilers": "^2.2.0",
         "debug": "^4.3.4",
         "dotenv": "^16.3.1",
-        "express": "^4.19.2",
+        "jsonlines": "^0.1.1",
         "lodash": "^4.17.21",
         "micromatch": "^4.0.5",
         "mongodb": "^6.3.0",
@@ -15657,6 +15657,11 @@
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "node_modules/jsonlines": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsonlines/-/jsonlines-0.1.1.tgz",
+      "integrity": "sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA=="
     },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.4",
@@ -35783,6 +35788,11 @@
       "requires": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "jsonlines": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsonlines/-/jsonlines-0.1.1.tgz",
+      "integrity": "sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA=="
     },
     "jsx-ast-utils": {
       "version": "3.3.4",

--- a/package.json
+++ b/package.json
@@ -275,6 +275,10 @@
         "title": "Copy Connection String"
       },
       {
+        "command": "mdb.openInCompass",
+        "title": "Open in Compass"
+      },
+      {
         "command": "mdb.renameConnection",
         "title": "Rename Connection..."
       },
@@ -429,6 +433,10 @@
       {
         "command": "mdb.dropStreamProcessor",
         "title": "Drop Stream Processor..."
+      },
+      {
+        "command": "mdb.reloadConnections",
+        "title": "MongoDB: Reload Connections"
       }
     ],
     "menus": {
@@ -504,6 +512,11 @@
           "group": "4@1"
         },
         {
+          "command": "mdb.openInCompass",
+          "when": "view == mongoDBConnectionExplorer && viewItem == connectedConnectionTreeItem",
+          "group": "4@1"
+        },
+        {
           "command": "mdb.disconnectFromConnectionTreeItem",
           "when": "view == mongoDBConnectionExplorer && viewItem == connectedConnectionTreeItem",
           "group": "5@1"
@@ -535,6 +548,11 @@
         },
         {
           "command": "mdb.copyConnectionString",
+          "when": "view == mongoDBConnectionExplorer && viewItem == disconnectedConnectionTreeItem",
+          "group": "3@1"
+        },
+        {
+          "command": "mdb.openInCompass",
           "when": "view == mongoDBConnectionExplorer && viewItem == disconnectedConnectionTreeItem",
           "group": "3@1"
         },
@@ -773,6 +791,10 @@
           "when": "false"
         },
         {
+          "command": "mdb.openInCompass",
+          "when": "false"
+        },
+        {
           "command": "mdb.renameConnection",
           "when": "false"
         },
@@ -899,6 +921,10 @@
         {
           "command": "mdb.dropStreamProcessor",
           "when": "false"
+        },
+        {
+          "command": "mdb.reloadConnections",
+          "when": "true"
         }
       ]
     },
@@ -1091,6 +1117,7 @@
     "bson-transpilers": "^2.2.0",
     "debug": "^4.3.4",
     "dotenv": "^16.3.1",
+    "jsonlines": "^0.1.1",
     "lodash": "^4.17.21",
     "micromatch": "^4.0.5",
     "mongodb": "^6.3.0",

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -73,6 +73,9 @@ enum EXTENSION_COMMANDS {
   MDB_START_STREAM_PROCESSOR = 'mdb.startStreamProcessor',
   MDB_STOP_STREAM_PROCESSOR = 'mdb.stopStreamProcessor',
   MDB_DROP_STREAM_PROCESSOR = 'mdb.dropStreamProcessor',
+
+  MDB_RELOAD_CONNECTIONS = 'mdb.reloadConnections',
+  MDB_OPEN_IN_COMPASS = 'mdb.openInCompass',
 }
 
 export default EXTENSION_COMMANDS;

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -163,9 +163,13 @@ export default class ConnectionController {
       this._connections[connection.id] = connection;
     }
 
-    if (loadedConnections.length) {
-      this.eventEmitter.emit(DataServiceEventTypes.CONNECTIONS_DID_CHANGE);
+    for (const connectionId of Object.keys(this._connections)) {
+      if (!loadedConnections.find(c => c.id === connectionId)) {
+        delete this._connections[connectionId];
+      }
     }
+
+    this.eventEmitter.emit(DataServiceEventTypes.CONNECTIONS_DID_CHANGE);
 
     // TODO: re-enable with fewer 'Saved Connections Loaded' events
     // https://jira.mongodb.org/browse/VSCODE-462

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -155,6 +155,13 @@ export default class MDBExtensionController implements vscode.Disposable {
   registerCommands = (): void => {
     // Register our extension's commands. These are the event handlers and
     // control the functionality of our extension.
+
+    // ------ CONNECTIONS ------ //
+    this.registerCommand(EXTENSION_COMMANDS.MDB_RELOAD_CONNECTIONS, () => {
+      this._connectionController.loadSavedConnections();
+      return Promise.resolve(true);
+    });
+
     // ------ CONNECTION ------ //
     this.registerCommand(EXTENSION_COMMANDS.MDB_OPEN_OVERVIEW_PAGE, () => {
       this._webviewController.openWebview(this._context);
@@ -346,6 +353,20 @@ export default class MDBExtensionController implements vscode.Disposable {
 
         await vscode.env.clipboard.writeText(connectionString);
         void vscode.window.showInformationMessage('Copied to clipboard.');
+
+        return true;
+      }
+    );
+    this.registerCommand(
+      EXTENSION_COMMANDS.MDB_OPEN_IN_COMPASS,
+      async (element: ConnectionTreeItem): Promise<boolean> => {
+        const connectionString =
+          this._connectionController.copyConnectionStringByConnectionId(
+            element.connectionId
+          );
+
+        await vscode.env.openExternal(vscode.Uri.parse(connectionString));
+        void vscode.window.showInformationMessage('Opening connection in Compass...');
 
         return true;
       }

--- a/src/storage/connectionStorage.ts
+++ b/src/storage/connectionStorage.ts
@@ -15,6 +15,10 @@ import {
   StorageVariables,
 } from './storageController';
 
+import { spawn } from 'child_process';
+import jsonlines from 'jsonlines';
+import { URL } from 'url';
+
 const log = createLogger('connection storage');
 
 export interface StoreConnectionInfo {
@@ -33,6 +37,27 @@ type StoreConnectionInfoWithSecretStorageLocation = StoreConnectionInfo &
 
 export type LoadedConnection = StoreConnectionInfoWithConnectionOptions &
   StoreConnectionInfoWithSecretStorageLocation;
+
+
+interface ContainerPort {
+  host: string;
+  port: Number;
+  containerPort: Number;
+  protocol: 'tcp' | 'udp';
+}
+
+interface Container {
+  id: string;
+  name: string;
+  ports: ContainerPort[];
+}
+
+interface _Container {
+  ID: string;
+  Names: string;
+  Image: string;
+  Ports: string;
+}
 
 export class ConnectionStorage {
   _storageController: StorageController;
@@ -202,7 +227,98 @@ export class ConnectionStorage {
       })
     );
 
-    return loadedConnections;
+    return loadedConnections.concat(await this.loadConnectionsToLocalInstances());
+  }
+
+  static parsePorts(portsString) {
+    // Given the docker port string, parse it and return an array of objects
+    // Example input:
+    // 0.0.0.0:27778->27017/tcp
+    // Example output:
+    // [{ host: '0.0.0.0', port: 27778, containerPort: 27017, protocol: 'tcp' }]
+    return portsString.split(",").map((portString) => {
+      const [host, container] = portString.split("->");
+      const [hostIp, hostPort] = host.split(":");
+      const [containerPort, protocol] = container.split("/");
+      return {
+        host: hostIp,
+        port: parseInt(hostPort),
+        containerPort: parseInt(containerPort),
+        protocol,
+      };
+    });
+  }
+
+  static toLoadedConnection(container: Container): LoadedConnection {
+    return {
+      id: container.id,
+      name: `LocalAtlas-${container.name}`,
+      storageLocation: StorageLocation.NONE,
+      secretStorageLocation: 'vscode.SecretStorage',
+      connectionOptions: {
+        connectionString: `mongodb://localhost:${container.ports[0].port}/?directConnection=true`
+      }
+    }
+  }
+
+  static async addCredentials(loadedConnection: LoadedConnection): Promise<LoadedConnection> {
+    return new Promise((resolve, reject) => {
+      const docker = spawn("docker", ["inspect", loadedConnection.id]);
+      let dockerInspectOutput = '';
+      docker.stdout.on('data', data => dockerInspectOutput += data);
+      docker.stdout.on('end', () => {
+        const parsedOutput = JSON.parse(dockerInspectOutput);
+        const env = parsedOutput.pop().Config.Env;
+
+        const credentials = env.reduce((acc, envVar) => {
+          const usernameMatch = envVar.match(/^MONGODB_INITDB_ROOT_USERNAME=(.*)$/);
+          const passwordMatch = envVar.match(/^MONGODB_INITDB_ROOT_PASSWORD=(.*)$/);
+          if (usernameMatch) {
+            acc.username = usernameMatch[1];
+          }
+          if (passwordMatch) {
+            acc.password = passwordMatch[1];
+          }
+          return acc;
+        }, {});
+
+        const { username, password } = credentials;
+
+        const connString = new URL(loadedConnection.connectionOptions.connectionString);
+        connString.username = username;
+        connString.password = password;
+        loadedConnection.connectionOptions.connectionString = connString.toString();
+        resolve(loadedConnection);
+      })
+    });
+  }
+
+  async loadConnectionsToLocalInstances(): Promise<LoadedConnection[]> {
+    const imageRegex = /^mongodb\/mongodb-atlas-local(:[a-zA-Z0-9\.-]+)?$/;
+    return new Promise((resolve, reject) => {
+      const docker = spawn("docker", ["ps", "--format", "json"]);
+      const parser = jsonlines.parse();
+      const containers: _Container[] = [];
+      docker.stdout.pipe(parser);
+      parser.on('data', function (data: _Container) {
+        containers.push(data);
+      });
+
+      parser.on('end', async function () {
+
+        let localInstances = containers
+          .filter((container: _Container) => imageRegex.test(container.Image))
+          .map((container) => ConnectionStorage.toLoadedConnection({
+            id: container.ID,
+            name: container.Names,
+            ports: ConnectionStorage.parsePorts(container.Ports),
+          }));
+
+        localInstances = await Promise.all(localInstances.map(li => ConnectionStorage.addCredentials(li)));
+
+        resolve(localInstances);
+      });
+    });
   }
 
   async removeConnection(connectionId: string) {


### PR DESCRIPTION
With this PR, the VS Code extension detects local atlas environments and shows them in the list of connections so that the user does not need to pass connection strings around.

It does so by looking at the running docker containers, as that is how local atlas environments are provided.

As added bonus, connections can now be open in Compass directy from VSCode if the protocol handler is registered.

<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. VSCODE-1111: updates ace editor width in agg pipeline view -->
<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->
## Description

Wouldn't it be nice if our dev tools delivered a unified developer experience? This is what I could come up with in the couple of free hours I had this week.

### Checklist
- [ ] New tests and/or benchmarks are included - 😂 far from that
- [ ] Documentation is changed or added - nope, who needs documentation
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
