### PR TITLE
feat: connect to a cluster on a button click VSCODE-577

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -34,6 +34,7 @@ enum EXTENSION_COMMANDS {
   MDB_SAVE_MONGODB_DOCUMENT = 'mdb.saveMongoDBDocument',
 
   MDB_CHANGE_ACTIVE_CONNECTION = 'mdb.changeActiveConnection',
+  MDB_CHANGE_ACTIVE_CONNECTION_FROM_COPILOT = 'mdb.changeActiveConnectionFromCopilot',
 
   MDB_CODELENS_SHOW_MORE_DOCUMENTS = 'mdb.codeLens.showMoreDocumentsClicked',
 

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -304,6 +304,10 @@ export default class MDBExtensionController implements vscode.Disposable {
         });
       }
     );
+    this.registerCommand(
+      EXTENSION_COMMANDS.MDB_CHANGE_ACTIVE_CONNECTION_FROM_COPILOT,
+      (data) => this._participantController.changeActiveConnection(data)
+    );
   };
 
   registerParticipantCommand = (


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. VSCODE-1111: updates ace editor width in agg pipeline view -->
<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
When the participant generates a query and a user is not connected, show the "Connect" button in the Chat. After connecting proceed with the query generation.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
The current implementation uses the `workbench.action.chat.open` command that repeats the query. Is it acceptable and better than just expanding the command palette directly? 🤔

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
