### PR TITLE
feat: show survey VSCODE-562

### DIFF
--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -839,7 +839,7 @@ export default class MDBExtensionController implements vscode.Disposable {
             title: action,
           }
         );
-        if (result && result.title === action) {
+        if (result?.title === action) {
           void vscode.env.openExternal(vscode.Uri.parse(link));
         }
 

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -826,8 +826,9 @@ export default class MDBExtensionController implements vscode.Disposable {
     // Show the overview page when it hasn't been show to the
     // user yet, and they have saved connections
     // -> they haven't just started using this extension
-    if (!hasBeenShownSurveyAlready) {
-      if (this._connectionStorage.hasSavedConnections()) {
+    if (hasBeenShownSurveyAlready || !this._connectionStorage.hasSavedConnections()) {
+      return;
+    }
         const action = 'Share your thoughts';
         const text = 'How can we make the MongoDB extension better for you?';
         const link = 'https://forms.gle/9viN9wcbsC3zvHyg7';

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -150,6 +150,7 @@ export default class MDBExtensionController implements vscode.Disposable {
 
     this.registerCommands();
     this.showOverviewPageIfRecentlyInstalled();
+    void this.showSurveyForEstablishedUsers();
   }
 
   registerCommands = (): void => {
@@ -812,6 +813,41 @@ export default class MDBExtensionController implements vscode.Disposable {
         StorageVariables.GLOBAL_HAS_BEEN_SHOWN_INITIAL_VIEW,
         true
       );
+    }
+  }
+
+  async showSurveyForEstablishedUsers(): Promise<void> {
+    const surveyId = '9viN9wcbsC3zvHyg7';
+
+    const hasBeenShownSurveyAlready =
+      this._storageController.get(StorageVariables.GLOBAL_SURVEY_SHOWN) ===
+      surveyId;
+
+    // Show the overview page when it hasn't been show to the
+    // user yet, and they have saved connections
+    // -> they haven't just started using this extension
+    if (!hasBeenShownSurveyAlready) {
+      if (this._connectionStorage.hasSavedConnections()) {
+        const action = 'Share your thoughts';
+        const text = 'How can we make the MongoDB extension better for you?';
+        const link = 'https://forms.gle/9viN9wcbsC3zvHyg7';
+        const result = await vscode.window.showInformationMessage(
+          text,
+          {},
+          {
+            title: action,
+          }
+        );
+        if (result && result.title === action) {
+          void vscode.env.openExternal(vscode.Uri.parse(link));
+        }
+
+        // whether action was taken or the prompt dismissed, we won't show this again
+        void this._storageController.update(
+          StorageVariables.GLOBAL_SURVEY_SHOWN,
+          surveyId
+        );
+      }
     }
   }
 

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -826,30 +826,32 @@ export default class MDBExtensionController implements vscode.Disposable {
     // Show the overview page when it hasn't been show to the
     // user yet, and they have saved connections
     // -> they haven't just started using this extension
-    if (hasBeenShownSurveyAlready || !this._connectionStorage.hasSavedConnections()) {
+    if (
+      hasBeenShownSurveyAlready ||
+      !this._connectionStorage.hasSavedConnections()
+    ) {
       return;
     }
-        const action = 'Share your thoughts';
-        const text = 'How can we make the MongoDB extension better for you?';
-        const link = 'https://forms.gle/9viN9wcbsC3zvHyg7';
-        const result = await vscode.window.showInformationMessage(
-          text,
-          {},
-          {
-            title: action,
-          }
-        );
-        if (result?.title === action) {
-          void vscode.env.openExternal(vscode.Uri.parse(link));
-        }
 
-        // whether action was taken or the prompt dismissed, we won't show this again
-        void this._storageController.update(
-          StorageVariables.GLOBAL_SURVEY_SHOWN,
-          surveyId
-        );
+    const action = 'Share your thoughts';
+    const text = 'How can we make the MongoDB extension better for you?';
+    const link = 'https://forms.gle/9viN9wcbsC3zvHyg7';
+    const result = await vscode.window.showInformationMessage(
+      text,
+      {},
+      {
+        title: action,
       }
+    );
+    if (result?.title === action) {
+      void vscode.env.openExternal(vscode.Uri.parse(link));
     }
+
+    // whether action was taken or the prompt dismissed, we won't show this again
+    void this._storageController.update(
+      StorageVariables.GLOBAL_SURVEY_SHOWN,
+      surveyId
+    );
   }
 
   async dispose(): Promise<void> {

--- a/src/storage/storageController.ts
+++ b/src/storage/storageController.ts
@@ -6,6 +6,7 @@ import type { StoreConnectionInfo } from './connectionStorage';
 export enum StorageVariables {
   // Only exists on globalState.
   GLOBAL_HAS_BEEN_SHOWN_INITIAL_VIEW = 'GLOBAL_HAS_BEEN_SHOWN_INITIAL_VIEW',
+  GLOBAL_SURVEY_SHOWN = 'GLOBAL_SURVEY_SHOWN',
   GLOBAL_SAVED_CONNECTIONS = 'GLOBAL_SAVED_CONNECTIONS',
   // Analytics user identify.
   GLOBAL_USER_ID = 'GLOBAL_USER_ID',
@@ -50,6 +51,7 @@ interface StorageVariableContents {
   [StorageVariables.GLOBAL_USER_ID]: string;
   [StorageVariables.GLOBAL_ANONYMOUS_ID]: string;
   [StorageVariables.GLOBAL_HAS_BEEN_SHOWN_INITIAL_VIEW]: boolean;
+  [StorageVariables.GLOBAL_SURVEY_SHOWN]: string;
   [StorageVariables.GLOBAL_SAVED_CONNECTIONS]: ConnectionsFromStorage;
   [StorageVariables.WORKSPACE_SAVED_CONNECTIONS]: ConnectionsFromStorage;
 }

--- a/src/test/suite/mdbExtensionController.test.ts
+++ b/src/test/suite/mdbExtensionController.test.ts
@@ -176,7 +176,6 @@ suite('MDBExtensionController Test Suite', function () {
     let showErrorMessageStub: SinonStub;
     let fakeCreatePlaygroundFileWithContent: SinonSpy;
     let openExternalStub: SinonStub;
-    let uriParseStub: SinonStub;
 
     const sandbox = sinon.createSandbox();
 
@@ -186,7 +185,6 @@ suite('MDBExtensionController Test Suite', function () {
         'showInformationMessage'
       );
       openExternalStub = sandbox.stub(vscode.env, 'openExternal');
-      uriParseStub = sandbox.stub(vscode.Uri, 'parse');
       openTextDocumentStub = sandbox.stub(vscode.workspace, 'openTextDocument');
       fakeActiveConnectionId = sandbox.fake.returns('tasty_sandwhich');
       sandbox.replace(
@@ -1735,6 +1733,7 @@ suite('MDBExtensionController Test Suite', function () {
           ].forEach((reaction) => {
             suite(`user ${reaction.description}`, () => {
               let connectionsUpdateStub: SinonStub;
+              let uriParseStub: SinonStub;
               beforeEach(async () => {
                 showInformationMessageStub.resolves(reaction.value);
                 openExternalStub.resolves(undefined);
@@ -1752,6 +1751,7 @@ suite('MDBExtensionController Test Suite', function () {
                   mdbTestExtension.testExtensionController._storageController,
                   'update'
                 );
+                uriParseStub = sandbox.stub(vscode.Uri, 'parse');
                 connectionsUpdateStub.resolves(undefined);
                 await mdbTestExtension.testExtensionController.showSurveyForEstablishedUsers();
               });

--- a/src/test/suite/mdbExtensionController.test.ts
+++ b/src/test/suite/mdbExtensionController.test.ts
@@ -1729,7 +1729,7 @@ suite('MDBExtensionController Test Suite', function () {
             let showInformationMessageStub: SinonStub;
             let fakeUpdate: SinonSpy;
             let openExternalStub: SinonStub;
-            beforeEach(() => {
+            before(() => {
               showInformationMessageStub = sandbox.stub(
                 vscode.window,
                 'showInformationMessage'
@@ -1791,6 +1791,70 @@ suite('MDBExtensionController Test Suite', function () {
           }
         }
       );
+
+      suite('when a user has been shown the survey prompt already', () => {
+        let showInformationMessageStub: SinonStub;
+        let fakeUpdate: SinonSpy;
+        before(() => {
+          showInformationMessageStub = sandbox.stub(
+            vscode.window,
+            'showInformationMessage'
+          );
+          sandbox.replace(
+            mdbTestExtension.testExtensionController._storageController,
+            'get',
+            sandbox.fake.returns('9viN9wcbsC3zvHyg7') // survey has been shown
+          );
+          sandbox.replace(
+            mdbTestExtension.testExtensionController._connectionStorage,
+            'hasSavedConnections',
+            sandbox.fake.returns(true)
+          );
+          fakeUpdate = sandbox.fake.resolves(undefined);
+          sandbox.replace(
+            mdbTestExtension.testExtensionController._storageController,
+            'update',
+            fakeUpdate
+          );
+          void mdbTestExtension.testExtensionController.showSurveyForEstablishedUsers();
+        });
+
+        test('they are not shown the survey prompt', () => {
+          assert(showInformationMessageStub.notCalled);
+        });
+      });
+
+      suite('when a has no connections saved', () => {
+        let showInformationMessageStub: SinonStub;
+        let fakeUpdate: SinonSpy;
+        before(() => {
+          showInformationMessageStub = sandbox.stub(
+            vscode.window,
+            'showInformationMessage'
+          );
+          sandbox.replace(
+            mdbTestExtension.testExtensionController._storageController,
+            'get',
+            sandbox.fake.returns(undefined)
+          );
+          sandbox.replace(
+            mdbTestExtension.testExtensionController._connectionStorage,
+            'hasSavedConnections',
+            sandbox.fake.returns(false) // no connections yet - this might be the first install
+          );
+          fakeUpdate = sandbox.fake.resolves(undefined);
+          sandbox.replace(
+            mdbTestExtension.testExtensionController._storageController,
+            'update',
+            fakeUpdate
+          );
+          void mdbTestExtension.testExtensionController.showSurveyForEstablishedUsers();
+        });
+
+        test('they are not shown the survey prompt', () => {
+          assert(showInformationMessageStub.notCalled);
+        });
+      });
     });
   });
 });

--- a/src/test/suite/mdbExtensionController.test.ts
+++ b/src/test/suite/mdbExtensionController.test.ts
@@ -1727,8 +1727,11 @@ suite('MDBExtensionController Test Suite', function () {
         "when a user hasn't been shown the survey prompt yet, and they have connections saved",
         () => {
           [
-            { description: 'clicked the button', value: { title: 'Share your thoughts' } },
-            // { description: 'dismissed', value: undefined },
+            {
+              description: 'clicked the button',
+              value: { title: 'Share your thoughts' },
+            },
+            { description: 'dismissed', value: undefined },
           ].forEach((reaction) => {
             suite(`user ${reaction.description}`, () => {
               let connectionsUpdateStub: SinonStub;
@@ -1774,7 +1777,7 @@ suite('MDBExtensionController Test Suite', function () {
                   assert(uriParseStub.called);
                   assert.strictEqual(
                     uriParseStub.firstCall.args[0],
-                    'https://forms.gle/9viN9wcbsC3zvHyg7',
+                    'https://forms.gle/9viN9wcbsC3zvHyg7'
                   );
                 }
               });


### PR DESCRIPTION
## Description
https://jira.mongodb.org/browse/VSCODE-562

![Screenshot 2024-08-19 at 13 36 42](https://github.com/user-attachments/assets/fc65c77d-59b6-498e-9ae4-5cfe26be3e5a)

We had to adjust the wording, because the information message doesn't support formatting - so we cannot have a title and subtitle as planned. Alternative would be to show a popup, which is much more intrusive.

The prompt is shown at activation, for users who
a) haven't been shown the survey before
b) already have some connections (indicating this is not their first plugin activation)

Note: I am saving the shown survey not as a boolean, but by "id", as I imagine we might have different surveys later. 

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
