### PR TITLE
chore(testing): use ts source map in tests, improve test cleanup error handling VSCODE-593

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -105,6 +105,7 @@
         "process": "^0.11.10",
         "sinon": "^9.2.4",
         "sinon-chai": "^3.7.0",
+        "source-map-support": "^0.5.21",
         "stream-browserify": "^3.0.0",
         "terser-webpack-plugin": "^5.3.10",
         "ts-loader": "^9.5.1",
@@ -17344,6 +17345,7 @@
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"

--- a/package.json
+++ b/package.json
@@ -1174,6 +1174,7 @@
     "process": "^0.11.10",
     "sinon": "^9.2.4",
     "sinon-chai": "^3.7.0",
+    "source-map-support": "^0.5.21",
     "stream-browserify": "^3.0.0",
     "terser-webpack-plugin": "^5.3.10",
     "ts-loader": "^9.5.1",

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -17,41 +17,65 @@ async function startTestMongoDBServer() {
   });
 }
 
-async function main(): Promise<any> {
-  const testMongoDBServer = await startTestMongoDBServer();
+let testMongoDBServer: MongoCluster;
 
-  let failed = false;
-
-  try {
-    // The folder containing the Extension Manifest package.json
-    // Passed to `--extensionDevelopmentPath`
-    const extensionDevelopmentPath = path.join(__dirname, '../../');
-
-    // The path to test runner pased to --extensionTestsPath
-    const extensionTestsPath = path.join(__dirname, './suite/index');
-
-    // This is the workspace we open in our tests.
-    const testWorkspace = path.join(__dirname, '../../out/test');
-
-    // Download VS Code, unzip it and run the integration test
-    await runTests({
-      version: 'insiders', // Download latest insiders.
-      extensionDevelopmentPath,
-      extensionTestsPath,
-      launchArgs: [testWorkspace, '--disable-extensions'],
-    });
-  } catch (err) {
-    console.error('Failed to run tests:');
-    console.error(err);
-    failed = true;
-  } finally {
-    console.log('Stopping MongoDB server on port', TEST_DATABASE_PORT);
-    await testMongoDBServer.close();
-  }
-
-  if (failed) {
-    process.exit(1);
-  }
+function cleanup() {
+  console.log('Stopping MongoDB server on port', TEST_DATABASE_PORT);
+  void testMongoDBServer?.close();
 }
+
+async function main(): Promise<any> {
+  testMongoDBServer = await startTestMongoDBServer();
+
+  // The folder containing the Extension Manifest package.json
+  // Passed to `--extensionDevelopmentPath`
+  const extensionDevelopmentPath = path.join(__dirname, '../../');
+
+  // The path to test runner passed to --extensionTestsPath
+  const extensionTestsPath = path.join(__dirname, './suite/index');
+
+  // This is the workspace we open in our tests.
+  const testWorkspace = path.join(__dirname, '../../out/test');
+
+  // Download VS Code, unzip it and run the integration test
+  await runTests({
+    version: 'insiders', // Download latest insiders.
+    extensionDevelopmentPath,
+    extensionTestsPath,
+    launchArgs: [testWorkspace, '--disable-extensions'],
+  });
+
+  cleanup();
+}
+
+process.once('SIGINT', () => {
+  console.log('Process was interrupted. Cleaning-up and exiting.');
+  cleanup();
+  process.kill(process.pid, 'SIGINT');
+});
+
+process.once('SIGTERM', () => {
+  console.log('Process was terminated. Cleaning-up and exiting.');
+  cleanup();
+  process.kill(process.pid, 'SIGTERM');
+});
+
+process.once('uncaughtException', (err: Error) => {
+  console.log('Uncaught exception. Cleaning-up and exiting.');
+  cleanup();
+  throw err;
+});
+
+process.on('unhandledRejection', (err: Error) => {
+  if (!err.message.match('Test run failed with code 1')?.[0]) {
+    // Log an unhandled exception when it's not the regular test failure.
+    // Test failures are logged in the test runner already so we avoid a generic message here.
+    console.log('Unhandled exception. Cleaning-up and exiting.');
+    console.error(err.stack || err.message || err);
+  }
+
+  cleanup();
+  process.exitCode = 1;
+});
 
 void main();

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -1,3 +1,5 @@
+import sourceMapSupport from 'source-map-support';
+sourceMapSupport.install();
 import Mocha from 'mocha';
 import glob from 'glob';
 import path from 'path';


### PR DESCRIPTION
VSCODE-593

Updates our VSCode mocha integration tests to show the typescript file location when there's an error (use the source map). 

Also a bit of a drive-by I updated how we run the tests to remove a generic error we'd show and also to have better cleanup. Previously if someone was running the tests and ctrl + c'd then we wouldn't run the cleanup and sometimes we'd have a zombie mongod running.

| before | after |
| - | - |
| ![Screenshot 2024-08-20 at 2 18 04 PM](https://github.com/user-attachments/assets/9a1295d1-f3ad-46c1-89af-fe3a759b0c55) | ![Screenshot 2024-08-20 at 2 06 54 PM](https://github.com/user-attachments/assets/bb7027ab-39ee-4931-9ba6-3753fda73927) |
