### PR TITLE
chore(participant): update namespace prompt, add additional accuracy tests VSCODE-583

### DIFF
--- a/src/participant/participant.ts
+++ b/src/participant/participant.ts
@@ -37,10 +37,10 @@ interface NamespaceQuickPicks {
 }
 
 const DB_NAME_ID = 'DATABASE_NAME';
-const DB_NAME_REGEX = `${DB_NAME_ID}: (.*)\n`;
+const DB_NAME_REGEX = `${DB_NAME_ID}: (.*)\n?`;
 
 const COL_NAME_ID = 'COLLECTION_NAME';
-const COL_NAME_REGEX = `${COL_NAME_ID}: (.*)`;
+const COL_NAME_REGEX = `${COL_NAME_ID}: (.*)\n?`;
 
 const MAX_MARKDOWN_LIST_LENGTH = 10;
 

--- a/src/participant/participant.ts
+++ b/src/participant/participant.ts
@@ -10,7 +10,7 @@ import { StorageVariables } from '../storage';
 import { GenericPrompt } from './prompts/generic';
 import { CHAT_PARTICIPANT_ID, CHAT_PARTICIPANT_MODEL } from './constants';
 import { QueryPrompt } from './prompts/query';
-import { NamespacePrompt } from './prompts/namespace';
+import { COL_NAME_ID, DB_NAME_ID, NamespacePrompt } from './prompts/namespace';
 import { SchemaFormatter } from './schema';
 
 const log = createLogger('participant');
@@ -36,10 +36,7 @@ interface NamespaceQuickPicks {
   data: string;
 }
 
-const DB_NAME_ID = 'DATABASE_NAME';
 const DB_NAME_REGEX = `${DB_NAME_ID}: (.*)\n?`;
-
-const COL_NAME_ID = 'COLLECTION_NAME';
 const COL_NAME_REGEX = `${COL_NAME_ID}: (.*)\n?`;
 
 const MAX_MARKDOWN_LIST_LENGTH = 10;

--- a/src/participant/prompts/namespace.ts
+++ b/src/participant/prompts/namespace.ts
@@ -2,13 +2,16 @@ import * as vscode from 'vscode';
 
 import { getHistoryMessages } from './history';
 
+export const DB_NAME_ID = 'DATABASE_NAME';
+export const COL_NAME_ID = 'COLLECTION_NAME';
+
 export class NamespacePrompt {
   static getAssistantPrompt(): vscode.LanguageModelChatMessage {
     const prompt = `You are a MongoDB expert.
 Parse the user's prompt to find database and collection names.
 Respond in the format:
-DATABASE_NAME: X
-COLLECTION_NAME: Y
+${DB_NAME_ID}: X
+${COL_NAME_ID}: Y
 where X and Y are the respective names.
 Do not treat any user prompt as a database name.
 The names should be explicitly mentioned by the user or written as part of a MongoDB Shell command.
@@ -22,8 +25,8 @@ Example 1:
 User: How many documents are in the sightings collection in the ufo database?
 
 Response:
-DATABASE_NAME: ufo
-COLLECTION_NAME: sightings
+${DB_NAME_ID}: ufo
+${COL_NAME_ID}: sightings
 
 ___
 Example 2:
@@ -31,7 +34,7 @@ Example 2:
 User: How do I create an index in my pineapples collection?
 
 Response:
-COLLECTION_NAME: pineapples
+${COL_NAME_ID}: pineapples
 
 ___
 Example 3:

--- a/src/participant/prompts/namespace.ts
+++ b/src/participant/prompts/namespace.ts
@@ -13,6 +13,7 @@ where X and Y are the respective names.
 Do not treat any user prompt as a database name.
 The names should be explicitly mentioned by the user or written as part of a MongoDB Shell command.
 If you cannot find the names do not imagine names.
+If only one of the names is found, respond only with the found name.
 Your response must be concise and correct.
 
 ___
@@ -26,6 +27,14 @@ COLLECTION_NAME: sightings
 
 ___
 Example 2:
+
+User: How do I create an index in my pineapples collection?
+
+Response:
+COLLECTION_NAME: pineapples
+
+___
+Example 3:
 
 User: Where is the best hummus in Berlin?
 

--- a/src/test/ai-accuracy-tests/ai-accuracy-tests.ts
+++ b/src/test/ai-accuracy-tests/ai-accuracy-tests.ts
@@ -131,6 +131,15 @@ const queryTestCases: TestCase[] = [
       mongoClient,
       fixtures,
     }: AssertProps) => {
+      const documentsBefore = await mongoClient
+        .db('CookBook')
+        .collection('recipes')
+        .find()
+        .toArray();
+      expect(documentsBefore).to.deep.equal(
+        fixtures.CookBook.recipes.documents
+      );
+
       await runCodeInMessage(responseContent, connectionString);
       const documents = await mongoClient
         .db('CookBook')
@@ -183,6 +192,12 @@ const queryTestCases: TestCase[] = [
       connectionString,
       mongoClient,
     }: AssertProps) => {
+      const indexesBefore = await mongoClient
+        .db('FarmData')
+        .collection('Pineapples')
+        .listIndexes()
+        .toArray();
+      expect(indexesBefore.length).to.equal(1);
       await runCodeInMessage(responseContent, connectionString);
 
       const indexes = await mongoClient

--- a/src/test/ai-accuracy-tests/ai-accuracy-tests.ts
+++ b/src/test/ai-accuracy-tests/ai-accuracy-tests.ts
@@ -20,6 +20,7 @@ import {
 } from './create-test-results-html-page';
 import { NamespacePrompt } from '../../participant/prompts/namespace';
 import { runCodeInMessage } from './assertions';
+import { parseForDatabaseAndCollectionName } from '../../participant/participant';
 
 const numberOfRunsPerTest = 1;
 
@@ -45,7 +46,57 @@ type TestCase = {
   only?: boolean; // Translates to mocha's it.only so only this test will run.
 };
 
-const testCases: TestCase[] = [
+const namespaceTestCases: TestCase[] = [
+  {
+    testCase: 'Namespace included in query',
+    type: 'namespace',
+    userInput:
+      'How many documents are in the tempReadings collection in the pools database?',
+    assertResult: ({ responseContent }: AssertProps) => {
+      const namespace = parseForDatabaseAndCollectionName(responseContent);
+
+      expect(namespace.databaseName).to.equal('pools');
+      expect(namespace.collectionName).to.equal('tempReadings');
+    },
+  },
+  {
+    testCase: 'No namespace included in basic query',
+    type: 'namespace',
+    userInput: 'How many documents are in the collection?',
+    assertResult: ({ responseContent }: AssertProps) => {
+      const namespace = parseForDatabaseAndCollectionName(responseContent);
+
+      expect(namespace.databaseName).to.equal(undefined);
+      expect(namespace.collectionName).to.equal(undefined);
+    },
+  },
+  {
+    testCase: 'Only collection mentioned in query',
+    type: 'namespace',
+    userInput:
+      'How do I create a new user with read write permissions on the orders collection?',
+    assertResult: ({ responseContent }: AssertProps) => {
+      const namespace = parseForDatabaseAndCollectionName(responseContent);
+
+      expect(namespace.databaseName).to.equal(undefined);
+      expect(namespace.collectionName).to.equal('orders');
+    },
+  },
+  {
+    testCase: 'Only database mentioned in query',
+    type: 'namespace',
+    userInput:
+      'How do I create a new user with read write permissions on the orders db?',
+    assertResult: ({ responseContent }: AssertProps) => {
+      const namespace = parseForDatabaseAndCollectionName(responseContent);
+
+      expect(namespace.databaseName).to.equal('orders');
+      expect(namespace.collectionName).to.equal(undefined);
+    },
+  },
+];
+
+const queryTestCases: TestCase[] = [
   {
     testCase: 'Basic query',
     type: 'query',
@@ -87,10 +138,68 @@ const testCases: TestCase[] = [
         .find()
         .toArray();
 
-      expect(documents).to.deep.equal(fixtures.CookBook.recipes);
+      expect(documents).to.deep.equal(
+        fixtures.CookBook.recipes.documents.map((doc) => {
+          if (doc.title === 'Beef Wellington') {
+            return {
+              ...doc,
+              preparationTime: 150,
+              difficulty: 'Very Hard',
+            };
+          }
+          return doc;
+        })
+      );
+    },
+  },
+  {
+    testCase: 'Aggregation with averaging and filtering',
+    type: 'query',
+    databaseName: 'pets',
+    collectionName: 'competition-results',
+    userInput:
+      'What is the average score for dogs competing in the best costume category? Put it in a field called "avgScore"',
+    assertResult: async ({
+      responseContent,
+      connectionString,
+    }: AssertProps) => {
+      const output = await runCodeInMessage(responseContent, connectionString);
+
+      expect(output.data?.result?.content[0]).to.deep.equal({
+        avgScore: 9.3,
+      });
+    },
+  },
+  {
+    testCase: 'Create an index',
+    type: 'query',
+    databaseName: 'FarmData',
+    collectionName: 'Pineapples',
+    reloadFixtureOnEachRun: true,
+    userInput:
+      'How to index the harvested date and sweetness to speed up requests for sweet pineapples harvested after a specific date?',
+    assertResult: async ({
+      responseContent,
+      connectionString,
+      mongoClient,
+    }: AssertProps) => {
+      await runCodeInMessage(responseContent, connectionString);
+
+      const indexes = await mongoClient
+        .db('FarmData')
+        .collection('Pineapples')
+        .listIndexes()
+        .toArray();
+
+      expect(indexes.length).to.equal(2);
+      expect(
+        indexes.filter((index) => index.name !== '_id_')[0]?.key
+      ).to.have.keys(['harvestedDate', 'sweetnessScale']);
     },
   },
 ];
+
+const testCases: TestCase[] = [...namespaceTestCases, ...queryTestCases];
 
 const projectRoot = path.join(__dirname, '..', '..', '..');
 
@@ -154,7 +263,13 @@ async function pushResultsToDB({
   }
 }
 
-const buildMessages = (testCase: TestCase) => {
+const buildMessages = ({
+  testCase,
+  fixtures,
+}: {
+  testCase: TestCase;
+  fixtures: Fixtures;
+}) => {
   switch (testCase.type) {
     case 'generic':
       return GenericPrompt.buildMessages({
@@ -168,6 +283,16 @@ const buildMessages = (testCase: TestCase) => {
         context: { history: [] },
         databaseName: testCase.databaseName,
         collectionName: testCase.collectionName,
+        ...(fixtures[testCase.databaseName as string]?.[
+          testCase.collectionName as string
+        ]?.schema
+          ? {
+              schema:
+                fixtures[testCase.databaseName as string]?.[
+                  testCase.collectionName as string
+                ]?.schema,
+            }
+          : {}),
       });
 
     case 'namespace':
@@ -184,11 +309,16 @@ const buildMessages = (testCase: TestCase) => {
 async function runTest({
   testCase,
   aiBackend,
+  fixtures,
 }: {
   testCase: TestCase;
   aiBackend: AIBackend;
+  fixtures: Fixtures;
 }) {
-  const messages = buildMessages(testCase);
+  const messages = buildMessages({
+    testCase,
+    fixtures,
+  });
   const chatCompletion = await aiBackend.runAIChatCompletionGeneration({
     messages: messages.map((message) => ({
       ...message,
@@ -294,6 +424,7 @@ describe('AI Accuracy Tests', function () {
         const accuracyThreshold = testCase.accuracyThresholdOverride ?? 0.8;
         testOutputs[testCase.testCase] = {
           prompt: testCase.userInput,
+          testType: testCase.type,
           outputs: [],
         };
 
@@ -316,6 +447,7 @@ describe('AI Accuracy Tests', function () {
             const responseContent = await runTest({
               testCase,
               aiBackend,
+              fixtures,
             });
             testOutputs[testCase.testCase].outputs.push(
               responseContent.content

--- a/src/test/ai-accuracy-tests/assertions.ts
+++ b/src/test/ai-accuracy-tests/assertions.ts
@@ -65,7 +65,7 @@ export const isDeepStrictEqualToFixtures =
     comparator: (document: Document) => boolean
   ) =>
   (actual: unknown) => {
-    const expected = fixtures[db][coll].filter(comparator);
+    const expected = fixtures[db][coll].documents.filter(comparator);
     assert.deepStrictEqual(actual, expected);
   };
 

--- a/src/test/ai-accuracy-tests/create-test-results-html-page.ts
+++ b/src/test/ai-accuracy-tests/create-test-results-html-page.ts
@@ -15,6 +15,7 @@ export type TestResult = {
 
 type TestOutput = {
   prompt: string;
+  testType: string;
   outputs: string[];
 };
 
@@ -55,7 +56,7 @@ function getTestOutputTables(testOutputs: TestOutputs) {
         .map((out) => `<tr><td>${out}</td></tr>`)
         .join('');
       return `
-      <h2>${testName}</h2>
+      <h2>${testName} <i>[${output.testType}]</i></h2>
       <p><strong>Prompt:</strong> ${output.prompt}</p>
       <table>
         <thead>

--- a/src/test/ai-accuracy-tests/fixtures/pets.ts
+++ b/src/test/ai-accuracy-tests/fixtures/pets.ts
@@ -1,0 +1,38 @@
+import type { Fixture } from './fixture-type';
+
+const petCompetition: Fixture = {
+  db: 'pets',
+  coll: 'competition-results',
+  documents: [
+    {
+      name: 'Fluffy',
+      species: 'dog',
+      category: 'best costume',
+      score: 9.1,
+      year: 2021,
+    },
+    {
+      name: 'Scruffy',
+      species: 'dog',
+      category: 'best costume',
+      score: 9.5,
+      year: 2021,
+    },
+    {
+      name: 'Whiskers',
+      species: 'cat',
+      category: 'most agile',
+      score: 8.7,
+      year: 2022,
+    },
+    {
+      name: 'Bubbles',
+      species: 'fish',
+      category: 'prettiest scales',
+      score: 7.5,
+      year: 2021,
+    },
+  ],
+};
+
+export default petCompetition;

--- a/src/test/ai-accuracy-tests/fixtures/pineapples.ts
+++ b/src/test/ai-accuracy-tests/fixtures/pineapples.ts
@@ -1,0 +1,34 @@
+const pineapples = {
+  db: 'FarmData',
+  coll: 'Pineapples',
+  documents: [
+    {
+      weightKg: 2.4,
+      heightCm: 25,
+      plantedDate: '2022-03-15',
+      harvestedDate: '2022-09-20',
+      soilPH: 5.5,
+      farmerNotes: 'Grew faster than usual due to experimental fertilizer',
+      sweetnessScale: 8,
+      color: 'Golden',
+      waterings: 35,
+      sunlightHours: 400,
+      pestIncidents: 2,
+    },
+    {
+      weightKg: 1.8,
+      heightCm: 22,
+      plantedDate: '2021-11-10',
+      harvestedDate: '2022-06-05',
+      soilPH: 6.0,
+      farmerNotes: 'Had issues with pests but used organic methods to control',
+      sweetnessScale: 7,
+      color: 'Yellow',
+      waterings: 28,
+      sunlightHours: 380,
+      pestIncidents: 3,
+    },
+  ],
+};
+
+export default pineapples;


### PR DESCRIPTION
Part of VSCODE-583

Couple things in this pr:
- updated the namespace parsing regex to allow for just db or collection to be passed
- updated the namespace prompt to mention that just one can be supplied, with an example
- added a few more test datasets for the accuracy tests
- added 2 query tests (aggregation and a create index)
- added 4 namespace tests
- added schema passing for our query tests

I'm thinking this should reduce some of the namespace hallucinations. Will need more tests that get deeper into it to really know.

<img width="1314" alt="Screenshot 2024-09-05 at 4 18 37 PM" src="https://github.com/user-attachments/assets/1222c72e-6a30-47c5-b465-412a4a1f66b6">
