### PR TITLE
fix: disable export to language when selection is invalid VSCODE-455

### DIFF
--- a/package.json
+++ b/package.json
@@ -708,35 +708,35 @@
         },
         {
           "command": "mdb.exportToRuby",
-          "when": "mdb.isPlayground == true && mdb.connectedToMongoDB == true && mdb.isAtlasStreams == false"
+          "when": "mdb.isPlayground == true && mdb.connectedToMongoDB == true && mdb.isAtlasStreams == false && mdb.canExportToLanguage"
         },
         {
           "command": "mdb.exportToPython",
-          "when": "mdb.isPlayground == true && mdb.connectedToMongoDB == true && mdb.isAtlasStreams == false"
+          "when": "mdb.isPlayground == true && mdb.connectedToMongoDB == true && mdb.isAtlasStreams == false && mdb.canExportToLanguage"
         },
         {
           "command": "mdb.exportToJava",
-          "when": "mdb.isPlayground == true && mdb.connectedToMongoDB == true && mdb.isAtlasStreams == false"
+          "when": "mdb.isPlayground == true && mdb.connectedToMongoDB == true && mdb.isAtlasStreams == false && mdb.canExportToLanguage"
         },
         {
           "command": "mdb.exportToCsharp",
-          "when": "mdb.isPlayground == true && mdb.connectedToMongoDB == true && mdb.isAtlasStreams == false"
+          "when": "mdb.isPlayground == true && mdb.connectedToMongoDB == true && mdb.isAtlasStreams == false && mdb.canExportToLanguage"
         },
         {
           "command": "mdb.exportToNode",
-          "when": "mdb.isPlayground == true && mdb.connectedToMongoDB == true && mdb.isAtlasStreams == false"
+          "when": "mdb.isPlayground == true && mdb.connectedToMongoDB == true && mdb.isAtlasStreams == false && mdb.canExportToLanguage"
         },
         {
           "command": "mdb.exportToGo",
-          "when": "mdb.isPlayground == true && mdb.connectedToMongoDB == true && mdb.isAtlasStreams == false"
+          "when": "mdb.isPlayground == true && mdb.connectedToMongoDB == true && mdb.isAtlasStreams == false && mdb.canExportToLanguage"
         },
         {
           "command": "mdb.exportToRust",
-          "when": "mdb.isPlayground == true && mdb.connectedToMongoDB == true && mdb.isAtlasStreams == false"
+          "when": "mdb.isPlayground == true && mdb.connectedToMongoDB == true && mdb.isAtlasStreams == false && mdb.canExportToLanguage"
         },
         {
           "command": "mdb.exportToPHP",
-          "when": "mdb.isPlayground == true && mdb.connectedToMongoDB == true && mdb.isAtlasStreams == false"
+          "when": "mdb.isPlayground == true && mdb.connectedToMongoDB == true && mdb.isAtlasStreams == false && mdb.canExportToLanguage"
         },
         {
           "command": "mdb.refreshPlaygroundsFromTreeView",

--- a/src/editors/playgroundSelectedCodeActionProvider.ts
+++ b/src/editors/playgroundSelectedCodeActionProvider.ts
@@ -14,6 +14,13 @@ export default class PlaygroundSelectedCodeActionProvider
   mode?: ExportToLanguageMode;
   activeTextEditor?: TextEditor;
 
+  get canExportToLanguage(): boolean {
+    return (
+      this.mode == ExportToLanguageMode.QUERY ||
+      this.mode == ExportToLanguageMode.AGGREGATION
+    );
+  }
+
   static readonly providedCodeActionKinds = [vscode.CodeActionKind.QuickFix];
 
   constructor() {
@@ -41,6 +48,11 @@ export default class PlaygroundSelectedCodeActionProvider
     this.selection = selection;
     this.mode = mode;
     this._onDidChangeCodeCodeAction.fire();
+    void vscode.commands.executeCommand(
+      'setContext',
+      'mdb.canExportToLanguage',
+      this.canExportToLanguage
+    );
   }
 
   isPlayground(): boolean {
@@ -64,10 +76,7 @@ export default class PlaygroundSelectedCodeActionProvider
     };
     codeActions.push(runSelectedPlaygroundBlockCommand);
 
-    if (
-      this.mode === ExportToLanguageMode.QUERY ||
-      this.mode === ExportToLanguageMode.AGGREGATION
-    ) {
+    if (this.canExportToLanguage) {
       const exportToPythonCommand = new vscode.CodeAction(
         'Export To Python 3',
         vscode.CodeActionKind.Empty


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. VSCODE-1111: updates ace editor width in agg pipeline view -->
<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->
## Description

This adds the `mdb.canExportToLanguage` to the extension context and uses it in the when clause for the export to language commands.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
Not sure if that's the best way to go about it - I also considered adding a the mode directly and writing a more complex when clause, but decided against it to avoid the code lens and the palette commands diverging.

Also, not sure how to test that change other than manually, so will need some pointers here.

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
