### PR TITLE
chore: update listDatabases to use nameOnly: true

### DIFF
--- a/src/explorer/connectionTreeItem.ts
+++ b/src/explorer/connectionTreeItem.ts
@@ -115,7 +115,9 @@ export default class ConnectionTreeItem
     }
 
     try {
-      const dbs = await dataService.listDatabases();
+      const dbs = await dataService.listDatabases({
+        nameOnly: true,
+      });
       return dbs.map((dbItem) => dbItem.name);
     } catch (error) {
       throw new Error(

--- a/src/participant/participant.ts
+++ b/src/participant/participant.ts
@@ -323,7 +323,9 @@ export default class ParticipantController {
     }
 
     try {
-      const databases = await dataService.listDatabases();
+      const databases = await dataService.listDatabases({
+        nameOnly: true,
+      });
       return databases.map((db) => ({
         label: db.name,
         data: db.name,
@@ -408,7 +410,9 @@ export default class ParticipantController {
     }
 
     try {
-      const databases = await dataService.listDatabases();
+      const databases = await dataService.listDatabases({
+        nameOnly: true,
+      });
       return [
         ...databases.slice(0, MAX_MARKDOWN_LIST_LENGTH).map((db) =>
           this._createMarkdownLink({


### PR DESCRIPTION
We do this on main, this was changed on this branch, so this is reverting that change. Thread in slack: 
https://mongodb.slack.com/archives/GTTUKDWRH/p1726516767884079
Not sure on why it's causing errors, will be looking into it.