### PR TITLE
fix: incorrect intent checking for namespace messages

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,7 @@
         "--extensionDevelopmentPath=${workspaceFolder}"
       ],
       "outFiles": [
-        "${workspaceFolder}/out/**/*.js"
+        "${workspaceFolder}/dist/**/*.js"
       ],
       "preLaunchTask": "${defaultBuildTask}"
     },

--- a/src/participant/prompts/history.ts
+++ b/src/participant/prompts/history.ts
@@ -39,7 +39,7 @@ export function getHistoryMessages({
       ];
       if (
         responseTypesToSkip.indexOf(
-          (historyItem.result as ChatResult)?.metadata.intent
+          (historyItem.result as ChatResult)?.metadata?.intent
         ) > -1
       ) {
         continue;
@@ -50,7 +50,7 @@ export function getHistoryMessages({
           message += fragment.value.value;
 
           if (
-            (historyItem.result as ChatResult)?.metadata.intent ===
+            (historyItem.result as ChatResult)?.metadata?.intent ===
             'askForNamespace'
           ) {
             // When the message is the assistant asking for part of a namespace,


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. VSCODE-1111: updates ace editor width in agg pipeline view -->
<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->
## Description
As I was looking through the namespace buildMessages implementation for something different, I noticed we're using a non-existent field from the chat result metadata to slice the message history. It doesn't appear we have tests for it, which is why it slipped. I restructured the check a little to more explicitly leverage the type system, but perhaps we should have tests to catch future cases.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
