### PR TITLE
chore(participant): update anchor rendering to use markdown link instead of html a tag VSCODE-616

### DIFF
--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -79,7 +79,12 @@ function isOIDCAuth(connectionString: string): boolean {
 // Exported for testing.
 export function getNotifyDeviceFlowForConnectionAttempt(
   connectionOptions: ConnectionOptions
-) {
+):
+  | ((deviceFlowInformation: {
+      verificationUrl: string;
+      userCode: string;
+    }) => void)
+  | undefined {
   const isOIDCConnectionAttempt = isOIDCAuth(
     connectionOptions.connectionString
   );
@@ -97,7 +102,7 @@ export function getNotifyDeviceFlowForConnectionAttempt(
     }: {
       verificationUrl: string;
       userCode: string;
-    }) => {
+    }): void => {
       void vscode.window.showInformationMessage(
         `Visit the following URL to complete authentication: ${verificationUrl}  Enter the following code on that page: ${userCode}`
       );
@@ -381,7 +386,7 @@ export default class ConnectionController {
           ...cloneDeep(connectionOptions.oidc),
           openBrowser: browserAuthCommand
             ? { command: browserAuthCommand }
-            : async ({ signal, url }) => {
+            : async ({ signal, url }): Promise<void> => {
                 try {
                   await openLink(url);
                 } catch (err) {
@@ -469,7 +474,7 @@ export default class ConnectionController {
   }
 
   // Used to re-authenticate with OIDC.
-  async _reauthenticationHandler() {
+  async _reauthenticationHandler(): Promise<void> {
     const removeConfirmationResponse =
       await vscode.window.showInformationMessage(
         'You need to re-authenticate to the database in order to continue.',
@@ -488,7 +493,7 @@ export default class ConnectionController {
   }: {
     connectionInfo: LoadedConnection;
     dataService: DataService;
-  }) {
+  }): Promise<void> {
     if (connectionInfo.storageLocation === 'NONE') {
       return;
     }
@@ -513,7 +518,7 @@ export default class ConnectionController {
 
     // ?. because mocks in tests don't provide it
     dataService.on?.('connectionInfoSecretsChanged', () => {
-      void (async () => {
+      void (async (): Promise<void> => {
         try {
           if (
             !vscode.workspace.getConfiguration('mdb').get('persistOIDCTokens')
@@ -546,7 +551,7 @@ export default class ConnectionController {
     });
   }
 
-  cancelConnectionAttempt() {
+  cancelConnectionAttempt(): void {
     this._connectionAttempt?.cancelConnectionAttempt();
   }
 
@@ -806,11 +811,11 @@ export default class ConnectionController {
     this.eventEmitter.removeListener(eventType, listener);
   }
 
-  deactivate() {
+  deactivate(): void {
     this.eventEmitter.removeAllListeners();
   }
 
-  closeConnectionStringInput() {
+  closeConnectionStringInput(): void {
     this._connectionStringInputCancellationToken?.cancel();
   }
 
@@ -905,7 +910,7 @@ export default class ConnectionController {
     return connectionStringData.toString();
   }
 
-  isConnectedToAtlasStreams() {
+  isConnectedToAtlasStreams(): boolean {
     return (
       this.isCurrentlyConnected() &&
       isAtlasStream(this.getActiveConnectionString())
@@ -927,7 +932,7 @@ export default class ConnectionController {
     return connectionString;
   }
 
-  getActiveDataService() {
+  getActiveDataService(): DataService | null {
     return this._activeDataService;
   }
 

--- a/src/participant/markdown.ts
+++ b/src/participant/markdown.ts
@@ -16,9 +16,8 @@ export function createMarkdownLink({
   const encodedData = encodeURIComponent(JSON.stringify(data));
   const commandQueryString = data ? `?${encodedData}` : '';
   const link = new vscode.MarkdownString(
-    `- <a href="command:${commandId}${commandQueryString}">${name}</a>\n`
+    `- [${name}](command:${commandId}${commandQueryString})\n`
   );
-  link.supportHtml = true;
   link.isTrusted = { enabledCommands: [commandId] };
   return link;
 }

--- a/src/participant/participant.ts
+++ b/src/participant/participant.ts
@@ -1134,7 +1134,7 @@ export default class ParticipantController {
     if (docsResult.responseReferences) {
       for (const ref of docsResult.responseReferences) {
         const link = new vscode.MarkdownString(
-          `- <a href="${ref.url}">${ref.title}</a>\n`
+          `- [${ref.title}](${ref.url})\n`
         );
         link.supportHtml = true;
         stream.markdown(link);

--- a/src/test/suite/participant/participant.test.ts
+++ b/src/test/suite/participant/participant.test.ts
@@ -217,13 +217,13 @@ suite('Participant Controller Test Suite', function () {
       const listConnectionsMessage = chatStreamStub.markdown.getCall(1).args[0];
       const expectedContent = encodeStringify({ id: 'id', command: '/query' });
       expect(listConnectionsMessage.value).to.include(
-        `- <a href="command:mdb.connectWithParticipant?${expectedContent}">localhost</a>`
+        `- [localhost](command:mdb.connectWithParticipant?${expectedContent})`
       );
       const showMoreMessage = chatStreamStub.markdown.getCall(2).args[0];
       expect(showMoreMessage.value).to.include(
-        `- <a href="command:mdb.connectWithParticipant?${encodeStringify({
+        `- [Show more](command:mdb.connectWithParticipant?${encodeStringify({
           command: '/query',
-        })}">Show more</a>`
+        })})`
       );
       expect(chatResult?.metadata?.chatId.length).to.equal(testChatId.length);
       expect({
@@ -258,13 +258,13 @@ suite('Participant Controller Test Suite', function () {
       const listConnectionsMessage = chatStreamStub.markdown.getCall(1).args[0];
       const expectedContent = encodeStringify({ id: 'id0', command: '/query' });
       expect(listConnectionsMessage.value).to.include(
-        `- <a href="command:mdb.connectWithParticipant?${expectedContent}">localhost0</a>`
+        `- [localhost0](command:mdb.connectWithParticipant?${expectedContent})`
       );
       const showMoreMessage = chatStreamStub.markdown.getCall(11).args[0];
       expect(showMoreMessage.value).to.include(
-        `- <a href="command:mdb.connectWithParticipant?${encodeStringify({
+        `- [Show more](command:mdb.connectWithParticipant?${encodeStringify({
           command: '/query',
-        })}">Show more</a>`
+        })})`
       );
       expect(chatStreamStub.markdown.callCount).to.be.eql(12);
       expect(chatResult?.metadata?.chatId.length).to.equal(testChatId.length);
@@ -296,13 +296,13 @@ suite('Participant Controller Test Suite', function () {
       const listConnectionsMessage = chatStreamStub.markdown.getCall(4).args[0];
       const expectedContent = encodeStringify({ id: 'id', command: '/query' });
       expect(listConnectionsMessage.value).to.include(
-        `- <a href="command:mdb.connectWithParticipant?${expectedContent}">localhost</a>`
+        `- [localhost](command:mdb.connectWithParticipant?${expectedContent})`
       );
       const showMoreMessage = chatStreamStub.markdown.getCall(5).args[0];
       expect(showMoreMessage.value).to.include(
-        `- <a href="command:mdb.connectWithParticipant?${encodeStringify({
+        `- [Show more](command:mdb.connectWithParticipant?${encodeStringify({
           command: '/query',
-        })}">Show more</a>`
+        })})`
       );
       expect(chatResult?.metadata?.chatId.length).to.equal(testChatId.length);
       expect({
@@ -738,16 +738,15 @@ suite('Participant Controller Test Suite', function () {
               databaseName: 'dbOne',
             });
             expect(listDBsMessage.value).to.include(
-              `- <a href="command:mdb.selectDatabaseWithParticipant?${expectedContent}">dbOne</a>`
+              `- [dbOne](command:mdb.selectDatabaseWithParticipant?${expectedContent})`
             );
             const showMoreDBsMessage =
               chatStreamStub.markdown.getCall(11).args[0];
             expect(showMoreDBsMessage.value).to.include(
-              `- <a href="command:mdb.selectDatabaseWithParticipant?${encodeStringify(
+              `- [Show more](command:mdb.selectDatabaseWithParticipant?${encodeStringify(
                 { command: '/query', chatId: testChatId }
-              )}">Show more</a>`
+              )})`
             );
-            expect(showMoreDBsMessage.value).to.include('"');
             expect(chatStreamStub.markdown.callCount).to.be.eql(12);
             const firstChatId = chatResult?.metadata?.chatId;
             expect(chatResult?.metadata?.chatId.length).to.equal(
@@ -816,18 +815,18 @@ suite('Participant Controller Test Suite', function () {
               collectionName: 'collOne',
             });
             expect(listCollsMessage.value).to.include(
-              `- <a href="command:mdb.selectCollectionWithParticipant?${expectedCollsContent}">collOne</a>`
+              `- [collOne](command:mdb.selectCollectionWithParticipant?${expectedCollsContent})`
             );
             const showMoreCollsMessage =
               chatStreamStub.markdown.getCall(23).args[0];
             expect(showMoreCollsMessage.value).to.include(
-              `- <a href="command:mdb.selectCollectionWithParticipant?${encodeStringify(
+              `- [Show more](command:mdb.selectCollectionWithParticipant?${encodeStringify(
                 {
                   command: '/query',
                   chatId: testChatId,
                   databaseName: 'dbOne',
                 }
-              )}">Show more</a>`
+              )})`
             );
             expect(chatStreamStub.markdown.callCount).to.be.eql(24);
             expect(chatResult2?.metadata?.chatId).to.equal(firstChatId);
@@ -974,23 +973,23 @@ suite('Participant Controller Test Suite', function () {
             );
             const listDBsMessage = chatStreamStub.markdown.getCall(1).args[0];
             expect(listDBsMessage.value).to.include(
-              `- <a href="command:mdb.selectDatabaseWithParticipant?${encodeStringify(
+              `- [dbOne](command:mdb.selectDatabaseWithParticipant?${encodeStringify(
                 {
                   command: '/query',
                   chatId: 'pineapple',
                   databaseName: 'dbOne',
                 }
-              )}">dbOne</a>`
+              )})`
             );
             const showMoreDBsMessage =
               chatStreamStub.markdown.getCall(11).args[0];
             expect(showMoreDBsMessage.value).to.include(
-              `- <a href="command:mdb.selectDatabaseWithParticipant?${encodeStringify(
+              `- [Show more](command:mdb.selectDatabaseWithParticipant?${encodeStringify(
                 {
                   command: '/query',
                   chatId: 'pineapple',
                 }
-              )}">Show more</a>`
+              )})`
             );
             expect({
               ...chatResult?.metadata,
@@ -1076,25 +1075,25 @@ suite('Participant Controller Test Suite', function () {
             );
             const listCollsMessage = chatStreamStub.markdown.getCall(1).args[0];
             expect(listCollsMessage.value).to.include(
-              `- <a href="command:mdb.selectCollectionWithParticipant?${encodeStringify(
+              `- [collOne](command:mdb.selectCollectionWithParticipant?${encodeStringify(
                 {
                   command: '/query',
                   chatId: 'pineapple',
                   databaseName: 'dbOne',
                   collectionName: 'collOne',
                 }
-              )}">collOne</a>`
+              )})`
             );
             const showMoreCollsMessage =
               chatStreamStub.markdown.getCall(11).args[0];
             expect(showMoreCollsMessage.value).to.include(
-              `- <a href="command:mdb.selectCollectionWithParticipant?${encodeStringify(
+              `- [Show more](command:mdb.selectCollectionWithParticipant?${encodeStringify(
                 {
                   command: '/query',
                   chatId: 'pineapple',
                   databaseName: 'dbOne',
                 }
-              )}">Show more</a>`
+              )})`
             );
             expect({
               ...chatResult?.metadata,


### PR DESCRIPTION
VSCODE-616

We would show characters in the url as we streamed them in until the full `<a>` tag was built. This fixes that by using the markdown link format for running our clickable commands. `[text](link)`