### PR TITLE
chore(participant): add maxTimeMS to sample

### DIFF
--- a/src/participant/participant.ts
+++ b/src/participant/participant.ts
@@ -700,7 +700,7 @@ export default class ParticipantController {
           query: {},
           size: amountOfDocumentsToSample,
         },
-        { promoteValues: false },
+        { promoteValues: false, maxTimeMS: 10_000 },
         {
           abortSignal,
         }


### PR DESCRIPTION
This adds the [maxTimeMS](https://mongodb.github.io/node-mongodb-native/6.9/classes/FindCursor.html#maxTimeMS) option for the sample we have in the participant. In the past, for collections with many documents, and atlas data lake, sample could take a really long time. We want to avoid that, especially as there's no way to cancel this at the moment besides ending the chat or restarting VSCode.

We should have maxTimeMS set on all of our requests, outside of playgrounds, in our extension. Created VSCODE-617 for that. 