### PR TITLE
chore(participant): add handling for token cancellation, pass to docs fetch request, remove unused abort controllers

### DIFF
--- a/src/participant/constants.ts
+++ b/src/participant/constants.ts
@@ -10,6 +10,7 @@ export type ParticipantResponseType =
   | 'docs'
   | 'generic'
   | 'emptyRequest'
+  | 'cancelledRequest'
   | 'askToConnect'
   | 'askForNamespace';
 
@@ -47,6 +48,12 @@ export function namespaceRequestChatResult({
       collectionName,
     },
   };
+}
+
+export function createCancelledRequestChatResult(
+  history: ReadonlyArray<vscode.ChatRequestTurn | vscode.ChatResponseTurn>
+): ChatResult {
+  return createChatResult('cancelledRequest', history);
 }
 
 function createChatResult(

--- a/src/participant/docsChatbotAIService.ts
+++ b/src/participant/docsChatbotAIService.ts
@@ -54,7 +54,7 @@ export class DocsChatbotAIService {
     return `${this._serverBaseUri}api/${MONGODB_DOCS_CHATBOT_API_VERSION}${path}`;
   }
 
-  async _fetch({
+  _fetch({
     uri,
     method,
     body,
@@ -67,7 +67,7 @@ export class DocsChatbotAIService {
     body?: string;
     headers?: { [key: string]: string };
   }): Promise<Response> {
-    return await fetch(uri, {
+    return fetch(uri, {
       headers: {
         origin: this._serverBaseUri,
         'User-Agent': `mongodb-vscode/${version}`,

--- a/src/participant/docsChatbotAIService.ts
+++ b/src/participant/docsChatbotAIService.ts
@@ -58,29 +58,37 @@ export class DocsChatbotAIService {
     uri,
     method,
     body,
+    signal,
     headers,
   }: {
     uri: string;
     method: string;
+    signal?: AbortSignal;
     body?: string;
     headers?: { [key: string]: string };
   }): Promise<Response> {
-    return fetch(uri, {
+    return await fetch(uri, {
       headers: {
         origin: this._serverBaseUri,
         'User-Agent': `mongodb-vscode/${version}`,
         ...headers,
       },
       method,
+      signal,
       ...(body && { body }),
     });
   }
 
-  async createConversation(): Promise<ConversationData> {
+  async createConversation({
+    signal,
+  }: {
+    signal: AbortSignal;
+  }): Promise<ConversationData> {
     const uri = this.getUri('/conversations');
     const res = await this._fetch({
       uri,
       method: 'POST',
+      signal,
     });
 
     let data;
@@ -113,9 +121,11 @@ export class DocsChatbotAIService {
   async addMessage({
     conversationId,
     message,
+    signal,
   }: {
     conversationId: string;
     message: string;
+    signal: AbortSignal;
   }): Promise<MessageData> {
     const uri = this.getUri(`/conversations/${conversationId}/messages`);
     const res = await this._fetch({
@@ -123,6 +133,7 @@ export class DocsChatbotAIService {
       method: 'POST',
       body: JSON.stringify({ message }),
       headers: { 'Content-Type': 'application/json' },
+      signal,
     });
 
     let data;

--- a/src/participant/participant.ts
+++ b/src/participant/participant.ts
@@ -1118,7 +1118,7 @@ export default class ParticipantController {
       vscode.CancellationToken
     ]
   ): Promise<ChatResult> {
-    const [request, context, stream] = args;
+    const [request, context, stream, token] = args;
 
     const chatId = ChatMetadataStore.getChatIdFromHistoryOrNewChatId(
       context.history
@@ -1133,17 +1133,17 @@ export default class ParticipantController {
       docsResult = await this._handleDocsRequestWithChatbot({
         prompt: request.prompt,
         chatId,
-        token: args[3],
+        token,
       });
     } catch (error) {
       // If the docs chatbot API is not available, fall back to Copilot’s LLM and include
       // the MongoDB documentation link for users to go to our documentation site directly.
       log.error(error);
 
-      if (args[3].isCancellationRequested) {
+      if (token.isCancellationRequested) {
         return this._handleCancelledRequest({
           context,
-          stream: args[2],
+          stream,
         });
       }
 

--- a/src/test/suite/participant/docsChatbotAIService.test.ts
+++ b/src/test/suite/participant/docsChatbotAIService.test.ts
@@ -28,7 +28,9 @@ suite('DocsChatbotAIService Test Suite', function () {
         }),
     });
     global.fetch = fetchStub;
-    const conversation = await docsChatbotAIService.createConversation();
+    const conversation = await docsChatbotAIService.createConversation({
+      signal: new AbortController().signal,
+    });
     expect(conversation._id).to.be.eql('650b4b260f975ef031016c8a');
   });
 
@@ -42,10 +44,25 @@ suite('DocsChatbotAIService Test Suite', function () {
     global.fetch = fetchStub;
 
     try {
-      await docsChatbotAIService.createConversation();
+      await docsChatbotAIService.createConversation({
+        signal: new AbortController().signal,
+      });
       expect.fail('It must fail with the server error');
     } catch (error) {
       expect((error as Error).message).to.include('Internal server error');
+    }
+  });
+
+  test('throws when aborted', async () => {
+    try {
+      const abortController = new AbortController();
+      abortController.abort();
+      await docsChatbotAIService.createConversation({
+        signal: abortController.signal,
+      });
+      expect.fail('It must fail with the server error');
+    } catch (error) {
+      expect((error as Error).message).to.include('This operation was aborted');
     }
   });
 
@@ -59,7 +76,9 @@ suite('DocsChatbotAIService Test Suite', function () {
     global.fetch = fetchStub;
 
     try {
-      await docsChatbotAIService.createConversation();
+      await docsChatbotAIService.createConversation({
+        signal: new AbortController().signal,
+      });
       expect.fail('It must fail with the bad request error');
     } catch (error) {
       expect((error as Error).message).to.include('Bad request');
@@ -76,7 +95,9 @@ suite('DocsChatbotAIService Test Suite', function () {
     global.fetch = fetchStub;
 
     try {
-      await docsChatbotAIService.createConversation();
+      await docsChatbotAIService.createConversation({
+        signal: new AbortController().signal,
+      });
       expect.fail('It must fail with the rate limited error');
     } catch (error) {
       expect((error as Error).message).to.include('Rate limited');
@@ -95,6 +116,7 @@ suite('DocsChatbotAIService Test Suite', function () {
       await docsChatbotAIService.addMessage({
         conversationId: '650b4b260f975ef031016c8a',
         message: 'what is mongosh?',
+        signal: new AbortController().signal,
       });
       expect.fail('It must fail with the timeout error');
     } catch (error) {


### PR DESCRIPTION
We want to fail early and not ping the model when the chat token's token is cancelled.

This pr:
- Adds more places for us to fail early when the token is cancelled. 
- Adds an abort signal to the docs ai requests. 
- Removes 3 unused abort controllers we had.