### PR TITLE
chore: remove enabledApiProposals from package.json VSCODE-631

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "color": "#3D4F58",
     "theme": "dark"
   },
-  "enabledApiProposals": [],
   "license": "SEE LICENSE IN LICENSE.txt",
   "main": "./dist/extension.js",
   "scripts": {


### PR DESCRIPTION
VSCODE-631

Even though it's empty, it's likely causing the error when publishing:
```
Extensions using proposed API (enabledApiProposals: [...]) can't be published to the Marketplace
```

Originally added in https://github.com/mongodb-js/vscode/pull/757/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R36 and removed the api in https://github.com/mongodb-js/vscode/pull/842/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R35 
