### PR TITLE
VSCODE-640: Adapt message content access to latest vscode API

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -42,19 +42,19 @@
       ]
     },
     {
-			"name": "Run Tests",
-			"type": "extensionHost",
-			"request": "launch",
-			"runtimeExecutable": "${execPath}",
-			"args": [
-        "${workspaceFolder}/out/test/suite", // TODO: remove suite
-				"--disable-extensions",
-				"--extensionDevelopmentPath=${workspaceFolder}",
-				"--extensionTestsPath=${workspaceFolder}/out/test/suite"
-			],
-			"outFiles": ["${workspaceFolder}/out/**/*.js"],
-			"preLaunchTask": "npm: compile:extension",
-		}
+      "name": "Run Tests",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": [
+        "${workspaceFolder}/out/test/suite", // TODO: VSCODE-641 - remove suite
+        "--disable-extensions",
+        "--extensionDevelopmentPath=${workspaceFolder}",
+        "--extensionTestsPath=${workspaceFolder}/out/test/suite"
+      ],
+      "outFiles": ["${workspaceFolder}/out/**/*.js"],
+      "preLaunchTask": "npm: compile:extension",
+    }
   ],
   "compounds": [
     {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -40,7 +40,21 @@
       "outFiles": [
         "${workspaceFolder}/dist/**/*.js"
       ]
-    }
+    },
+    {
+			"name": "Run Tests",
+			"type": "extensionHost",
+			"request": "launch",
+			"runtimeExecutable": "${execPath}",
+			"args": [
+        "${workspaceFolder}/out/test/suite", // TODO: remove suite
+				"--disable-extensions",
+				"--extensionDevelopmentPath=${workspaceFolder}",
+				"--extensionTestsPath=${workspaceFolder}/out/test/suite"
+			],
+			"outFiles": ["${workspaceFolder}/out/**/*.js"],
+			"preLaunchTask": "npm: compile:extension",
+		}
   ],
   "compounds": [
     {

--- a/src/participant/participant.ts
+++ b/src/participant/participant.ts
@@ -189,7 +189,7 @@ export default class ParticipantController {
         (message: vscode.LanguageModelChatMessage) =>
           util.inspect({
             role: message.role,
-            contentLength: message.content.length,
+            contentLength: Prompts.getContentLength(message),
           })
       ),
     });
@@ -790,15 +790,18 @@ export default class ParticipantController {
       // it currently errors (not on insiders, only main VSCode).
       // Here we're defaulting to have some content as a workaround.
       // TODO: Remove this when the issue is fixed.
-      messagesWithNamespace.messages[
-        messagesWithNamespace.messages.length - 1
-        // eslint-disable-next-line new-cap
-      ] = vscode.LanguageModelChatMessage.User(
+      if (
+        !Prompts.doMessagesContainUserInput([
+          messagesWithNamespace.messages[
+            messagesWithNamespace.messages.length - 1
+          ],
+        ])
+      ) {
         messagesWithNamespace.messages[
           messagesWithNamespace.messages.length - 1
-        ].content.trim() || 'see previous messages'
-      );
-
+          // eslint-disable-next-line new-cap
+        ] = vscode.LanguageModelChatMessage.User('see previous messages');
+      }
       const responseContentWithNamespace = await this.getChatResponseContent({
         modelInput: messagesWithNamespace,
         token,

--- a/src/participant/participant.ts
+++ b/src/participant/participant.ts
@@ -10,7 +10,7 @@ import type { LoadedConnection } from '../storage/connectionStorage';
 import EXTENSION_COMMANDS from '../commands';
 import type { StorageController } from '../storage';
 import { StorageVariables } from '../storage';
-import { Prompts } from './prompts';
+import { getContentLength, Prompts } from './prompts';
 import type { ChatResult } from './constants';
 import {
   askToConnectChatResult,
@@ -189,7 +189,7 @@ export default class ParticipantController {
         (message: vscode.LanguageModelChatMessage) =>
           util.inspect({
             role: message.role,
-            contentLength: Prompts.getContentLength(message),
+            contentLength: getContentLength(message),
           })
       ),
     });

--- a/src/participant/prompts/index.ts
+++ b/src/participant/prompts/index.ts
@@ -5,6 +5,7 @@ import { IntentPrompt } from './intent';
 import { NamespacePrompt } from './namespace';
 import { QueryPrompt } from './query';
 import { SchemaPrompt } from './schema';
+import { isContentEmpty, getContentLength } from './promptBase';
 
 export class Prompts {
   public static generic = new GenericPrompt();
@@ -26,12 +27,18 @@ export class Prompts {
     for (const message of messages) {
       if (
         message.role === vscode.LanguageModelChatMessageRole.User &&
-        message.content.trim().length > 0
+        !isContentEmpty(message)
       ) {
         return true;
       }
     }
 
     return false;
+  }
+
+  public static getContentLength(
+    message: vscode.LanguageModelChatMessage
+  ): number {
+    return getContentLength(message);
   }
 }

--- a/src/participant/prompts/index.ts
+++ b/src/participant/prompts/index.ts
@@ -5,7 +5,9 @@ import { IntentPrompt } from './intent';
 import { NamespacePrompt } from './namespace';
 import { QueryPrompt } from './query';
 import { SchemaPrompt } from './schema';
-import { isContentEmpty, getContentLength } from './promptBase';
+import { isContentEmpty } from './promptBase';
+
+export { getContentLength } from './promptBase';
 
 export class Prompts {
   public static generic = new GenericPrompt();
@@ -34,11 +36,5 @@ export class Prompts {
     }
 
     return false;
-  }
-
-  public static getContentLength(
-    message: vscode.LanguageModelChatMessage
-  ): number {
-    return getContentLength(message);
   }
 }


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. VSCODE-1111: updates ace editor width in agg pipeline view -->
<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->
## Description
https://github.com/microsoft/vscode/pull/231788 changes the content field type of LanguageModelChatMessage. This means that in insiders builds, we're seeing exceptions/test failures due to us assuming the content will always be a string. Since the type definitions haven't been updated to account for this breaking change, this PR takes a somewhat hacky approach of casting the content to `any` and then testing for string or array.

### Checklist
- [x] New tests and/or benchmarks are included

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
