### PR TITLE
feat(chat): Prompt to connect when a disconnected user tries to run code from participant VSCODE-618

### DIFF
--- a/src/editors/playgroundController.ts
+++ b/src/editors/playgroundController.ts
@@ -583,10 +583,13 @@ export default class PlaygroundController {
       .get('confirmRunCopilotCode');
 
     if (!this._connectionController.isCurrentlyConnected()) {
-      // TODO(VSCODE-618): Prompt user to connect when clicked.
-      void vscode.window.showErrorMessage(connectBeforeRunningMessage);
+      const successfullyConnected =
+        await this._connectionController.changeActiveConnection();
 
-      return false;
+      if (!successfullyConnected) {
+        void vscode.window.showErrorMessage(connectBeforeRunningMessage);
+        return false;
+      }
     }
 
     if (shouldConfirmRunCopilotCode === true) {

--- a/src/test/suite/editors/playgroundController.test.ts
+++ b/src/test/suite/editors/playgroundController.test.ts
@@ -270,6 +270,60 @@ suite('Playground Controller Test Suite', function () {
           expectedMessage
         );
       });
+
+      suite('running code from the participant', function () {
+        beforeEach(function () {
+          sinon
+            .stub(testPlaygroundController, '_evaluateWithCancelModal')
+            .resolves({ result: '123' } as any);
+          sinon.stub(testPlaygroundController, '_openInResultPane').resolves();
+
+          showInformationMessageStub.resolves('Yes');
+        });
+
+        afterEach(() => sinon.restore());
+
+        test('prompts to connect to a database and succeeds with selection', async () => {
+          const changeActiveConnectionStub = sinon.stub(
+            testPlaygroundController._connectionController,
+            'changeActiveConnection'
+          );
+          // Mocks the user selecting a connection.
+          changeActiveConnectionStub.resolves(true);
+
+          const result = await testPlaygroundController.evaluateParticipantCode(
+            'console.log("test");'
+          );
+
+          expect(showErrorMessageStub.notCalled).is.true;
+
+          expect(changeActiveConnectionStub.calledOnce).is.true;
+
+          expect(result).is.true;
+        });
+
+        test('prompts to connect to a database and errors if not selected', async () => {
+          const changeActiveConnectionStub = sinon.stub(
+            testPlaygroundController._connectionController,
+            'changeActiveConnection'
+          );
+          // Mocks the user selecting a connection.
+          changeActiveConnectionStub.resolves(false);
+
+          const result = await testPlaygroundController.evaluateParticipantCode(
+            'console.log("test");'
+          );
+
+          const expectedMessage =
+            'Please connect to a database before running a playground.';
+          await testPlaygroundController.runAllOrSelectedPlaygroundBlocks();
+          expect(showErrorMessageStub.firstCall.args[0]).to.be.equal(
+            expectedMessage
+          );
+
+          expect(result).is.false;
+        });
+      });
     });
 
     suite('user is connected', () => {
@@ -429,6 +483,35 @@ suite('Playground Controller Test Suite', function () {
             await testPlaygroundController.runAllPlaygroundBlocks();
 
           expect(result).to.be.false;
+        });
+      });
+
+      suite('running code from the participant', function () {
+        beforeEach(function () {
+          sinon
+            .stub(testPlaygroundController, '_evaluateWithCancelModal')
+            .resolves({ result: '123' } as any);
+          sinon.stub(testPlaygroundController, '_openInResultPane').resolves();
+
+          showInformationMessageStub.resolves('Yes');
+        });
+
+        afterEach(() => sinon.restore());
+
+        test('does not prompt to connect to the database', async () => {
+          const changeActiveConnectionStub = sinon.stub(
+            testPlaygroundController._connectionController,
+            'changeActiveConnection'
+          );
+          const result = await testPlaygroundController.evaluateParticipantCode(
+            'console.log("test");'
+          );
+
+          expect(showErrorMessageStub.notCalled).is.true;
+
+          expect(changeActiveConnectionStub.notCalled).is.true;
+
+          expect(result).is.true;
         });
       });
     });


### PR DESCRIPTION
[VSCODE-618](https://jira.mongodb.org/browse/VSCODE-618)
When a users asks the participant something that results in code generation we provide a button to run the code. However, they may not be connected to an instance, so they can't run that code. At the moment if a user hits the `> Run` button while not connected we fail silently. This involves adding a connection flow when not connected. Similar to the `Change active connection` command handler.

<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. VSCODE-1111: updates ace editor width in agg pipeline view -->
<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
