### PR TITLE
fix: show export to language icon only when copilot is active VSCODE-655

### DIFF
--- a/package.json
+++ b/package.json
@@ -724,7 +724,7 @@
         {
           "command": "mdb.selectTargetForExportToLanguage",
           "group": "navigation@1",
-          "when": "mdb.isPlayground == true"
+          "when": "mdb.isPlayground == true && mdb.isCopilotActive == true"
         },
         {
           "command": "mdb.runPlayground",

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -168,6 +168,21 @@ export default class MDBExtensionController implements vscode.Disposable {
     this.showOverviewPageIfRecentlyInstalled();
     void this.showSurveyForEstablishedUsers();
     void this.showCopilotIntroductionForEstablishedUsers();
+
+    const copilot = vscode.extensions.getExtension('GitHub.copilot');
+    void vscode.commands.executeCommand(
+      'setContext',
+      'mdb.isCopilotActive',
+      copilot?.isActive
+    );
+
+    vscode.extensions.onDidChange(() => {
+      void vscode.commands.executeCommand(
+        'setContext',
+        'mdb.isCopilotActive',
+        copilot?.isActive
+      );
+    });
   }
 
   registerCommands = (): void => {

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -175,14 +175,6 @@ export default class MDBExtensionController implements vscode.Disposable {
       'mdb.isCopilotActive',
       copilot?.isActive
     );
-
-    vscode.extensions.onDidChange(() => {
-      void vscode.commands.executeCommand(
-        'setContext',
-        'mdb.isCopilotActive',
-        copilot?.isActive
-      );
-    });
   }
 
   registerCommands = (): void => {

--- a/src/test/suite/participant/participant.test.ts
+++ b/src/test/suite/participant/participant.test.ts
@@ -1698,6 +1698,8 @@ Schema:
       });
 
       suite('export to playground', function () {
+        this.timeout(5000);
+
         beforeEach(async function () {
           await vscode.commands.executeCommand(
             'workbench.action.files.newUntitledFile'


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. VSCODE-1111: updates ace editor width in agg pipeline view -->
<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
Show export to language icon only when the copilot is active.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
