### PR TITLE
fix(participant): add a space after query from announcement notification 

### DIFF
--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -955,7 +955,7 @@ export default class MDBExtensionController implements vscode.Disposable {
         'workbench.action.chat.clearHistory'
       );
       await vscode.commands.executeCommand('workbench.action.chat.open', {
-        query: '@MongoDB',
+        query: '@MongoDB ',
         isPartialQuery: true,
       });
       this._telemetryService.trackCopilotIntroductionClicked({


### PR DESCRIPTION
The space is more convenient for typing out the question right away.