### PR TITLE
fix(playground): hide playground export menu item if GitHub Copilot is not active VSCODE-660

### DIFF
--- a/package.json
+++ b/package.json
@@ -736,7 +736,7 @@
       "mdb.copilot": [
         {
           "command": "mdb.exportCodeToPlayground",
-          "when": "mdb.isPlayground == false"
+          "when": "mdb.isPlayground == false && mdb.isCopilotActive == true"
         }
       ],
       "editor/context": [


### PR DESCRIPTION
The Context Menu entry for MongoDB Copilot Extension currently appears even if you have GitHub Copilot uninstalled or deactivated. There are a lot of people without Copilot enabled that may discover this and use it and it would lead to an error. This PR hides it if Copilot is not active.