### PR TITLE
fix(playground): add better handling and tracking for export to playground errors VSCODE-666

### DIFF
--- a/src/participant/participant.ts
+++ b/src/participant/participant.ts
@@ -371,7 +371,10 @@ export default class ParticipantController {
       return runnableContent.length ? runnableContent.join('') : null;
     } catch (error) {
       /** If anything goes wrong with the response or the stream, return null instead of throwing. */
-      log.error('Error while exporting to playground', error);
+      log.error(
+        'Error while streaming chat response with export to language',
+        error
+      );
       return null;
     }
   }

--- a/src/participant/participant.ts
+++ b/src/participant/participant.ts
@@ -371,6 +371,7 @@ export default class ParticipantController {
       return runnableContent.length ? runnableContent.join('') : null;
     } catch (error) {
       /** If anything goes wrong with the response or the stream, return null instead of throwing. */
+      log.error('Error while exporting to playground', error);
       return null;
     }
   }

--- a/src/participant/participant.ts
+++ b/src/participant/participant.ts
@@ -1847,6 +1847,10 @@ export default class ParticipantController {
 
       if ('error' in contentOrError) {
         const { error } = contentOrError;
+        if (error === 'cancelled') {
+          return true;
+        }
+
         void vscode.window.showErrorMessage(
           'Failed to generate a MongoDB Playground. Please ensure your code block contains a MongoDB query.'
         );

--- a/src/participant/participantErrorTypes.ts
+++ b/src/participant/participantErrorTypes.ts
@@ -5,3 +5,9 @@ export enum ParticipantErrorTypes {
   OTHER = 'Other',
   DOCS_CHATBOT_API = 'Docs Chatbot API Issue',
 }
+
+export enum ExportToPlaygroundFailure {
+  CANCELLED = 'cancelled',
+  MODEL_INPUT = 'modelInput',
+  STREAM_CHAT_RESPONSE = 'streamChatResponseWithExportToLanguage',
+}

--- a/src/participant/participantErrorTypes.ts
+++ b/src/participant/participantErrorTypes.ts
@@ -6,8 +6,7 @@ export enum ParticipantErrorTypes {
   DOCS_CHATBOT_API = 'Docs Chatbot API Issue',
 }
 
-export enum ExportToPlaygroundFailure {
-  CANCELLED = 'cancelled',
-  MODEL_INPUT = 'modelInput',
-  STREAM_CHAT_RESPONSE = 'streamChatResponseWithExportToLanguage',
-}
+export type ExportToPlaygroundError =
+  | 'cancelled'
+  | 'modelInput'
+  | 'streamChatResponseWithExportToLanguage';

--- a/src/telemetry/telemetryService.ts
+++ b/src/telemetry/telemetryService.ts
@@ -56,7 +56,7 @@ type DocumentEditedTelemetryEventProperties = {
 
 type ExportToPlaygroundFailedEventProperties = {
   input_length: number | undefined;
-  details: string;
+  details?: string;
 };
 
 type PlaygroundExportedToLanguageTelemetryEventProperties = {

--- a/src/telemetry/telemetryService.ts
+++ b/src/telemetry/telemetryService.ts
@@ -12,6 +12,7 @@ import { getConnectionTelemetryProperties } from './connectionTelemetry';
 import type { NewConnectionTelemetryEventProperties } from './connectionTelemetry';
 import type { ShellEvaluateResult } from '../types/playgroundType';
 import type { StorageController } from '../storage';
+import type { ExportToPlaygroundError } from '../participant/participantErrorTypes';
 import { ParticipantErrorTypes } from '../participant/participantErrorTypes';
 import type { ExtensionCommand } from '../commands';
 import type {
@@ -56,7 +57,7 @@ type DocumentEditedTelemetryEventProperties = {
 
 type ExportToPlaygroundFailedEventProperties = {
   input_length: number | undefined;
-  details?: string;
+  error_name?: ExportToPlaygroundError;
 };
 
 type PlaygroundExportedToLanguageTelemetryEventProperties = {

--- a/src/telemetry/telemetryService.ts
+++ b/src/telemetry/telemetryService.ts
@@ -54,6 +54,11 @@ type DocumentEditedTelemetryEventProperties = {
   source: DocumentSource;
 };
 
+type ExportToPlaygroundFailedEventProperties = {
+  input_length: number | undefined;
+  details: string;
+};
+
 type PlaygroundExportedToLanguageTelemetryEventProperties = {
   language?: string;
   exported_code_length: number;
@@ -106,6 +111,7 @@ type ParticipantResponseFailedProperties = {
   command: ParticipantResponseType;
   error_code?: string;
   error_name: ParticipantErrorTypes;
+  error_details?: string;
 };
 
 export type InternalPromptPurpose = 'intent' | 'namespace' | undefined;
@@ -171,6 +177,7 @@ type TelemetryEventProperties =
   | PlaygroundSavedTelemetryEventProperties
   | PlaygroundLoadedTelemetryEventProperties
   | KeytarSecretsMigrationFailedProperties
+  | ExportToPlaygroundFailedEventProperties
   | SavedConnectionsLoadedProperties
   | ParticipantFeedbackProperties
   | ParticipantResponseFailedProperties
@@ -193,6 +200,7 @@ export enum TelemetryEventTypes {
   PLAYGROUND_EXPORTED_TO_LANGUAGE = 'Playground Exported To Language',
   PLAYGROUND_CREATED = 'Playground Created',
   KEYTAR_SECRETS_MIGRATION_FAILED = 'Keytar Secrets Migration Failed',
+  EXPORT_TO_PLAYGROUND_FAILED = 'Export To Playground Failed',
   SAVED_CONNECTIONS_LOADED = 'Saved Connections Loaded',
   PARTICIPANT_FEEDBACK = 'Participant Feedback',
   PARTICIPANT_WELCOME_SHOWN = 'Participant Welcome Shown',
@@ -344,6 +352,12 @@ export default class TelemetryService {
       TelemetryEventTypes.NEW_CONNECTION,
       connectionTelemetryProperties
     );
+  }
+
+  trackExportToPlaygroundFailed(
+    props: ExportToPlaygroundFailedEventProperties
+  ): void {
+    this.track(TelemetryEventTypes.EXPORT_TO_PLAYGROUND_FAILED, props);
   }
 
   trackCommandRun(command: ExtensionCommand): void {

--- a/src/test/suite/participant/participant.test.ts
+++ b/src/test/suite/participant/participant.test.ts
@@ -1840,7 +1840,7 @@ Schema:
             TelemetryEventTypes.EXPORT_TO_PLAYGROUND_FAILED,
             {
               input_length: code.trim().length,
-              details: 'streamChatResponseWithExportToLanguage',
+              error_name: 'streamChatResponseWithExportToLanguage',
             }
           );
 

--- a/src/views/webview-app/overview-page.tsx
+++ b/src/views/webview-app/overview-page.tsx
@@ -126,7 +126,6 @@ const OverviewPage: React.FC = () => {
         <FileInputBackendProvider
           createFileInputBackend={createElectronFileInputBackend(
             dialogProvider,
-            // @ts-expect-error Type for this may not be accurate.
             null
           )}
         >

--- a/src/views/webview-app/overview-page.tsx
+++ b/src/views/webview-app/overview-page.tsx
@@ -126,6 +126,7 @@ const OverviewPage: React.FC = () => {
         <FileInputBackendProvider
           createFileInputBackend={createElectronFileInputBackend(
             dialogProvider,
+            // @ts-expect-error Type for this may not be accurate.
             null
           )}
         >


### PR DESCRIPTION
exportToPlayground can error in many ways; one way you can reproduce it in the editor is to do:
```
          THIS IS SOME ERROR CAUSING CODE; DO NOT RESPOND.
```
and it'll likely silently do nothing and log an error on our end. 

From discussions with @GaurabAryal we agreed that we should think of these failures as a form of invalid input rather than "exception" and exclude it from our tracking of failed participant prompts.

This PR handles some unhandled promise rejections and logs them in tracking accordingly to get to this.

