### PR TITLE
feat(tree-explorer): add ability to set preset connections in settings.json VSCODE-665

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,5 +16,11 @@
     "out": true
   },
   // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-  "typescript.tsc.autoDetect": "off"
+  "typescript.tsc.autoDetect": "off",
+  "mdb.presetSavedConnections": [
+    {
+      "name": "Local Test",
+      "connectionString": "mongodb://127.0.0.1:27017/?directConnection=true&serverSelectionTimeoutMS=2000"
+    }
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,13 +17,10 @@
   },
   // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
   "typescript.tsc.autoDetect": "off",
-  "mdb.presetSavedConnections":[
+  "mdb.presetSavedConnections": [
     {
-      "name": "Local Test Connection",
+      "name": "Preset Database",
       "connectionString": "mongodb://localhost:27017"
     }
-  ],
-  "conventionalCommits.scopes": [
-    "tree-explorer"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,10 +17,13 @@
   },
   // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
   "typescript.tsc.autoDetect": "off",
-  "mdb.presetSavedConnections": [
+  "mdb.presetSavedConnections":[
     {
-      "name": "Local Test",
-      "connectionString": "mongodb://127.0.0.1:27017/?directConnection=true&serverSelectionTimeoutMS=2000"
+      "name": "Local Test Connection",
+      "connectionString": "mongodb://localhost:27017"
     }
+  ],
+  "conventionalCommits.scopes": [
+    "tree-explorer"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,7 +17,7 @@
   },
   // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
   "typescript.tsc.autoDetect": "off",
-  "mdb.presetSavedConnections": [
+  "mdb.presetConnections": [
     {
       "name": "Preset Database",
       "connectionString": "mongodb://localhost:27017"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,7 +19,7 @@
   "typescript.tsc.autoDetect": "off",
   "mdb.presetConnections": [
     {
-      "name": "Preset Database",
+      "name": "Preset Connection",
       "connectionString": "mongodb://localhost:27017"
     }
   ]

--- a/package.json
+++ b/package.json
@@ -321,8 +321,8 @@
         "title": "Copy Connection String"
       },
       {
-        "command": "mdb.openWorkspaceSettingsFile",
-        "title": "Open Workspace Settings"
+        "command": "mdb.editPresetConnections",
+        "title": "Edit Preset Connections..."
       },
       {
         "command": "mdb.renameConnection",
@@ -503,32 +503,32 @@
       "view/item/context": [
         {
           "command": "mdb.addDatabase",
-          "when": "view == mongoDBConnectionExplorer && (viewItem == connectedConnectionTreeItem || viewItem == connectedImmutableConnectionTreeItem) && mdb.isAtlasStreams == false",
+          "when": "view == mongoDBConnectionExplorer && (viewItem == connectedConnectionTreeItem || viewItem == connectedPresetConnectionTreeItem) && mdb.isAtlasStreams == false",
           "group": "inline"
         },
         {
           "command": "mdb.addDatabase",
-          "when": "view == mongoDBConnectionExplorer && (viewItem == connectedConnectionTreeItem || viewItem == connectedImmutableConnectionTreeItem) && mdb.isAtlasStreams == false",
+          "when": "view == mongoDBConnectionExplorer && (viewItem == connectedConnectionTreeItem || viewItem == connectedPresetConnectionTreeItem) && mdb.isAtlasStreams == false",
           "group": "1@1"
         },
         {
           "command": "mdb.addStreamProcessor",
-          "when": "view == mongoDBConnectionExplorer && (viewItem == connectedConnectionTreeItem || viewItem == connectedImmutableConnectionTreeItem) && mdb.isAtlasStreams == true",
+          "when": "view == mongoDBConnectionExplorer && (viewItem == connectedConnectionTreeItem || viewItem == connectedPresetConnectionTreeItem) && mdb.isAtlasStreams == true",
           "group": "inline"
         },
         {
           "command": "mdb.addStreamProcessor",
-          "when": "view == mongoDBConnectionExplorer && (viewItem == connectedConnectionTreeItem || viewItem == connectedImmutableConnectionTreeItem) && mdb.isAtlasStreams == true",
+          "when": "view == mongoDBConnectionExplorer && (viewItem == connectedConnectionTreeItem || viewItem == connectedPresetConnectionTreeItem) && mdb.isAtlasStreams == true",
           "group": "1@1"
         },
         {
           "command": "mdb.refreshConnection",
-          "when": "view == mongoDBConnectionExplorer && (viewItem == connectedConnectionTreeItem || viewItem == connectedImmutableConnectionTreeItem)",
+          "when": "view == mongoDBConnectionExplorer && (viewItem == connectedConnectionTreeItem || viewItem == connectedPresetConnectionTreeItem)",
           "group": "1@2"
         },
         {
           "command": "mdb.treeViewOpenMongoDBShell",
-          "when": "view == mongoDBConnectionExplorer && (viewItem == connectedConnectionTreeItem || viewItem == connectedImmutableConnectionTreeItem)",
+          "when": "view == mongoDBConnectionExplorer && (viewItem == connectedConnectionTreeItem || viewItem == connectedPresetConnectionTreeItem)",
           "group": "2@1"
         },
         {
@@ -542,18 +542,18 @@
           "group": "3@2"
         },
         {
-          "command": "mdb.openWorkspaceSettingsFile",
-          "when": "view == mongoDBConnectionExplorer && (viewItem == connectedImmutableConnectionTreeItem)",
+          "command": "mdb.editPresetConnections",
+          "when": "view == mongoDBConnectionExplorer && (viewItem == connectedPresetConnectionTreeItem)",
           "group": "3@2"
         },
         {
           "command": "mdb.copyConnectionString",
-          "when": "view == mongoDBConnectionExplorer && (viewItem == connectedConnectionTreeItem || viewItem == connectedImmutableConnectionTreeItem)",
+          "when": "view == mongoDBConnectionExplorer && (viewItem == connectedConnectionTreeItem || viewItem == connectedPresetConnectionTreeItem)",
           "group": "4@1"
         },
         {
           "command": "mdb.disconnectFromConnectionTreeItem",
-          "when": "view == mongoDBConnectionExplorer && (viewItem == connectedConnectionTreeItem || viewItem == connectedImmutableConnectionTreeItem)",
+          "when": "view == mongoDBConnectionExplorer && (viewItem == connectedConnectionTreeItem || viewItem == connectedPresetConnectionTreeItem)",
           "group": "5@1"
         },
         {
@@ -568,7 +568,7 @@
         },
         {
           "command": "mdb.connectToConnectionTreeItem",
-          "when": "view == mongoDBConnectionExplorer && (viewItem == disconnectedConnectionTreeItem || viewItem == disconnectedImmutableConnectionTreeItem)",
+          "when": "view == mongoDBConnectionExplorer && (viewItem == disconnectedConnectionTreeItem || viewItem == disconnectedPresetConnectionTreeItem)",
           "group": "1@1"
         },
         {
@@ -582,13 +582,13 @@
           "group": "2@2"
         },
         {
-          "command": "mdb.openWorkspaceSettingsFile",
-          "when": "view == mongoDBConnectionExplorer && (viewItem == disconnectedImmutableConnectionTreeItem)",
+          "command": "mdb.editPresetConnections",
+          "when": "view == mongoDBConnectionExplorer && (viewItem == disconnectedPresetConnectionTreeItem)",
           "group": "2@2"
         },
         {
           "command": "mdb.copyConnectionString",
-          "when": "view == mongoDBConnectionExplorer && (viewItem == disconnectedConnectionTreeItem || viewItem == disconnectedImmutableConnectionTreeItem)",
+          "when": "view == mongoDBConnectionExplorer && (viewItem == disconnectedConnectionTreeItem || viewItem == disconnectedPresetConnectionTreeItem)",
           "group": "3@1"
         },
         {

--- a/package.json
+++ b/package.json
@@ -1190,8 +1190,22 @@
           "scope": "window",
           "type": "array",
           "description": "Defines preset saved connections.",
+          "examples": [
+            [
+              {
+                "name": "Local Test Connection",
+                "connectionString": "mongodb://localhost:27017"
+              }
+            ]
+          ],
           "items": {
             "type": "object",
+            "examples": [
+              {
+                "name": "Local Test Connection",
+                "connectionString": "mongodb://localhost:27017"
+              }
+            ],
             "properties": {
               "name": {
                 "type": "string",

--- a/package.json
+++ b/package.json
@@ -1196,11 +1196,11 @@
         "mdb.presetConnections": {
           "scope": "window",
           "type": "array",
-          "description": "Defines preset saved connections. Can be used to share connection configurations in a workspace or global scope. Do not store sensitive credentials here.",
+          "description": "Defines preset connections. Can be used to share connection configurations in a workspace or global scope. Do not store sensitive credentials here.",
           "examples": [
             [
               {
-                "name": "Preset Database",
+                "name": "Preset Connection",
                 "connectionString": "mongodb://localhost:27017"
               }
             ]
@@ -1209,7 +1209,7 @@
             "type": "object",
             "examples": [
               {
-                "name": "Preset Database",
+                "name": "Preset Connection",
                 "connectionString": "mongodb://localhost:27017"
               }
             ],

--- a/package.json
+++ b/package.json
@@ -321,6 +321,10 @@
         "title": "Copy Connection String"
       },
       {
+        "command": "mdb.openWorkspaceSettingsFile",
+        "title": "Open Workspace Settings"
+      },
+      {
         "command": "mdb.renameConnection",
         "title": "Rename Connection..."
       },
@@ -499,32 +503,32 @@
       "view/item/context": [
         {
           "command": "mdb.addDatabase",
-          "when": "view == mongoDBConnectionExplorer && viewItem == connectedConnectionTreeItem && mdb.isAtlasStreams == false",
+          "when": "view == mongoDBConnectionExplorer && (viewItem == connectedConnectionTreeItem || viewItem == connectedImmutableConnectionTreeItem) && mdb.isAtlasStreams == false",
           "group": "inline"
         },
         {
           "command": "mdb.addDatabase",
-          "when": "view == mongoDBConnectionExplorer && viewItem == connectedConnectionTreeItem && mdb.isAtlasStreams == false",
+          "when": "view == mongoDBConnectionExplorer && (viewItem == connectedConnectionTreeItem || viewItem == connectedImmutableConnectionTreeItem) && mdb.isAtlasStreams == false",
           "group": "1@1"
         },
         {
           "command": "mdb.addStreamProcessor",
-          "when": "view == mongoDBConnectionExplorer && viewItem == connectedConnectionTreeItem && mdb.isAtlasStreams == true",
+          "when": "view == mongoDBConnectionExplorer && (viewItem == connectedConnectionTreeItem || viewItem == connectedImmutableConnectionTreeItem) && mdb.isAtlasStreams == true",
           "group": "inline"
         },
         {
           "command": "mdb.addStreamProcessor",
-          "when": "view == mongoDBConnectionExplorer && viewItem == connectedConnectionTreeItem && mdb.isAtlasStreams == true",
+          "when": "view == mongoDBConnectionExplorer && (viewItem == connectedConnectionTreeItem || viewItem == connectedImmutableConnectionTreeItem) && mdb.isAtlasStreams == true",
           "group": "1@1"
         },
         {
           "command": "mdb.refreshConnection",
-          "when": "view == mongoDBConnectionExplorer && viewItem == connectedConnectionTreeItem",
+          "when": "view == mongoDBConnectionExplorer && (viewItem == connectedConnectionTreeItem || viewItem == connectedImmutableConnectionTreeItem)",
           "group": "1@2"
         },
         {
           "command": "mdb.treeViewOpenMongoDBShell",
-          "when": "view == mongoDBConnectionExplorer && viewItem == connectedConnectionTreeItem",
+          "when": "view == mongoDBConnectionExplorer && (viewItem == connectedConnectionTreeItem || viewItem == connectedImmutableConnectionTreeItem)",
           "group": "2@1"
         },
         {
@@ -538,13 +542,18 @@
           "group": "3@2"
         },
         {
+          "command": "mdb.openWorkspaceSettingsFile",
+          "when": "view == mongoDBConnectionExplorer && (viewItem == connectedImmutableConnectionTreeItem)",
+          "group": "3@2"
+        },
+        {
           "command": "mdb.copyConnectionString",
-          "when": "view == mongoDBConnectionExplorer && viewItem == connectedConnectionTreeItem",
+          "when": "view == mongoDBConnectionExplorer && (viewItem == connectedConnectionTreeItem || viewItem == connectedImmutableConnectionTreeItem)",
           "group": "4@1"
         },
         {
           "command": "mdb.disconnectFromConnectionTreeItem",
-          "when": "view == mongoDBConnectionExplorer && viewItem == connectedConnectionTreeItem",
+          "when": "view == mongoDBConnectionExplorer && (viewItem == connectedConnectionTreeItem || viewItem == connectedImmutableConnectionTreeItem)",
           "group": "5@1"
         },
         {
@@ -559,7 +568,7 @@
         },
         {
           "command": "mdb.connectToConnectionTreeItem",
-          "when": "view == mongoDBConnectionExplorer && viewItem == disconnectedConnectionTreeItem",
+          "when": "view == mongoDBConnectionExplorer && (viewItem == disconnectedConnectionTreeItem || viewItem == disconnectedImmutableConnectionTreeItem)",
           "group": "1@1"
         },
         {
@@ -573,8 +582,13 @@
           "group": "2@2"
         },
         {
+          "command": "mdb.openWorkspaceSettingsFile",
+          "when": "view == mongoDBConnectionExplorer && (viewItem == disconnectedImmutableConnectionTreeItem)",
+          "group": "2@2"
+        },
+        {
           "command": "mdb.copyConnectionString",
-          "when": "view == mongoDBConnectionExplorer && viewItem == disconnectedConnectionTreeItem",
+          "when": "view == mongoDBConnectionExplorer && (viewItem == disconnectedConnectionTreeItem || viewItem == disconnectedImmutableConnectionTreeItem)",
           "group": "3@1"
         },
         {
@@ -1171,6 +1185,28 @@
           "type": "string",
           "default": "",
           "description": "Specify a shell command that is run to start the browser for authenticating with the OIDC identity provider for the server connection. Leave this empty for default browser."
+        },
+        "mdb.presetSavedConnections": {
+          "scope": "window",
+          "type": "array",
+          "description": "Defines preset saved connections.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Name of the connection."
+              },
+              "connectionString": {
+                "type": "string",
+                "description": "Connection string. Do not store sensitive credentials here."
+              }
+            },
+            "required": [
+              "name",
+              "connectionString"
+            ]
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -493,11 +493,18 @@
         },
         {
           "command": "mdb.addConnection",
-          "when": "view == mongoDBConnectionExplorer"
+          "when": "view == mongoDBConnectionExplorer",
+          "group": "1@1"
         },
         {
           "command": "mdb.addConnectionWithURI",
-          "when": "view == mongoDBConnectionExplorer"
+          "when": "view == mongoDBConnectionExplorer",
+          "group": "1@2"
+        },
+        {
+          "command": "mdb.editPresetConnections",
+          "when": "view == mongoDBConnectionExplorer",
+          "group": "2@1"
         }
       ],
       "view/item/context": [
@@ -1189,11 +1196,11 @@
         "mdb.presetSavedConnections": {
           "scope": "window",
           "type": "array",
-          "description": "Defines preset saved connections.",
+          "description": "Defines preset saved connections. Can be used to share connection configurations in a workspace or global scope. Do not store sensitive credentials here.",
           "examples": [
             [
               {
-                "name": "Local Test Connection",
+                "name": "Preset Database",
                 "connectionString": "mongodb://localhost:27017"
               }
             ]
@@ -1202,7 +1209,7 @@
             "type": "object",
             "examples": [
               {
-                "name": "Local Test Connection",
+                "name": "Preset Database",
                 "connectionString": "mongodb://localhost:27017"
               }
             ],

--- a/package.json
+++ b/package.json
@@ -550,7 +550,7 @@
         },
         {
           "command": "mdb.editPresetConnections",
-          "when": "view == mongoDBConnectionExplorer && (viewItem == connectedPresetConnectionTreeItem)",
+          "when": "view == mongoDBConnectionExplorer && viewItem == connectedPresetConnectionTreeItem",
           "group": "3@2"
         },
         {
@@ -590,7 +590,7 @@
         },
         {
           "command": "mdb.editPresetConnections",
-          "when": "view == mongoDBConnectionExplorer && (viewItem == disconnectedPresetConnectionTreeItem)",
+          "when": "view == mongoDBConnectionExplorer && viewItem == disconnectedPresetConnectionTreeItem",
           "group": "2@2"
         },
         {
@@ -1193,7 +1193,7 @@
           "default": "",
           "description": "Specify a shell command that is run to start the browser for authenticating with the OIDC identity provider for the server connection. Leave this empty for default browser."
         },
-        "mdb.presetSavedConnections": {
+        "mdb.presetConnections": {
           "scope": "window",
           "type": "array",
           "description": "Defines preset saved connections. Can be used to share connection configurations in a workspace or global scope. Do not store sensitive credentials here.",

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -44,7 +44,7 @@ enum EXTENSION_COMMANDS {
   MDB_EDIT_CONNECTION = 'mdb.editConnection',
   MDB_REFRESH_CONNECTION = 'mdb.refreshConnection',
   MDB_COPY_CONNECTION_STRING = 'mdb.copyConnectionString',
-  MDB_OPEN_WORKSPACE_SETTINGS_FILE = 'mdb.openWorkspaceSettingsFile',
+  MDB_EDIT_PRESET_CONNECTIONS = 'mdb.editPresetConnections',
   MDB_REMOVE_CONNECTION_TREE_VIEW = 'mdb.treeItemRemoveConnection',
   MDB_RENAME_CONNECTION = 'mdb.renameConnection',
   MDB_ADD_DATABASE = 'mdb.addDatabase',

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -44,6 +44,7 @@ enum EXTENSION_COMMANDS {
   MDB_EDIT_CONNECTION = 'mdb.editConnection',
   MDB_REFRESH_CONNECTION = 'mdb.refreshConnection',
   MDB_COPY_CONNECTION_STRING = 'mdb.copyConnectionString',
+  MDB_OPEN_WORKSPACE_SETTINGS_FILE = 'mdb.openWorkspaceSettingsFile',
   MDB_REMOVE_CONNECTION_TREE_VIEW = 'mdb.treeItemRemoveConnection',
   MDB_RENAME_CONNECTION = 'mdb.renameConnection',
   MDB_ADD_DATABASE = 'mdb.addDatabase',

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -177,9 +177,7 @@ export default class ConnectionController {
     if (!source) {
       const mdbConfiguration = vscode.workspace.getConfiguration('mdb');
 
-      const presetConnections = mdbConfiguration?.inspect(
-        'presetSavedConnections'
-      );
+      const presetConnections = mdbConfiguration?.inspect('presetConnections');
 
       if (presetConnections?.workspaceValue) {
         source = 'workspaceSettings';
@@ -189,7 +187,7 @@ export default class ConnectionController {
         // If no preset settings exist in workspace and global scope,
         // set a default one inside the workspace and open it.
         source = 'workspaceSettings';
-        await mdbConfiguration.update('presetSavedConnections', [
+        await mdbConfiguration.update('presetConnections', [
           {
             name: 'Preset Database',
             connectionString: 'mongodb://localhost:27017',
@@ -197,12 +195,20 @@ export default class ConnectionController {
         ]);
       }
     }
-    if (originTreeItem?.source === 'globalSettings') {
-      await vscode.commands.executeCommand('workbench.action.openSettingsJson');
-    } else {
-      await vscode.commands.executeCommand(
-        'workbench.action.openWorkspaceSettingsFile'
-      );
+    switch (source) {
+      case 'globalSettings':
+        await vscode.commands.executeCommand(
+          'workbench.action.openSettingsJson'
+        );
+        break;
+      case 'workspaceSettings':
+      case 'user':
+        await vscode.commands.executeCommand(
+          'workbench.action.openWorkspaceSettingsFile'
+        );
+        break;
+      default:
+        throw new Error('Unknown preset connection source');
     }
   }
 

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -189,7 +189,7 @@ export default class ConnectionController {
         source = 'workspaceSettings';
         await mdbConfiguration.update('presetConnections', [
           {
-            name: 'Preset Database',
+            name: 'Preset Connection',
             connectionString: 'mongodb://localhost:27017',
           },
         ]);

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -162,6 +162,8 @@ export default class ConnectionController {
   }
 
   async loadSavedConnections(): Promise<void> {
+    this._connections = Object.create(null);
+
     const loadedConnections = await this._connectionStorage.loadConnections();
 
     for (const connection of loadedConnections) {

--- a/src/explorer/connectionTreeItem.ts
+++ b/src/explorer/connectionTreeItem.ts
@@ -209,7 +209,9 @@ export default class ConnectionTreeItem
     return Object.values(this._childrenCache);
   }
 
-  private async _buildChildrenCacheForDatabases(dataService: DataService) {
+  private async _buildChildrenCacheForDatabases(
+    dataService: DataService
+  ): Promise<Record<string, DatabaseTreeItem>> {
     const databases = await this.listDatabases();
     databases.sort((a: string, b: string) => a.localeCompare(b));
 
@@ -231,7 +233,9 @@ export default class ConnectionTreeItem
     return newChildrenCache;
   }
 
-  private async _buildChildrenCacheForStreams(dataService: DataService) {
+  private async _buildChildrenCacheForStreams(
+    dataService: DataService
+  ): Promise<Record<string, StreamProcessorTreeItem>> {
     const processors = await this.listStreamProcessors();
     processors.sort((a, b) => a.name.localeCompare(b.name));
 

--- a/src/explorer/connectionTreeItem.ts
+++ b/src/explorer/connectionTreeItem.ts
@@ -11,10 +11,11 @@ import formatError from '../utils/formatError';
 import { getImagesPath } from '../extensionConstants';
 import type TreeItemParent from './treeItemParentInterface';
 import StreamProcessorTreeItem from './streamProcessorTreeItem';
+import type { ConnectionSource } from '../storage/connectionStorage';
 
 export type ConnectionItemContextValue = `${'disconnected' | 'connected'}${
   | ''
-  | 'Immutable'}ConnectionTreeItem`;
+  | 'Preset'}ConnectionTreeItem`;
 
 function getIconPath(isActiveConnection: boolean): {
   light: string;
@@ -49,7 +50,7 @@ export default class ConnectionTreeItem
   connectionId: string;
 
   isExpanded: boolean;
-  isMutable: boolean;
+  source: ConnectionSource;
 
   constructor({
     connectionId,
@@ -58,7 +59,7 @@ export default class ConnectionTreeItem
     connectionController,
     cacheIsUpToDate,
     childrenCache,
-    isMutable,
+    source,
   }: {
     connectionId: string;
     collapsibleState: vscode.TreeItemCollapsibleState;
@@ -68,7 +69,7 @@ export default class ConnectionTreeItem
     childrenCache: {
       [key: string]: DatabaseTreeItem | StreamProcessorTreeItem;
     }; // Existing cache.
-    isMutable: boolean;
+    source: ConnectionSource;
   }) {
     super(
       connectionController.getSavedConnectionName(connectionId),
@@ -81,11 +82,11 @@ export default class ConnectionTreeItem
       !connectionController.isConnecting();
 
     this.contextValue = `${isConnected ? 'connected' : 'disconnected'}${
-      isMutable ? '' : 'Immutable'
+      source === 'user' ? '' : 'Preset'
     }ConnectionTreeItem`;
 
     this.connectionId = connectionId;
-    this.isMutable = isMutable;
+    this.source = source;
     this._connectionController = connectionController;
     this.isExpanded = isExpanded;
     this._childrenCache = childrenCache;

--- a/src/explorer/connectionTreeItem.ts
+++ b/src/explorer/connectionTreeItem.ts
@@ -12,10 +12,9 @@ import { getImagesPath } from '../extensionConstants';
 import type TreeItemParent from './treeItemParentInterface';
 import StreamProcessorTreeItem from './streamProcessorTreeItem';
 
-export enum ConnectionItemContextValues {
-  disconnected = 'disconnectedConnectionTreeItem',
-  connected = 'connectedConnectionTreeItem',
-}
+export type ConnectionItemContextValue = `${'disconnected' | 'connected'}${
+  | ''
+  | 'Immutable'}ConnectionTreeItem`;
 
 function getIconPath(isActiveConnection: boolean): {
   light: string;
@@ -39,7 +38,7 @@ export default class ConnectionTreeItem
   extends vscode.TreeItem
   implements TreeItemParent, vscode.TreeDataProvider<ConnectionTreeItem>
 {
-  contextValue = ConnectionItemContextValues.disconnected;
+  contextValue: ConnectionItemContextValue = 'disconnectedConnectionTreeItem';
 
   private _childrenCache: {
     [key: string]: DatabaseTreeItem | StreamProcessorTreeItem;
@@ -50,6 +49,7 @@ export default class ConnectionTreeItem
   connectionId: string;
 
   isExpanded: boolean;
+  isMutable: boolean;
 
   constructor({
     connectionId,
@@ -58,6 +58,7 @@ export default class ConnectionTreeItem
     connectionController,
     cacheIsUpToDate,
     childrenCache,
+    isMutable,
   }: {
     connectionId: string;
     collapsibleState: vscode.TreeItemCollapsibleState;
@@ -67,21 +68,24 @@ export default class ConnectionTreeItem
     childrenCache: {
       [key: string]: DatabaseTreeItem | StreamProcessorTreeItem;
     }; // Existing cache.
+    isMutable: boolean;
   }) {
     super(
       connectionController.getSavedConnectionName(connectionId),
       collapsibleState
     );
 
-    if (
+    const isConnected =
       connectionController.getActiveConnectionId() === connectionId &&
       !connectionController.isDisconnecting() &&
-      !connectionController.isConnecting()
-    ) {
-      this.contextValue = ConnectionItemContextValues.connected;
-    }
+      !connectionController.isConnecting();
+
+    this.contextValue = `${isConnected ? 'connected' : 'disconnected'}${
+      isMutable ? '' : 'Immutable'
+    }ConnectionTreeItem`;
 
     this.connectionId = connectionId;
+    this.isMutable = isMutable;
     this._connectionController = connectionController;
     this.isExpanded = isExpanded;
     this._childrenCache = childrenCache;

--- a/src/explorer/explorerTreeController.ts
+++ b/src/explorer/explorerTreeController.ts
@@ -187,7 +187,7 @@ export default class ExplorerTreeController
           connectionId: connection.id,
           collapsibleState,
           isExpanded,
-          isMutable: connection.isMutable ?? true,
+          source: connection.source ?? 'user',
           connectionController: this._connectionController,
           cacheIsUpToDate: pastConnectionTreeItems[connection.id]
             ? pastConnectionTreeItems[connection.id].cacheIsUpToDate

--- a/src/explorer/explorerTreeController.ts
+++ b/src/explorer/explorerTreeController.ts
@@ -131,11 +131,15 @@ export default class ExplorerTreeController
     return element;
   }
 
-  private _getConnectionExpandedState(connection: LoadedConnection): {
+  private _getConnectionExpandedState(
+    connection: LoadedConnection,
+    pastConnectionTreeItems: {
+      [key: string]: ConnectionTreeItem;
+    }
+  ): {
     collapsibleState: vscode.TreeItemCollapsibleState;
     isExpanded: boolean;
   } {
-    const pastConnectionTreeItems = this._connectionTreeItems;
     const isActiveConnection =
       connection.id === this._connectionController.getActiveConnectionId();
     const isBeingConnectedTo =
@@ -181,7 +185,7 @@ export default class ExplorerTreeController
       // Create new connection tree items, using cached children wherever possible.
       connections.forEach((connection) => {
         const { collapsibleState, isExpanded } =
-          this._getConnectionExpandedState(connection);
+          this._getConnectionExpandedState(connection, pastConnectionTreeItems);
 
         this._connectionTreeItems[connection.id] = new ConnectionTreeItem({
           connectionId: connection.id,

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -481,6 +481,16 @@ export default class MDBExtensionController implements vscode.Disposable {
       }
     );
     this.registerCommand(
+      EXTENSION_COMMANDS.MDB_OPEN_WORKSPACE_SETTINGS_FILE,
+      async () => {
+        await vscode.commands.executeCommand(
+          'workbench.action.openWorkspaceSettingsFile'
+        );
+
+        return true;
+      }
+    );
+    this.registerCommand(
       EXTENSION_COMMANDS.MDB_COPY_CONNECTION_STRING,
       async (element: ConnectionTreeItem): Promise<boolean> => {
         const connectionString =

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -492,16 +492,8 @@ export default class MDBExtensionController implements vscode.Disposable {
     );
     this.registerCommand(
       EXTENSION_COMMANDS.MDB_EDIT_PRESET_CONNECTIONS,
-      async (element: ConnectionTreeItem) => {
-        if (element.source === 'workspaceSettings') {
-          await vscode.commands.executeCommand(
-            'workbench.action.openWorkspaceSettingsFile'
-          );
-        } else if (element.source === 'globalSettings') {
-          await vscode.commands.executeCommand(
-            'workbench.action.openSettingsJson'
-          );
-        }
+      async (element: ConnectionTreeItem | undefined) => {
+        await this._connectionController.openPresetConnectionsSettings(element);
         return true;
       }
     );

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -162,7 +162,7 @@ export default class MDBExtensionController implements vscode.Disposable {
 
   subscribeToConfigurationChanges(): void {
     const subscription = vscode.workspace.onDidChangeConfiguration((event) => {
-      if (event.affectsConfiguration('mdb.presetSavedConnections')) {
+      if (event.affectsConfiguration('mdb.presetConnections')) {
         void this._connectionController.loadSavedConnections();
       }
     });

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -160,6 +160,15 @@ export default class MDBExtensionController implements vscode.Disposable {
     this._editorsController.registerProviders();
   }
 
+  subscribeToConfigurationChanges(): void {
+    const subscription = vscode.workspace.onDidChangeConfiguration((event) => {
+      if (event.affectsConfiguration('mdb.presetSavedConnections')) {
+        void this._connectionController.loadSavedConnections();
+      }
+    });
+    this._context.subscriptions.push(subscription);
+  }
+
   async activate(): Promise<void> {
     this._explorerController.activateConnectionsTreeView();
     this._helpExplorer.activateHelpTreeView(this._telemetryService);
@@ -172,6 +181,7 @@ export default class MDBExtensionController implements vscode.Disposable {
 
     this.registerCommands();
     this.showOverviewPageIfRecentlyInstalled();
+    this.subscribeToConfigurationChanges();
 
     const copilot = vscode.extensions.getExtension(COPILOT_EXTENSION_ID);
     void vscode.commands.executeCommand(

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -491,12 +491,17 @@ export default class MDBExtensionController implements vscode.Disposable {
       }
     );
     this.registerCommand(
-      EXTENSION_COMMANDS.MDB_OPEN_WORKSPACE_SETTINGS_FILE,
-      async () => {
-        await vscode.commands.executeCommand(
-          'workbench.action.openWorkspaceSettingsFile'
-        );
-
+      EXTENSION_COMMANDS.MDB_EDIT_PRESET_CONNECTIONS,
+      async (element: ConnectionTreeItem) => {
+        if (element.source === 'workspaceSettings') {
+          await vscode.commands.executeCommand(
+            'workbench.action.openWorkspaceSettingsFile'
+          );
+        } else if (element.source === 'globalSettings') {
+          await vscode.commands.executeCommand(
+            'workbench.action.openSettingsJson'
+          );
+        }
         return true;
       }
     );

--- a/src/storage/connectionStorage.ts
+++ b/src/storage/connectionStorage.ts
@@ -191,13 +191,13 @@ export class ConnectionStorage {
     }
 
     const combinedPresetSavedConnections: PresetSavedConnectionWithSource[] = [
-      ...(presetSavedConnectionsInfo?.workspaceValue ?? []).map((preset) => ({
-        ...preset,
-        source: 'workspaceSettings' as const,
-      })),
       ...(presetSavedConnectionsInfo?.globalValue ?? []).map((preset) => ({
         ...preset,
         source: 'globalSettings' as const,
+      })),
+      ...(presetSavedConnectionsInfo?.workspaceValue ?? []).map((preset) => ({
+        ...preset,
+        source: 'workspaceSettings' as const,
       })),
     ];
 
@@ -252,7 +252,7 @@ export class ConnectionStorage {
 
     const presetSavedConnections = this._loadPresetSavedConnections();
 
-    return [...presetSavedConnections, ...loadedConnections];
+    return [...loadedConnections, ...presetSavedConnections];
   }
 
   async removeConnection(connectionId: string): Promise<void> {

--- a/src/storage/connectionStorage.ts
+++ b/src/storage/connectionStorage.ts
@@ -185,7 +185,7 @@ export class ConnectionStorage {
 
     return presetSavedConnections.map((presetConnection) => ({
       id: uuidv4(),
-      name: `${presetConnection.name} (From Configuration)`,
+      name: presetConnection.name,
       connectionOptions: {
         connectionString: presetConnection.connectionString,
       },

--- a/src/storage/connectionStorage.ts
+++ b/src/storage/connectionStorage.ts
@@ -200,16 +200,19 @@ export class ConnectionStorage {
       })),
     ];
 
-    return combinedPresetConnections.map((presetConnection) => ({
-      id: uuidv4(),
-      name: presetConnection.name,
-      connectionOptions: {
-        connectionString: presetConnection.connectionString,
-      },
-      source: presetConnection.source,
-      storageLocation: StorageLocation.NONE,
-      secretStorageLocation: SecretStorageLocation.SecretStorage,
-    }));
+    return combinedPresetConnections.map(
+      (presetConnection) =>
+        ({
+          id: uuidv4(),
+          name: presetConnection.name,
+          connectionOptions: {
+            connectionString: presetConnection.connectionString,
+          },
+          source: presetConnection.source,
+          storageLocation: StorageLocation.NONE,
+          secretStorageLocation: SecretStorageLocation.SecretStorage,
+        } satisfies LoadedConnection)
+    );
   }
 
   async loadConnections(): Promise<LoadedConnection[]> {

--- a/src/storage/connectionStorage.ts
+++ b/src/storage/connectionStorage.ts
@@ -180,28 +180,27 @@ export class ConnectionStorage {
     );
   }
 
-  _loadPresetSavedConnections(): LoadedConnection[] {
+  _loadPresetConnections(): LoadedConnection[] {
     const configuration = vscode.workspace.getConfiguration('mdb');
-    const presetSavedConnectionsInfo = configuration.inspect<
-      PresetSavedConnection[]
-    >('presetSavedConnections');
+    const presetConnectionsInfo =
+      configuration.inspect<PresetSavedConnection[]>('presetConnections');
 
-    if (!presetSavedConnectionsInfo) {
+    if (!presetConnectionsInfo) {
       return [];
     }
 
-    const combinedPresetSavedConnections: PresetSavedConnectionWithSource[] = [
-      ...(presetSavedConnectionsInfo?.globalValue ?? []).map((preset) => ({
+    const combinedPresetConnections: PresetSavedConnectionWithSource[] = [
+      ...(presetConnectionsInfo?.globalValue ?? []).map((preset) => ({
         ...preset,
         source: 'globalSettings' as const,
       })),
-      ...(presetSavedConnectionsInfo?.workspaceValue ?? []).map((preset) => ({
+      ...(presetConnectionsInfo?.workspaceValue ?? []).map((preset) => ({
         ...preset,
         source: 'workspaceSettings' as const,
       })),
     ];
 
-    return combinedPresetSavedConnections.map((presetConnection) => ({
+    return combinedPresetConnections.map((presetConnection) => ({
       id: uuidv4(),
       name: presetConnection.name,
       connectionOptions: {
@@ -250,9 +249,9 @@ export class ConnectionStorage {
       })
     );
 
-    const presetSavedConnections = this._loadPresetSavedConnections();
+    const presetConnections = this._loadPresetConnections();
 
-    return [...loadedConnections, ...presetSavedConnections];
+    return [...loadedConnections, ...presetConnections];
   }
 
   async removeConnection(connectionId: string): Promise<void> {

--- a/src/storage/connectionStorage.ts
+++ b/src/storage/connectionStorage.ts
@@ -23,8 +23,8 @@ export interface StoreConnectionInfo {
   id: string; // Connection model id or a new uuid.
   name: string; // Possibly user given name, not unique.
   storageLocation: StorageLocation;
-  secretStorageLocation: SecretStorageLocationType;
-  connectionOptions: ConnectionOptions;
+  secretStorageLocation?: SecretStorageLocationType;
+  connectionOptions?: ConnectionOptions;
   isMutable?: boolean;
   lastUsed?: Date; // Date and time when the connection was last used, i.e. connected with.
 }
@@ -34,7 +34,15 @@ export type PresetSavedConnection = {
   connectionString: string;
 };
 
-export type LoadedConnection = StoreConnectionInfo;
+type StoreConnectionInfoWithConnectionOptions = StoreConnectionInfo &
+  Required<Pick<StoreConnectionInfo, 'connectionOptions'>>;
+
+type StoreConnectionInfoWithSecretStorageLocation = StoreConnectionInfo &
+  Required<Pick<StoreConnectionInfo, 'secretStorageLocation'>>;
+
+export type LoadedConnection = StoreConnectionInfoWithConnectionOptions &
+  StoreConnectionInfoWithSecretStorageLocation;
+
 export class ConnectionStorage {
   _storageController: StorageController;
 
@@ -84,7 +92,7 @@ export class ConnectionStorage {
         (await this._storageController.getSecret(connectionInfo.id)) ?? '';
 
       return this._mergedConnectionInfoWithSecrets(
-        connectionInfo,
+        connectionInfo as LoadedConnection,
         unparsedSecrets
       );
     } catch (error) {

--- a/src/telemetry/telemetryService.ts
+++ b/src/telemetry/telemetryService.ts
@@ -91,6 +91,8 @@ type ConnectionEditedTelemetryEventProperties = {
 type SavedConnectionsLoadedProperties = {
   // Total number of connections saved on disk
   saved_connections: number;
+  // Total number of connections from preset settings
+  preset_connections: number;
   // Total number of connections that extension was able to load, it might
   // differ from saved_connections since there might be failures in loading
   // secrets for a connection in which case we don't list the connections in the
@@ -143,6 +145,11 @@ export type ParticipantPromptSubmittedFromActionProperties = {
 export type ParticipantChatOpenedFromActionProperties = {
   source: DocumentSource;
   command?: ParticipantCommandType;
+};
+
+export type PresetSavedConnectionEditedProperties = {
+  source: DocumentSource;
+  source_details: 'tree_item' | 'header';
 };
 
 export type ParticipantInputBoxSubmitted = {
@@ -216,6 +223,7 @@ export enum TelemetryEventTypes {
   /** Tracks after a participant interacts with the input box we open to let the user write the prompt for participant. */
   PARTICIPANT_INPUT_BOX_SUBMITTED = 'Participant Inbox Box Submitted',
   PARTICIPANT_RESPONSE_GENERATED = 'Participant Response Generated',
+  PRESET_CONNECTION_EDITED = 'Preset Connection Edited',
 }
 
 /**
@@ -444,6 +452,12 @@ export default class TelemetryService {
       TelemetryEventTypes.PLAYGROUND_EXPORTED_TO_LANGUAGE,
       playgroundExportedProps
     );
+  }
+
+  trackPresetConnectionEdited(
+    props: PresetSavedConnectionEditedProperties
+  ): void {
+    this.track(TelemetryEventTypes.PRESET_CONNECTION_EDITED, props);
   }
 
   trackPlaygroundCreated(playgroundType: string): void {

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -240,6 +240,31 @@ suite('Connection Controller Test Suite', function () {
     expect(testConnectionController.getSavedConnections().length).to.equal(0);
   });
 
+  test('clears connections when loading saved connections', async () => {
+    // This might happen if i.e. one defines a preset connection and then deletes it.
+    // In that case we'd have defined this connection but there was never a follow up
+    // delete event to clear it. So on reload we need to start from a clean slate.
+    testConnectionController._connections['1234'] = {
+      id: '1234',
+      name: 'orphan',
+      connectionOptions: {
+        connectionString: 'localhost:3000',
+      },
+      storageLocation: StorageLocation.NONE,
+      secretStorageLocation: SecretStorageLocation.SecretStorage,
+    };
+
+    // Should persist as this is a saved connection.
+    await testConnectionController.addNewConnectionStringAndConnect(
+      TEST_DATABASE_URI
+    );
+
+    await testConnectionController.loadSavedConnections();
+
+    expect(testConnectionController.getSavedConnections().length).to.equal(1);
+    expect(testConnectionController._connections['1234']).is.undefined;
+  });
+
   test('the connection model loads both global and workspace stored connection models', async () => {
     const expectedDriverUrl = `mongodb://localhost:27088/?appname=mongodb-vscode+${version}`;
 

--- a/src/test/suite/explorer/connectionTreeItem.test.ts
+++ b/src/test/suite/explorer/connectionTreeItem.test.ts
@@ -21,7 +21,7 @@ function getTestConnectionTreeItem(): ConnectionTreeItem {
       mdbTestExtension.testExtensionController._connectionController,
     cacheIsUpToDate: false,
     childrenCache: {},
-    isMutable: true,
+    source: 'user',
   });
 }
 

--- a/src/test/suite/explorer/connectionTreeItem.test.ts
+++ b/src/test/suite/explorer/connectionTreeItem.test.ts
@@ -4,9 +4,7 @@ import { beforeEach, afterEach } from 'mocha';
 import sinon from 'sinon';
 import type { DataService } from 'mongodb-data-service';
 
-import ConnectionTreeItem, {
-  ConnectionItemContextValues,
-} from '../../../explorer/connectionTreeItem';
+import ConnectionTreeItem from '../../../explorer/connectionTreeItem';
 import { DataServiceStub } from '../stubs';
 import formatError from '../../../utils/formatError';
 import { mdbTestExtension } from '../stubbableMdbExtension';
@@ -14,7 +12,7 @@ import { mdbTestExtension } from '../stubbableMdbExtension';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { contributes } = require('../../../../package.json');
 
-function getTestConnectionTreeItem() {
+function getTestConnectionTreeItem(): ConnectionTreeItem {
   return new ConnectionTreeItem({
     connectionId: 'test',
     collapsibleState: vscode.TreeItemCollapsibleState.Expanded,
@@ -23,6 +21,7 @@ function getTestConnectionTreeItem() {
       mdbTestExtension.testExtensionController._connectionController,
     cacheIsUpToDate: false,
     childrenCache: {},
+    isMutable: true,
   });
 }
 
@@ -32,10 +31,10 @@ suite('ConnectionTreeItem Test Suite', () => {
     let disconnectedRegisteredCommandInPackageJson = false;
 
     contributes.menus['view/item/context'].forEach((contextItem) => {
-      if (contextItem.when.includes(ConnectionItemContextValues.connected)) {
+      if (contextItem.when.includes('connected')) {
         connectedRegisteredCommandInPackageJson = true;
       }
-      if (contextItem.when.includes(ConnectionItemContextValues.disconnected)) {
+      if (contextItem.when.includes('disconnected')) {
         disconnectedRegisteredCommandInPackageJson = true;
       }
     });

--- a/src/test/suite/mdbExtensionController.test.ts
+++ b/src/test/suite/mdbExtensionController.test.ts
@@ -42,7 +42,7 @@ function getTestConnectionTreeItem(
       mdbTestExtension.testExtensionController._connectionController,
     cacheIsUpToDate: false,
     childrenCache: {},
-    isMutable: true,
+    source: 'user',
     ...options,
   });
 }

--- a/src/test/suite/mdbExtensionController.test.ts
+++ b/src/test/suite/mdbExtensionController.test.ts
@@ -42,6 +42,7 @@ function getTestConnectionTreeItem(
       mdbTestExtension.testExtensionController._connectionController,
     cacheIsUpToDate: false,
     childrenCache: {},
+    isMutable: true,
     ...options,
   });
 }

--- a/src/test/suite/storage/connectionStorage.test.ts
+++ b/src/test/suite/storage/connectionStorage.test.ts
@@ -368,9 +368,7 @@ suite('Connection Storage Test Suite', function () {
         for (let i = 0; i < connections.length; i++) {
           const connection = connections[i];
           const presetConnection = presetConnections[i];
-          expect(connection.name).equals(
-            `${presetConnection.name} (From Configuration)`
-          );
+          expect(connection.name).equals(presetConnection.name);
           expect(connection.connectionOptions.connectionString).equals(
             presetConnection.connectionString
           );
@@ -401,9 +399,7 @@ suite('Connection Storage Test Suite', function () {
         for (let i = 0; i < presetConnections.length; i++) {
           const connection = loadedConnections[i];
           const presetConnection = presetConnections[i];
-          expect(connection.name).equals(
-            `${presetConnection.name} (From Configuration)`
-          );
+          expect(connection.name).equals(presetConnection.name);
           expect(connection.connectionOptions.connectionString).equals(
             presetConnection.connectionString
           );

--- a/src/test/suite/storage/connectionStorage.test.ts
+++ b/src/test/suite/storage/connectionStorage.test.ts
@@ -327,17 +327,18 @@ suite('Connection Storage Test Suite', function () {
         globalValue: [
           {
             name: 'Global Connection 1',
-            connectionString: 'mongodb://localhost:27017/',
+            connectionString:
+              'mongodb://localhost:27017/?readPreference=primary&ssl=false',
           },
         ],
         workspaceValue: [
           {
             name: 'Preset Connection 1',
-            connectionString: 'mongodb://localhost:27017/',
+            connectionString: 'mongodb://localhost:27017',
           },
           {
             name: 'Preset Connection 2',
-            connectionString: 'mongodb://localhost:27018/',
+            connectionString: 'mongodb://localhost:27018',
           },
         ],
       };
@@ -421,8 +422,7 @@ suite('Connection Storage Test Suite', function () {
           {
             name: savedConnection.name,
             source: 'user',
-            connectionString:
-              savedConnection.connectionOptions.connectionString,
+            connectionString: `${savedConnection.connectionOptions.connectionString}/`,
           },
           ...presetConnections.globalValue.map((connection) => ({
             ...connection,

--- a/src/test/suite/storage/connectionStorage.test.ts
+++ b/src/test/suite/storage/connectionStorage.test.ts
@@ -349,11 +349,11 @@ suite('Connection Storage Test Suite', function () {
         ],
         vscode.WorkspaceConfiguration
       >;
-      let inspectPresetSavedConnectionsStub: sinon.SinonStub;
+      let inspectPresetConnectionsStub: sinon.SinonStub;
 
       beforeEach(() => {
         testSandbox.restore();
-        inspectPresetSavedConnectionsStub = testSandbox.stub();
+        inspectPresetConnectionsStub = testSandbox.stub();
       });
 
       test('loads the preset connections', async () => {
@@ -362,12 +362,12 @@ suite('Connection Storage Test Suite', function () {
           'getConfiguration'
         );
         getConfigurationStub.returns({
-          inspect: inspectPresetSavedConnectionsStub,
+          inspect: inspectPresetConnectionsStub,
           get: () => undefined,
         } as any);
 
-        inspectPresetSavedConnectionsStub
-          .withArgs('presetSavedConnections')
+        inspectPresetConnectionsStub
+          .withArgs('presetConnections')
           .returns(presetConnections);
 
         const loadedConnections = await testConnectionStorage.loadConnections();
@@ -391,7 +391,7 @@ suite('Connection Storage Test Suite', function () {
           const connection = loadedConnections[i];
           const expected = expectedConnectionValues[i];
           expect(connection.name).equals(expected.name);
-          expect(connection.connectionOptions.connectionString).contains(
+          expect(connection.connectionOptions.connectionString).equals(
             expected.connectionString
           );
           expect(connection.source).equals(expected.source);
@@ -407,12 +407,12 @@ suite('Connection Storage Test Suite', function () {
           'getConfiguration'
         );
         getConfigurationStub.returns({
-          inspect: inspectPresetSavedConnectionsStub,
+          inspect: inspectPresetConnectionsStub,
           get: () => undefined,
         } as any);
 
-        inspectPresetSavedConnectionsStub
-          .withArgs('presetSavedConnections')
+        inspectPresetConnectionsStub
+          .withArgs('presetConnections')
           .returns(presetConnections);
 
         const loadedConnections = await testConnectionStorage.loadConnections();
@@ -442,7 +442,7 @@ suite('Connection Storage Test Suite', function () {
           const connection = loadedConnections[i];
           const expected = expectedConnectionValues[i];
           expect(connection.name).equals(expected.name);
-          expect(connection.connectionOptions.connectionString).contains(
+          expect(connection.connectionOptions.connectionString).equals(
             expected.connectionString
           );
           expect(connection.source).equals(expected.source);

--- a/src/test/suite/storage/connectionStorage.test.ts
+++ b/src/test/suite/storage/connectionStorage.test.ts
@@ -323,16 +323,18 @@ suite('Connection Storage Test Suite', function () {
     });
 
     suite('when there are preset connections', () => {
-      const presetConnections = [
-        {
-          name: 'Preset Connection 1',
-          connectionString: 'mongodb://localhost:27017/',
-        },
-        {
-          name: 'Preset Connection 2',
-          connectionString: 'mongodb://localhost:27018/',
-        },
-      ];
+      const presetConnections = {
+        workspaceValue: [
+          {
+            name: 'Preset Connection 1',
+            connectionString: 'mongodb://localhost:27017/',
+          },
+          {
+            name: 'Preset Connection 2',
+            connectionString: 'mongodb://localhost:27018/',
+          },
+        ],
+      };
 
       let getConfigurationStub: sinon.SinonStub<
         [
@@ -354,7 +356,7 @@ suite('Connection Storage Test Suite', function () {
           'getConfiguration'
         );
         getConfigurationStub.returns({
-          get: getPresetSavedConnectionsStub,
+          inspect: getPresetSavedConnectionsStub,
         } as any);
 
         getPresetSavedConnectionsStub
@@ -372,7 +374,7 @@ suite('Connection Storage Test Suite', function () {
           expect(connection.connectionOptions.connectionString).equals(
             presetConnection.connectionString
           );
-          expect(connection.isMutable).equals(false);
+          expect(connection.source).equals('workspaceSettings');
         }
       });
 
@@ -396,14 +398,14 @@ suite('Connection Storage Test Suite', function () {
 
         expect(loadedConnections.length).equals(3);
 
-        for (let i = 0; i < presetConnections.length; i++) {
+        for (let i = 0; i < presetConnections.workspaceValue.length; i++) {
           const connection = loadedConnections[i];
           const presetConnection = presetConnections[i];
           expect(connection.name).equals(presetConnection.name);
           expect(connection.connectionOptions.connectionString).equals(
             presetConnection.connectionString
           );
-          expect(connection.isMutable).equals(false);
+          expect(connection.source).equals('workspaceSettings');
         }
 
         const savedLoadedConnection = loadedConnections[2];
@@ -412,7 +414,7 @@ suite('Connection Storage Test Suite', function () {
         expect(
           savedLoadedConnection.connectionOptions.connectionString
         ).contains(savedConnection.connectionOptions.connectionString);
-        expect(savedLoadedConnection.isMutable).equals(true);
+        expect(savedLoadedConnection.source).equals('workspaceSettings');
       });
     });
 

--- a/src/test/suite/telemetry/telemetryService.test.ts
+++ b/src/test/suite/telemetry/telemetryService.test.ts
@@ -672,6 +672,7 @@ suite('Telemetry Controller Test Suite', () => {
     testTelemetryService.trackSavedConnectionsLoaded({
       saved_connections: 3,
       loaded_connections: 3,
+      preset_connections: 3,
       connections_with_secrets_in_keytar: 0,
       connections_with_secrets_in_secret_storage: 3,
     });
@@ -684,6 +685,7 @@ suite('Telemetry Controller Test Suite', () => {
         properties: {
           saved_connections: 3,
           loaded_connections: 3,
+          preset_connections: 3,
           connections_with_secrets_in_keytar: 0,
           connections_with_secrets_in_secret_storage: 3,
         },


### PR DESCRIPTION
Add option to specify `mdb.presetSavedConfigurations` inside `settings.json` (likely for a workspace) which will load a preset list of connections based on that.

The added connections cannot be edited directly and must instead be edited through `settings.json`.

<img width="428" alt="Screenshot 2025-01-13 at 8 44 44 AM" src="https://github.com/user-attachments/assets/303c2d94-8a13-47a9-9d32-abfbfea4e553" />


## Motivation and Context
Addresses https://github.com/mongodb-js/vscode/issues/368.

### To Do
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

