### PR TITLE
fix: playground error when returning a function declaration VSCODE-669

### DIFF
--- a/src/language/worker.ts
+++ b/src/language/worker.ts
@@ -2,7 +2,6 @@ import { NodeDriverServiceProvider } from '@mongosh/service-provider-node-driver
 import { ElectronRuntime } from '@mongosh/browser-runtime-electron';
 import { parentPort } from 'worker_threads';
 import { ServerCommands } from './serverCommands';
-import type { Document } from 'bson';
 
 import type {
   ShellEvaluateResult,
@@ -17,7 +16,7 @@ interface EvaluationResult {
   type: string | null;
 }
 
-const getContent = ({ type, printable }: EvaluationResult): Document => {
+const getContent = ({ type, printable }: EvaluationResult): any => {
   if (type === 'Cursor' || type === 'AggregationCursor') {
     return getEJSON(printable.documents);
   }
@@ -27,11 +26,7 @@ const getContent = ({ type, printable }: EvaluationResult): Document => {
     : getEJSON(printable);
 };
 
-export const getLanguage = (
-  evaluationResult: EvaluationResult
-): 'json' | 'plaintext' => {
-  const content = getContent(evaluationResult);
-
+export const getLanguage = (content: any): 'json' | 'plaintext' => {
   if (typeof content === 'object' && content !== null) {
     return 'json';
   }
@@ -105,12 +100,19 @@ export const execute = async ({
         ? `${source.namespace.db}.${source.namespace.collection}`
         : undefined;
 
+    // The RPC protocol can't handle functions and it wouldn't make sense to return them anyway. Since just
+    // declaring a function doesn't execute it, the best thing we can do is return undefined, similarly to
+    // what we do when there's no return value from the script.
+    const rpcSafePrintable =
+      typeof printable !== 'function' ? printable : undefined;
+
     // Prepare a playground result.
+    const content = getContent({ type, printable: rpcSafePrintable });
     const result = {
       namespace,
-      type: type ? type : typeof printable,
-      content: getContent({ type, printable }),
-      language: getLanguage({ type, printable }),
+      type: type ? type : typeof rpcSafePrintable,
+      content,
+      language: getLanguage(content),
     };
 
     return { data: { result } };

--- a/src/language/worker.ts
+++ b/src/language/worker.ts
@@ -16,7 +16,7 @@ interface EvaluationResult {
   type: string | null;
 }
 
-const getContent = ({ type, printable }: EvaluationResult): any => {
+const getContent = ({ type, printable }: EvaluationResult): unknown => {
   if (type === 'Cursor' || type === 'AggregationCursor') {
     return getEJSON(printable.documents);
   }
@@ -26,7 +26,7 @@ const getContent = ({ type, printable }: EvaluationResult): any => {
     : getEJSON(printable);
 };
 
-export const getLanguage = (content: any): 'json' | 'plaintext' => {
+export const getLanguage = (content: unknown): 'json' | 'plaintext' => {
   if (typeof content === 'object' && content !== null) {
     return 'json';
   }


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. VSCODE-1111: updates ace editor width in agg pipeline view -->
<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->
## Description

When the last statement in a playground is a function declaration, we would error out with a misleading error claiming the playground services crashed due to OOM. The reality was that we were trying to return a function via the language server protocol, which is not supported and was crashing the language server. This change replaces the printable when it is a function with `undefined`.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
