### PR TITLE
fix(deps): update `@mongodb-js/compass-components` to fix compilation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@babel/core": "^7.25.8",
         "@babel/parser": "^7.25.8",
         "@babel/traverse": "^7.25.7",
-        "@mongodb-js/compass-components": "^1.34.1",
+        "@mongodb-js/compass-components": "^1.34.2",
         "@mongodb-js/connection-form": "^1.47.1",
         "@mongodb-js/connection-info": "^0.11.0",
         "@mongodb-js/mongodb-constants": "^0.10.4",
@@ -4137,6 +4137,46 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },
+    "node_modules/@leafygreen-ui/split-button": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/split-button/-/split-button-4.1.5.tgz",
+      "integrity": "sha512-vlDo9UxkEVAxMzQfW4JVHKyb8vTQfVxA1UnlKKA0HAsRblOtjldSSyOf60jg9KPvtGf/C7uMv/pM0D2sJzpcOw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@leafygreen-ui/button": "^23.0.0",
+        "@leafygreen-ui/emotion": "^4.0.9",
+        "@leafygreen-ui/hooks": "^8.3.4",
+        "@leafygreen-ui/icon": "^13.1.2",
+        "@leafygreen-ui/lib": "^14.0.2",
+        "@leafygreen-ui/menu": "^28.0.6",
+        "@leafygreen-ui/palette": "^4.1.3",
+        "@leafygreen-ui/polymorphic": "^2.0.5",
+        "@leafygreen-ui/popover": "^13.0.3",
+        "@leafygreen-ui/tokens": "^2.11.3"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^4.0.2"
+      }
+    },
+    "node_modules/@leafygreen-ui/split-button/node_modules/@leafygreen-ui/button": {
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/button/-/button-23.0.0.tgz",
+      "integrity": "sha512-E2yuIM1oAqW/Fe9S/mwK+GqBDThr31P+Y27cd0oPD6ZTtyWruKY60M7dBafvqCY+Q3kPPCbBr80Uo8vjs7RXYw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@leafygreen-ui/emotion": "^4.0.9",
+        "@leafygreen-ui/lib": "^14.0.2",
+        "@leafygreen-ui/palette": "^4.1.3",
+        "@leafygreen-ui/polymorphic": "^2.0.5",
+        "@leafygreen-ui/ripple": "^1.1.15",
+        "@leafygreen-ui/tokens": "^2.11.3",
+        "@lg-tools/test-harnesses": "^0.1.4",
+        "polished": "^4.2.2"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^4.0.2"
+      }
+    },
     "node_modules/@leafygreen-ui/table": {
       "version": "13.0.5",
       "resolved": "https://registry.npmjs.org/@leafygreen-ui/table/-/table-13.0.5.tgz",
@@ -4421,9 +4461,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/@mongodb-js/compass-components": {
-      "version": "1.34.1",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-components/-/compass-components-1.34.1.tgz",
-      "integrity": "sha512-ewUtwNitrAumuynjo7ywOmL3+Du9hFJDJvkELzLypW75HhTxT/Q8ITHmlXYgYaBjz+CCWlCUTgp6UnRN3nCIgQ==",
+      "version": "1.34.2",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-components/-/compass-components-1.34.2.tgz",
+      "integrity": "sha512-og69nkMYCbBrtjdrA1JQHyUPOEXb8c6cZqsxyNBRmZyXYXasprkkNr0B391NEiZ12vtWtDfnRr4DdRyb/JXRYw==",
       "license": "SSPL",
       "dependencies": {
         "@dnd-kit/core": "^6.0.7",
@@ -4441,7 +4481,7 @@
         "@leafygreen-ui/guide-cue": "^7.0.2",
         "@leafygreen-ui/hooks": "^8.3.4",
         "@leafygreen-ui/icon": "^13.1.2",
-        "@leafygreen-ui/icon-button": "^16.0.2",
+        "@leafygreen-ui/icon-button": "16.0.2",
         "@leafygreen-ui/info-sprinkle": "^4.0.2",
         "@leafygreen-ui/leafygreen-provider": "^4.0.2",
         "@leafygreen-ui/logo": "^10.0.2",
@@ -4458,6 +4498,7 @@
         "@leafygreen-ui/search-input": "^5.0.2",
         "@leafygreen-ui/segmented-control": "^10.0.2",
         "@leafygreen-ui/select": "^14.0.2",
+        "@leafygreen-ui/split-button": "^4.1.5",
         "@leafygreen-ui/table": "^13.0.1",
         "@leafygreen-ui/tabs": "^14.0.2",
         "@leafygreen-ui/text-area": "^10.0.2",
@@ -4473,8 +4514,8 @@
         "@tanstack/table-core": "^8.14.0",
         "bson": "^6.10.1",
         "focus-trap-react": "^9.0.2",
-        "hadron-document": "^8.8.1",
-        "hadron-type-checker": "^7.4.1",
+        "hadron-document": "^8.8.2",
+        "hadron-type-checker": "^7.4.2",
         "is-electron-renderer": "^2.0.1",
         "lodash": "^4.17.21",
         "polished": "^4.2.2",
@@ -4483,6 +4524,25 @@
         "react-intersection-observer": "^8.34.0",
         "react-virtualized-auto-sizer": "^1.0.6",
         "react-window": "^1.8.6"
+      }
+    },
+    "node_modules/@mongodb-js/compass-components/node_modules/@leafygreen-ui/icon-button": {
+      "version": "16.0.2",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon-button/-/icon-button-16.0.2.tgz",
+      "integrity": "sha512-nCotpqN4VlGejm0ybzdZH4ExP8bdQZbLElBkTEsPSf4nNCvjC5LsbIqRuK/TGIHTa4tPnTHgnx7QZb5X36Q5Qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@leafygreen-ui/a11y": "^2.0.2",
+        "@leafygreen-ui/box": "^4.0.2",
+        "@leafygreen-ui/emotion": "^4.0.9",
+        "@leafygreen-ui/icon": "^13.1.2",
+        "@leafygreen-ui/lib": "^14.0.2",
+        "@leafygreen-ui/palette": "^4.1.3",
+        "@leafygreen-ui/tokens": "^2.11.3",
+        "polished": "^4.2.2"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^4.0.2"
       }
     },
     "node_modules/@mongodb-js/compass-editor": {
@@ -13339,14 +13399,14 @@
       }
     },
     "node_modules/hadron-document": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/hadron-document/-/hadron-document-8.8.1.tgz",
-      "integrity": "sha512-7zUKCD43izOetdo5t6g0JH6zUsVCsj9olHvFdLw1Kv6Hnyod4Ci4EVCSC19Wyv6U/GSEHk7wXjY9epb1cLXBrg==",
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/hadron-document/-/hadron-document-8.8.2.tgz",
+      "integrity": "sha512-GpNWbVb6H6WpcKWT+0YhnU0oCpBc5MEysghpSebGTTlOuNPvUTCE3XC6rGZ0md74dcPLeDPaIYKr+6wuSHww8Q==",
       "license": "SSPL",
       "dependencies": {
         "bson": "^6.10.1",
         "eventemitter3": "^4.0.0",
-        "hadron-type-checker": "^7.4.1",
+        "hadron-type-checker": "^7.4.2",
         "lodash": "^4.17.21"
       }
     },
@@ -13362,9 +13422,9 @@
       }
     },
     "node_modules/hadron-type-checker": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/hadron-type-checker/-/hadron-type-checker-7.4.1.tgz",
-      "integrity": "sha512-avGj4pTWGLcWNLxuNB08k/pJD+ZKyTIvYmL2CLHcbk3v8W6/zYSnJcyB901fQsjD0PZqFO7G5C+VlUdxRpTETA==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/hadron-type-checker/-/hadron-type-checker-7.4.2.tgz",
+      "integrity": "sha512-sR8LvoYw/fmrTobPPZ9WbpEBRD+zykc5TtGIEAqKk0raqC2mjguteKYyw01MROPxzW0Z1AhvwI0LO7pogH5rWg==",
       "license": "SSPL",
       "dependencies": {
         "bson": "^6.10.1",

--- a/package.json
+++ b/package.json
@@ -1314,7 +1314,7 @@
     "@babel/core": "^7.25.8",
     "@babel/parser": "^7.25.8",
     "@babel/traverse": "^7.25.7",
-    "@mongodb-js/compass-components": "^1.34.1",
+    "@mongodb-js/compass-components": "^1.34.2",
     "@mongodb-js/connection-form": "^1.47.1",
     "@mongodb-js/connection-info": "^0.11.0",
     "@mongodb-js/mongodb-constants": "^0.10.4",


### PR DESCRIPTION
There was a type error with the previous version of `@mongodb-js/compass-components` which broke our compilation step both locally and in CI.

We should investigate how this was not caught from the PR CI run opened by dependabot.