### PR TITLE
fix(tests): stub focus-trap to fix webview tests

### DIFF
--- a/.depcheckrc
+++ b/.depcheckrc
@@ -16,4 +16,5 @@ ignores:
  - ts-loader
  - mongodb-runner
  - tabbable # Mocha register testing workaround stub.
+ - focus-trap # Mocha register testing workaround stub.
  - ejson-shell-parser # Used by the connection-form.

--- a/src/test/setup-webview.ts
+++ b/src/test/setup-webview.ts
@@ -7,7 +7,7 @@ chai.use(sinonChai);
 import { JSDOM, VirtualConsole } from 'jsdom';
 
 /**
- * NB: tabbable requires special overrides to work in jsdom environments as per
+ * NB: focus-trap and tabbable require special overrides to work in jsdom environments as per
  * documentation
  *
  * @see {@link https://github.com/focus-trap/tabbable?tab=readme-ov-file#testing-in-jsdom}
@@ -26,6 +26,22 @@ Object.assign(tabbable, {
     origTabbable.isFocusable(node, { ...options, displayCheck: 'none' }),
   isTabbable: (node, options) =>
     origTabbable.isTabbable(node, { ...options, displayCheck: 'none' }),
+});
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const focusTrap = require('focus-trap');
+
+Object.assign(focusTrap, {
+  ...focusTrap,
+  createFocusTrap: () => {
+    const trap = {
+      activate: (): unknown => trap,
+      deactivate: (): unknown => trap,
+      pause: (): void => {},
+      unpause: (): void => {},
+    };
+    return trap;
+  },
 });
 
 const virtualConsole = new VirtualConsole();


### PR DESCRIPTION
Following from https://github.com/mongodb-js/vscode/pull/957 we discover that the new leafy green updated components use some parts of `focus-trap` which are not handled by our `tabbable` stub and error when used in our webview test environment so we stub it before importing any components to prevent this.

This is similar to what we do for tabbable.

See https://github.com/focus-trap/focus-trap-react/issues/24 and [official docs for testing with JSDom](https://github.com/focus-trap/focus-trap-react?tab=readme-ov-file#testing-in-jsdom)