### PR TITLE
fix(ci): let the fork workflow use the forked repository and be stricter

### DIFF
--- a/.github/workflows/test-and-build-from-fork.yaml
+++ b/.github/workflows/test-and-build-from-fork.yaml
@@ -24,6 +24,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
 
       - name: Setup Node.js Environment
         uses: actions/setup-node@v4


### PR DESCRIPTION
From https://github.com/mongodb-js/vscode/actions/runs/13435011260/job/37535233590?pr=959 we see that the intentionally failing tests aren't failing. We need to be explicit about the repository to check out in this case.