### PR TITLE
chore(telemetry): append user anonymousId & connectionId to appName passed to server COMPASS-8591

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@babel/parser": "^7.25.8",
         "@babel/traverse": "^7.25.7",
         "@mongodb-js/compass-components": "^1.34.5",
-        "@mongodb-js/connection-form": "1.47.2",
+        "@mongodb-js/connection-form": "1.47.6",
         "@mongodb-js/connection-info": "^0.11.6",
         "@mongodb-js/mongodb-constants": "^0.11.0",
         "@mongosh/browser-runtime-electron": "^3.8.0",
@@ -4927,9 +4927,9 @@
       }
     },
     "node_modules/@codemirror/language": {
-      "version": "6.10.8",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.10.8.tgz",
-      "integrity": "sha512-wcP8XPPhDH2vTqf181U8MbZnW+tDyPYy0UzVOa+oHORjyT+mhhom9vBd7dApJwoDz9Nb/a8kHjJIsuA/t8vNFw==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.0.tgz",
+      "integrity": "sha512-A7+f++LodNNc1wGgoRDTt78cOwWm9KVezApgjOMp1W4hM0898nsqBXwF+sbePE7ZRcjN7Sa1Z5m2oN27XkmEjQ==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
@@ -7242,9 +7242,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/@mongodb-js/compass-components": {
-      "version": "1.34.5",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-components/-/compass-components-1.34.5.tgz",
-      "integrity": "sha512-Z3UZCE3/gPyFjw6wV1giDnTtzVYAyjARixIKdDVCfLMxbHrHyW39yE+mepxOKBj5DVHZp0ppNKOo6bSQ1wmJtQ==",
+      "version": "1.34.6",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-components/-/compass-components-1.34.6.tgz",
+      "integrity": "sha512-O8kIso7ZDziQd++dE9BpF0nGlzWqVxWAmLRt3Al4tPOCYQ5BZdXm5xL0tdBTELZTcMbh/gX2uKdCbeDvjpk+BA==",
       "license": "SSPL",
       "dependencies": {
         "@dnd-kit/core": "^6.0.7",
@@ -7295,8 +7295,8 @@
         "@tanstack/table-core": "^8.14.0",
         "bson": "^6.10.3",
         "focus-trap-react": "^9.0.2",
-        "hadron-document": "^8.8.5",
-        "hadron-type-checker": "^7.4.5",
+        "hadron-document": "^8.8.6",
+        "hadron-type-checker": "^7.4.6",
         "is-electron-renderer": "^2.0.1",
         "lodash": "^4.17.21",
         "polished": "^4.2.2",
@@ -7327,9 +7327,9 @@
       }
     },
     "node_modules/@mongodb-js/compass-editor": {
-      "version": "0.36.5",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-editor/-/compass-editor-0.36.5.tgz",
-      "integrity": "sha512-9JxwWR1wTfRFfLM90j/KnNlQYxjmSpQq4nUm2pU+W/2B7UWu+ILifCrYs8+9WlHiZSgDnD1qMwo82nOyKrpWag==",
+      "version": "0.36.6",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-editor/-/compass-editor-0.36.6.tgz",
+      "integrity": "sha512-66dYJig0kI4pFJ6vsvVulL7RbIpa8KG3H8HsEKfvu6GdPFdL3iSUH4rt0lytAiFfA/yHBv+N84//RnJIF3qFqg==",
       "license": "SSPL",
       "dependencies": {
         "@codemirror/autocomplete": "^6.17.0",
@@ -7341,7 +7341,7 @@
         "@codemirror/state": "^6.1.4",
         "@codemirror/view": "^6.7.1",
         "@lezer/highlight": "^1.2.0",
-        "@mongodb-js/compass-components": "^1.34.5",
+        "@mongodb-js/compass-components": "^1.34.6",
         "@mongodb-js/mongodb-constants": "^0.10.0",
         "mongodb-query-parser": "^4.3.0",
         "polished": "^4.2.2",
@@ -7383,20 +7383,20 @@
       }
     },
     "node_modules/@mongodb-js/connection-form": {
-      "version": "1.47.2",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/connection-form/-/connection-form-1.47.2.tgz",
-      "integrity": "sha512-bZ3JspVa1OixLiRaDTDM4EW6PYRzoFpJO71oSv1lAy4fI/Imf9I6pUwF32vAWggw6CahLuOoq5q4WzK3WZsXXA==",
+      "version": "1.47.6",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/connection-form/-/connection-form-1.47.6.tgz",
+      "integrity": "sha512-v/RGFUXe+eIceJcUYggDqcSN9nxfc3bNjmn4+lO2DbF/2Yq1OaAJ6NknAbhriOX+ZrKcNUHLj/rtSS8E3BZfTQ==",
       "license": "SSPL",
       "dependencies": {
-        "@mongodb-js/compass-components": "^1.34.2",
-        "@mongodb-js/compass-editor": "^0.36.2",
-        "@mongodb-js/connection-info": "^0.11.2",
+        "@mongodb-js/compass-components": "^1.34.6",
+        "@mongodb-js/compass-editor": "^0.36.6",
+        "@mongodb-js/connection-info": "^0.11.6",
         "@mongodb-js/shell-bson-parser": "^1.2.0",
         "lodash": "^4.17.21",
-        "mongodb": "^6.12.0",
+        "mongodb": "^6.14.1",
         "mongodb-build-info": "^1.7.2",
         "mongodb-connection-string-url": "^3.0.1",
-        "mongodb-data-service": "^22.25.2",
+        "mongodb-data-service": "^22.25.6",
         "mongodb-query-parser": "^4.3.0",
         "react": "^17.0.2"
       }
@@ -16315,14 +16315,14 @@
       }
     },
     "node_modules/hadron-document": {
-      "version": "8.8.5",
-      "resolved": "https://registry.npmjs.org/hadron-document/-/hadron-document-8.8.5.tgz",
-      "integrity": "sha512-husLczMn8gUmMx4hqnxu/YTpqyzpe8dyDk6I+Klj/BtD/2i3adE1xAr7w8h9cC5YscLEUVeoTmLAbL/JFthXAg==",
+      "version": "8.8.6",
+      "resolved": "https://registry.npmjs.org/hadron-document/-/hadron-document-8.8.6.tgz",
+      "integrity": "sha512-fl9SwmGVE6asC0RUBkQcKLjOQ8U+oIkaHekAyr84yx5erw6E/iqzKND3PPTvO60uN6K29DpzocI4SG3EVrHpwg==",
       "license": "SSPL",
       "dependencies": {
         "bson": "^6.10.3",
         "eventemitter3": "^4.0.0",
-        "hadron-type-checker": "^7.4.5",
+        "hadron-type-checker": "^7.4.6",
         "lodash": "^4.17.21"
       }
     },
@@ -16338,9 +16338,9 @@
       }
     },
     "node_modules/hadron-type-checker": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/hadron-type-checker/-/hadron-type-checker-7.4.5.tgz",
-      "integrity": "sha512-+pfVizp5Hpo/1Pjme8Vu/DhEhnHbsqxKAyvP0ro0I0XU9/tW9N1buwbKC/I3ht1xpzajk48wXrBh3OSOhCrQBw==",
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/hadron-type-checker/-/hadron-type-checker-7.4.6.tgz",
+      "integrity": "sha512-D3x3NuVNv/7f249sI5yNeCCoy5FgQEXTPgEGZyYnOx8DuUdZ6M89GXUn8jCNrjecepkvmn7n/hmoEjx9r27uow==",
       "license": "SSPL",
       "dependencies": {
         "bson": "^6.10.3",

--- a/package.json
+++ b/package.json
@@ -1315,7 +1315,7 @@
     "@babel/parser": "^7.25.8",
     "@babel/traverse": "^7.25.7",
     "@mongodb-js/compass-components": "^1.34.5",
-    "@mongodb-js/connection-form": "1.47.2",
+    "@mongodb-js/connection-form": "1.47.4",
     "@mongodb-js/connection-info": "^0.11.6",
     "@mongodb-js/mongodb-constants": "^0.11.0",
     "@mongosh/browser-runtime-electron": "^3.8.0",

--- a/package.json
+++ b/package.json
@@ -1315,7 +1315,7 @@
     "@babel/parser": "^7.25.8",
     "@babel/traverse": "^7.25.7",
     "@mongodb-js/compass-components": "^1.34.5",
-    "@mongodb-js/connection-form": "1.47.4",
+    "@mongodb-js/connection-form": "1.47.6",
     "@mongodb-js/connection-info": "^0.11.6",
     "@mongodb-js/mongodb-constants": "^0.11.0",
     "@mongosh/browser-runtime-electron": "^3.8.0",

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -361,7 +361,9 @@ export default class ConnectionController {
    * appName with the VSCode extension name and version. This checks for this and
    * removes the previously appended appName.
    */
-  private _clearLegacyAppNameOverride(connectionId: string): void {
+  private async _clearLegacyAppNameOverride(
+    connectionId: string
+  ): Promise<void> {
     const connectionString = new ConnectionString(
       this._connections[connectionId].connectionOptions.connectionString
     );
@@ -374,7 +376,7 @@ export default class ConnectionController {
       connectionString.searchParams.delete('appname');
       this._connections[connectionId].connectionOptions.connectionString =
         connectionString.toString();
-      void this._connectionStorage.saveConnection(
+      await this._connectionStorage.saveConnection(
         this._connections[connectionId]
       );
     }
@@ -420,8 +422,6 @@ export default class ConnectionController {
         connectionErrorMessage: 'connection attempt cancelled',
       };
     }
-
-    this._clearLegacyAppNameOverride(connectionId);
 
     const connectionInfo: LoadedConnection = merge(
       cloneDeep(this._connections[connectionId]),
@@ -648,6 +648,8 @@ export default class ConnectionController {
 
     try {
       await this._connect(connectionId, ConnectionTypes.CONNECTION_ID);
+
+      await this._clearLegacyAppNameOverride(connectionId);
 
       return {
         successfullyConnected: true,

--- a/src/storage/connectionStorage.ts
+++ b/src/storage/connectionStorage.ts
@@ -324,4 +324,8 @@ export class ConnectionStorage {
 
     return StorageLocation.NONE;
   }
+
+  getUserAnonymousId(): string {
+    return this._storageController.getUserIdentity().anonymousId;
+  }
 }

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -150,7 +150,11 @@ suite('Connection Controller Test Suite', function () {
       );
     });
 
-    test('getMongoClientConnectionOptions appends anonymous and connection ID and options properties', function () {
+    test('getMongoClientConnectionOptions appends anonymous and connection ID and options properties', async function () {
+      await testConnectionController.addNewConnectionStringAndConnect(
+        `${TEST_DATABASE_URI}`
+      );
+
       const mongoClientConnectionOptions =
         testConnectionController.getMongoClientConnectionOptions();
 
@@ -400,8 +404,6 @@ suite('Connection Controller Test Suite', function () {
   });
 
   test('the connection model loads both global and workspace stored connection models', async () => {
-    const expectedDriverUrl = `mongodb://localhost:27088/?appname=mongodb-vscode+${version}`;
-
     await vscode.workspace
       .getConfiguration('mdb.connectionSaving')
       .update('defaultConnectionSavingLocation', DefaultSavingLocations.Global);
@@ -436,7 +438,7 @@ suite('Connection Controller Test Suite', function () {
     expect(
       connections[Object.keys(connections)[2]].connectionOptions
         ?.connectionString
-    ).to.equal(expectedDriverUrl);
+    ).to.equal('mongodb://localhost:27088/');
   });
 
   test('when a connection is added it is saved to the global storage', async () => {
@@ -1084,9 +1086,6 @@ suite('Connection Controller Test Suite', function () {
     );
     expect(connections[0].connectionOptions?.connectionString).to.not.include(
       TEST_USER_PASSWORD
-    );
-    expect(connections[0].connectionOptions?.connectionString).to.include(
-      `appName=mongodb-vscode+${version}`
     );
     expect(
       testConnectionController._connections[connections[0].id].connectionOptions

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -131,6 +131,30 @@ suite('Connection Controller Test Suite', function () {
       );
     });
 
+    test('should override legacy appended appName', async () => {
+      const successfullyConnected =
+        await testConnectionController.addNewConnectionStringAndConnect(
+          `${TEST_DATABASE_URI}/?appname=mongodb-vscode+9.9.9`
+        );
+      const connectionId =
+        testConnectionController.getActiveConnectionId() || '';
+      const connection = testConnectionController._connections[connectionId];
+
+      expect(successfullyConnected).to.be.true;
+
+      const anonymousId =
+        testConnectionController._connectionStorage.getUserAnonymousId();
+
+      // The stored connection string should not have the appName appended
+      expect(connection.connectionOptions.connectionString).equals(
+        `${TEST_DATABASE_URI}/`
+      );
+      // But the active connection should
+      expect(testConnectionController.getActiveConnectionString()).equals(
+        `${TEST_DATABASE_URI}/?appName=mongodb-vscode+${version}-${anonymousId}-${connectionId}`
+      );
+    });
+
     test('preserves appName if it is already set', async () => {
       const successfullyConnected =
         await testConnectionController.addNewConnectionStringAndConnect(


### PR DESCRIPTION
See [COMPASS-8591](https://jira.mongodb.org/browse/COMPASS-8591)

Builds on top of https://github.com/mongodb-js/compass/pull/6750

This appends `anonymousId` & `connectionId` to `appName` to improve analytics.

This also transitions us out of the legacy behavior of saving the modified connection string with the VSCode version in storage. Doing so while saving meant that we were reporting the vscode version at the moment the connection was created rather than when it was used. Now we add the appName information at runtime only for Atlas connections which allows us to always show up to date information.