### PR TITLE
chore: don't hardcode the extension version in test expectations

### DIFF
--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -18,6 +18,11 @@ on:
         description: 'Exact version: (Only effective selecting "exact-version" as version bump)'
         required: false
 
+description: |
+  Run manually to prepare a draft release for the next version of the extension. The workflow will create a draft
+  github release where the .vsix can be downloaded and manually tested before publishing. To release the version,
+  publish the draft release, which will trigger the publish-release workflow.
+
 permissions:
   contents: write
 

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -1249,8 +1249,10 @@ suite('Connection Controller Test Suite', function () {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     delete mongoClientConnectionOptions!.options.oidc?.openBrowser;
 
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const expectedVersion = require('../../../package.json').version;
     expect(mongoClientConnectionOptions).to.deep.equal({
-      url: 'mongodb://localhost:27088/?appName=mongodb-vscode+0.0.0-dev.0',
+      url: `mongodb://localhost:27088/?appName=mongodb-vscode+${expectedVersion}`,
       options: {
         autoEncryption: undefined,
         monitorCommands: true,


### PR DESCRIPTION

## Description
Fixes a test that had hardcoded 0.0.0-dev as an expectation for the extension version as that fails when running the tests as part of the draft-release workflow: https://github.com/mongodb-js/vscode/actions/runs/14241492483/job/39912232051

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc