### PR TITLE
chore: allow opting out of the welcome screen VSCODE-697

### DIFF
--- a/package.json
+++ b/package.json
@@ -1277,6 +1277,11 @@
               "connectionString"
             ]
           }
+        },
+        "mdb.showOverviewPageAfterInstall": {
+          "type": "boolean",
+          "default": true,
+          "description": "Specify whether to show the overview page immediately after installing the extension."
         }
       }
     },

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -1018,24 +1018,35 @@ export default class MDBExtensionController implements vscode.Disposable {
   }
 
   showOverviewPageIfRecentlyInstalled(): void {
+    const showOverviewFromSettings = vscode.workspace
+      .getConfiguration('mdb')
+      .get<boolean>('showOverviewPageAfterInstall');
+
+    if (!showOverviewFromSettings) {
+      // Users may opt out of showing the overview page in the settings.
+      return;
+    }
+
     const hasBeenShownViewAlready = !!this._storageController.get(
       StorageVariables.GLOBAL_HAS_BEEN_SHOWN_INITIAL_VIEW,
     );
 
-    // Show the overview page when it hasn't been show to the
-    // user yet, and they have no saved connections.
-    if (!hasBeenShownViewAlready) {
-      if (!this._connectionStorage.hasSavedConnections()) {
-        void vscode.commands.executeCommand(
-          EXTENSION_COMMANDS.MDB_OPEN_OVERVIEW_PAGE,
-        );
-      }
+    if (hasBeenShownViewAlready) {
+      // Don't show the overview page if it has already been shown.
+      return;
+    }
 
-      void this._storageController.update(
-        StorageVariables.GLOBAL_HAS_BEEN_SHOWN_INITIAL_VIEW,
-        true,
+    if (!this._connectionStorage.hasSavedConnections()) {
+      // Only show the overview page if there are no saved connections.
+      void vscode.commands.executeCommand(
+        EXTENSION_COMMANDS.MDB_OPEN_OVERVIEW_PAGE,
       );
     }
+
+    void this._storageController.update(
+      StorageVariables.GLOBAL_HAS_BEEN_SHOWN_INITIAL_VIEW,
+      true,
+    );
   }
 
   async dispose(): Promise<void> {

--- a/src/test/suite/mdbExtensionController.test.ts
+++ b/src/test/suite/mdbExtensionController.test.ts
@@ -1716,6 +1716,32 @@ suite('MDBExtensionController Test Suite', function () {
           assert(!executeCommandStub.called);
         });
       });
+
+      suite('when a user has opted out of the overview page', () => {
+        beforeEach(async () => {
+          await vscode.workspace
+            .getConfiguration('mdb')
+            .update('showOverviewPageAfterInstall', false);
+
+          sandbox.replace(
+            mdbTestExtension.testExtensionController._storageController,
+            'get',
+            sandbox.fake.returns(false),
+          );
+
+          void mdbTestExtension.testExtensionController.showOverviewPageIfRecentlyInstalled();
+        });
+
+        afterEach(async () => {
+          await vscode.workspace
+            .getConfiguration('mdb')
+            .update('showOverviewPageAfterInstall', undefined);
+        });
+
+        test('they are not shown the overview page', () => {
+          assert(!executeCommandStub.called);
+        });
+      });
     });
   });
 


### PR DESCRIPTION
## Description
Adds a config that allows users to opt out of showing the welcome screen after the extension is installed.

### Checklist
- [x] New tests and/or benchmarks are included

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
