### PR TITLE
chore: add codeowners VSCODE-687

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*          @mongodb-js/vscode-developers


### PR DESCRIPTION
## Description
Adds a codeowners file. We need to provision the team before we merge this.

