### PR TITLE
chore: set telemetry app name if not set or is vscode MCP-131

### DIFF
--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -79,6 +79,8 @@ interface NewConnectionParams {
   reuseExisting?: boolean;
 }
 
+export const DEFAULT_TELEMETRY_APP_NAME = `${packageJSON.name} ${packageJSON.version}`;
+
 function isOIDCAuth(connectionString: string): boolean {
   const authMechanismString = (
     new ConnectionString(connectionString).searchParams.get('authMechanism') ||
@@ -481,7 +483,7 @@ export default class ConnectionController {
       const connectionOptions = adjustConnectionOptionsBeforeConnect({
         connectionOptions: connectionInfo.connectionOptions,
         connectionId,
-        defaultAppName: `${packageJSON.name} ${packageJSON.version}`,
+        defaultAppName: DEFAULT_TELEMETRY_APP_NAME,
         notifyDeviceFlow,
         preferences: {
           forceConnectionOptions: [],

--- a/src/mcp/mcpConnectionManager.ts
+++ b/src/mcp/mcpConnectionManager.ts
@@ -131,28 +131,26 @@ To connect, choose a connection from MongoDB VSCode extensions's sidepanel - htt
     const connectOptions: DevtoolsConnectOptions = {
       ...connectParams.connectOptions,
     };
-    const searchParamAppName = connectionURL
-      .typedSearchParams<DevtoolsConnectOptions>()
-      .get('appName');
+    const searchParams = connectionURL
+      .typedSearchParams<DevtoolsConnectOptions>();
+    const appName = searchParams.get('appName')
 
     if (
-      !searchParamAppName ||
-      (searchParamAppName.startsWith(DEFAULT_TELEMETRY_APP_NAME) &&
-        !searchParamAppName.includes(MCP_SERVER_TELEMETRY_APP_NAME_SUFFIX))
+      !appName ||
+      (appName.startsWith(DEFAULT_TELEMETRY_APP_NAME) &&
+        !appName.includes(MCP_SERVER_TELEMETRY_APP_NAME_SUFFIX))
     ) {
       const defaultAppName = `${DEFAULT_TELEMETRY_APP_NAME} ${MCP_SERVER_TELEMETRY_APP_NAME_SUFFIX}`;
       const telemetryAnonymousId = this.getTelemetryAnonymousId();
       const connectionId = connectParams.connectionId;
-      const appName = isAtlas(connectParams.connectionString)
+      const newAppName = isAtlas(connectParams.connectionString)
         ? `${defaultAppName}${
             telemetryAnonymousId ? `--${telemetryAnonymousId}` : ''
           }--${connectionId}`
         : defaultAppName;
 
-      connectionURL
-        .typedSearchParams<DevtoolsConnectOptions>()
-        .set('appName', appName);
-      connectOptions.appName = appName;
+      searchParams.set('appName', newAppName);
+      connectOptions.appName = newAppName;
     }
 
     return {

--- a/src/mcp/mcpConnectionManager.ts
+++ b/src/mcp/mcpConnectionManager.ts
@@ -133,10 +133,9 @@ To connect, choose a connection from MongoDB VSCode extensions's sidepanel - htt
       !searchParamAppName ||
       searchParamAppName === DEFAULT_TELEMETRY_APP_NAME
     ) {
-      connectionURL.searchParams.set(
-        'appName',
-        `${DEFAULT_TELEMETRY_APP_NAME} MongoDB MCP Server`,
-      );
+      connectionURL
+        .typedSearchParams<DevtoolsConnectOptions>()
+        .set('appName', `${DEFAULT_TELEMETRY_APP_NAME} MongoDB MCP Server`);
       connectOptions.appName = `${DEFAULT_TELEMETRY_APP_NAME} MongoDB MCP Server`;
     }
 

--- a/src/mcp/mcpConnectionManager.ts
+++ b/src/mcp/mcpConnectionManager.ts
@@ -126,7 +126,9 @@ To connect, choose a connection from MongoDB VSCode extensions's sidepanel - htt
     const connectOptions: DevtoolsConnectOptions = {
       ...connectParams.connectOptions,
     };
-    const searchParamAppName = connectionURL.searchParams.get('appName');
+    const searchParamAppName = connectionURL
+      .typedSearchParams<DevtoolsConnectOptions>()
+      .get('appName');
     if (
       !searchParamAppName ||
       searchParamAppName === DEFAULT_TELEMETRY_APP_NAME

--- a/src/mcp/mcpController.ts
+++ b/src/mcp/mcpController.ts
@@ -44,6 +44,7 @@ export class MCPController {
   constructor(
     private readonly context: vscode.ExtensionContext,
     private readonly connectionController: ConnectionController,
+    private readonly getTelemetryAnonymousId: () => string,
   ) {
     this.context.subscriptions.push(
       vscode.lm.registerMcpServerDefinitionProvider('mongodb', {
@@ -86,7 +87,7 @@ export class MCPController {
       logger,
     }) => {
       const connectionManager = (this.mcpConnectionManager =
-        new MCPConnectionManager(logger));
+        new MCPConnectionManager(logger, this.getTelemetryAnonymousId));
       await this.switchConnectionManagerToCurrentConnection();
       return connectionManager;
     };

--- a/src/mcp/mcpController.ts
+++ b/src/mcp/mcpController.ts
@@ -36,16 +36,30 @@ export type MCPServerInfo = {
   runner: StreamableHttpRunner;
   headers: Record<string, string>;
 };
+
+type MCPControllerConfig = {
+  context: vscode.ExtensionContext;
+  connectionController: ConnectionController;
+  getTelemetryAnonymousId: () => string;
+};
+
 export class MCPController {
+  private context: vscode.ExtensionContext;
+  private connectionController: ConnectionController;
+  private getTelemetryAnonymousId: () => string;
+
   private didChangeEmitter = new vscode.EventEmitter<void>();
   private server?: MCPServerInfo;
   private mcpConnectionManager?: MCPConnectionManager;
 
-  constructor(
-    private readonly context: vscode.ExtensionContext,
-    private readonly connectionController: ConnectionController,
-    private readonly getTelemetryAnonymousId: () => string,
-  ) {
+  constructor({
+    context,
+    connectionController,
+    getTelemetryAnonymousId,
+  }: MCPControllerConfig) {
+    this.context = context;
+    this.connectionController = connectionController;
+    this.getTelemetryAnonymousId = getTelemetryAnonymousId;
     this.context.subscriptions.push(
       vscode.lm.registerMcpServerDefinitionProvider('mongodb', {
         onDidChangeMcpServerDefinitions: this.didChangeEmitter.event,
@@ -87,7 +101,10 @@ export class MCPController {
       logger,
     }) => {
       const connectionManager = (this.mcpConnectionManager =
-        new MCPConnectionManager(logger, this.getTelemetryAnonymousId));
+        new MCPConnectionManager({
+          logger,
+          getTelemetryAnonymousId: this.getTelemetryAnonymousId,
+        }));
       await this.switchConnectionManagerToCurrentConnection();
       return connectionManager;
     };

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -170,6 +170,7 @@ export default class MDBExtensionController implements vscode.Disposable {
     this._mcpController = new MCPController(
       context,
       this._connectionController,
+      () => this._connectionStorage.getUserAnonymousId(),
     );
   }
 

--- a/src/mdbExtensionController.ts
+++ b/src/mdbExtensionController.ts
@@ -167,11 +167,12 @@ export default class MDBExtensionController implements vscode.Disposable {
       telemetryService: this._telemetryService,
     });
     this._editorsController.registerProviders();
-    this._mcpController = new MCPController(
+    this._mcpController = new MCPController({
       context,
-      this._connectionController,
-      () => this._connectionStorage.getUserAnonymousId(),
-    );
+      connectionController: this._connectionController,
+      getTelemetryAnonymousId: (): string =>
+        this._connectionStorage.getUserAnonymousId(),
+    });
   }
 
   subscribeToConfigurationChanges(): void {

--- a/src/test/suite/mcp/mcpConnectionManager.test.ts
+++ b/src/test/suite/mcp/mcpConnectionManager.test.ts
@@ -17,7 +17,7 @@ import { DEFAULT_TELEMETRY_APP_NAME } from '../../../connectionController';
 chai.use(chaiAsPromised);
 
 const sandbox = sinon.createSandbox();
-suite.only('MCPConnectionManager Test Suite', function () {
+suite('MCPConnectionManager Test Suite', function () {
   let mcpConnectionManager: MCPConnectionManager;
   let fakeServiceProvider: NodeDriverServiceProvider;
 

--- a/src/test/suite/mcp/mcpConnectionManager.test.ts
+++ b/src/test/suite/mcp/mcpConnectionManager.test.ts
@@ -22,13 +22,10 @@ suite('MCPConnectionManager Test Suite', function () {
   let fakeServiceProvider: NodeDriverServiceProvider;
 
   beforeEach(() => {
-    mcpConnectionManager = new MCPConnectionManager(
-      {
-        error: () => {},
-        warning: () => {},
-      } as unknown as LoggerBase,
-      () => '1FOO',
-    );
+    mcpConnectionManager = new MCPConnectionManager({
+      logger: { error: () => {}, warning: () => {} } as unknown as LoggerBase,
+      getTelemetryAnonymousId: (): string => '1FOO',
+    });
     fakeServiceProvider = {
       runCommand: (() =>
         Promise.resolve({})) as NodeDriverServiceProvider['runCommand'],
@@ -357,9 +354,7 @@ suite('MCPConnectionManager Test Suite', function () {
             };
 
             expect(
-              getConnectionManager().overrideAppNameIfContainsVSCode(
-                connectParams,
-              ),
+              getConnectionManager().overridePresetAppName(connectParams),
             ).to.deep.equal({
               connectionId: '1',
               connectionString: expectedString(),
@@ -386,9 +381,7 @@ suite('MCPConnectionManager Test Suite', function () {
             };
 
             expect(
-              getConnectionManager().overrideAppNameIfContainsVSCode(
-                connectParams,
-              ),
+              getConnectionManager().overridePresetAppName(connectParams),
             ).to.deep.equal({
               connectionId: '1',
               connectionString: expectedString(),
@@ -416,9 +409,7 @@ suite('MCPConnectionManager Test Suite', function () {
             };
 
             expect(
-              getConnectionManager().overrideAppNameIfContainsVSCode(
-                connectParams,
-              ),
+              getConnectionManager().overridePresetAppName(connectParams),
             ).to.deep.equal(connectParams);
 
             // Now for the case when appName is already set to expected MCP server appname
@@ -437,9 +428,7 @@ suite('MCPConnectionManager Test Suite', function () {
             };
 
             expect(
-              getConnectionManager().overrideAppNameIfContainsVSCode(
-                nextConnectParams,
-              ),
+              getConnectionManager().overridePresetAppName(nextConnectParams),
             ).to.deep.equal(nextConnectParams);
           });
         });

--- a/src/test/suite/mcp/mcpController.test.ts
+++ b/src/test/suite/mcp/mcpController.test.ts
@@ -33,11 +33,11 @@ suite('MCPController test suite', function () {
       telemetryService: testTelemetryService,
     });
 
-    mcpController = new MCPController(
-      extensionContext,
-      connectionController,
-      () => '1FOO',
-    );
+    mcpController = new MCPController({
+      context: extensionContext,
+      connectionController: connectionController,
+      getTelemetryAnonymousId: (): string => '1FOO',
+    });
   });
 
   afterEach(async () => {

--- a/src/test/suite/mcp/mcpController.test.ts
+++ b/src/test/suite/mcp/mcpController.test.ts
@@ -33,7 +33,11 @@ suite('MCPController test suite', function () {
       telemetryService: testTelemetryService,
     });
 
-    mcpController = new MCPController(extensionContext, connectionController);
+    mcpController = new MCPController(
+      extensionContext,
+      connectionController,
+      () => '1FOO',
+    );
   });
 
   afterEach(async () => {


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. VSCODE-1111: updates ace editor width in agg pipeline view -->
<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->
## Description
Sets the appName parameter in connection string to the following format `{default vscode appname} MongoDB MCP Server` when:
- appName is not set
- appName is set to default VSCode's app name

and extend that VSCode specific extended app name format `${appName}--${telemetryAnonymousId}--${connectionId}`


<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
