### PR TITLE
chore: fix for publish workflow asking npm cache

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -12,6 +12,13 @@ jobs:
     name: Publish Release
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # NOTE: this is necessary to get the full history
+          # and check if tags are already present
+          fetch-depth: 0
+
       - name: Setup Node.js Environment
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -12,18 +12,10 @@ jobs:
     name: Publish Release
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          # NOTE: this is necessary to get the full history
-          # and check if tags are already present
-          fetch-depth: 0
-
       - name: Setup Node.js Environment
         uses: actions/setup-node@v4
         with:
           node-version: 22.15.1
-          cache: npm
 
       - name: Run node-gyp bug workaround script
         run: |


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. VSCODE-1111: updates ace editor width in agg pipeline view -->
<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->
## Description
At some point we added `cache: npm` to the publish workflow and that requires a repo checkout.
Since all the npm heavy work is already done by now, we don't need the cache anymore.

<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
