### PR TITLE
chore: Add running environment to telemetry VSCODE-352

### DIFF
--- a/src/telemetry/telemetryService.ts
+++ b/src/telemetry/telemetryService.ts
@@ -65,7 +65,7 @@ export class TelemetryService {
     return {
       extension_version: `${version}`,
       device_id: this.deviceId,
-      app_name: vscode.env.appName, // e.g., "Visual Studio Code" or "Azure Data Studio"
+      app_name: vscode.env.appName || 'Visual Studio Code - Unknown', // e.g., "VS Code" or "Azure Data Studio"
     };
   }
 
@@ -109,7 +109,7 @@ export class TelemetryService {
       anonymousId: this.anonymousId,
       traits: {
         device_id: this.deviceId,
-        app_name: vscode.env.appName, // e.g., "Visual Studio Code" or "Azure Data Studio"
+        app_name: vscode.env.appName || 'Visual Studio Code - Unknown', // e.g., "VS Code" or "Azure Data Studio"
       },
     };
 

--- a/src/test/suite/telemetry/telemetryService.test.ts
+++ b/src/test/suite/telemetry/telemetryService.test.ts
@@ -49,7 +49,7 @@ suite('Telemetry Controller Test Suite', () => {
   const commonProperties = {
     extension_version: version,
     device_id: testDeviceId,
-    app_name: vscode.env.appName,
+    app_name: vscode.env.appName || 'Visual Studio Code - Unknown',
   };
 
   const sandbox = sinon.createSandbox();


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. VSCODE-1111: updates ace editor width in agg pipeline view -->
<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->
## Description
vscode.env.appName is defined as "The application name of the editor, like 'VS Code'."
The expectation is that this will be "Azure Data Studio" when running inside Azure Data Studio.

Issue while testing: Latest version of Azure Data Studio uses vscode 1.82.0, which is now over 2 years old.
It doesn't support  Chat participant features and some others which are being heavily used in our extension.
Making a build which will work with Azure Data Studio has thusly proved to be quite a blocker.
Also, notably, Microsoft is retiring Azure Data Studio on February 28th, 2026: https://azure.microsoft.com/en-us/products/data-studio

Example app_names:

<img width="682" height="204" alt="image" src="https://github.com/user-attachments/assets/1752372a-3a82-4066-83ca-5940484d58a1" />

<img width="904" height="250" alt="image" src="https://github.com/user-attachments/assets/9600f5bf-11af-42cd-8a6a-592e13133d74" />


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [X] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [X] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
