### PR TITLE
chore: make sure we run test-and-build on non-PRs

### DIFF
--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   test-and-build:
     name: Test and Build
-    if: github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name != 'pull_request' || (github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository)
 
     strategy:
       matrix:


### PR DESCRIPTION
There was an error in the if-condition which caused the workflow to be skipped for all non-PR triggers