### PR TITLE
chore: update watch:extension npm script to pass watch to tsc

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "compile:extension": "tsc -p ./",
     "compile:extension-bundles": "webpack --mode development",
     "watch": "pnpm run compile && npm-run-all -p watch:*",
-    "watch:extension": "tsc -p ./ -watch",
+    "watch:extension": "tsc -p ./ --watch",
     "watch:extension-bundles": "webpack --mode development --watch",
     "pretest": "pnpm run compile",
     "test": "pnpm run test-webview && pnpm run test-extension",


### PR DESCRIPTION
I usually use this [launch command](https://github.com/mongodb-js/vscode/blob/c84482b4aee4832fe5654f89a73e100217842e29/.vscode/launch.json#L9) to manually test extension changes:

<img width="613" height="259" alt="Screenshot 2025-12-16 at 17 18 31" src="https://github.com/user-attachments/assets/2e19a825-f756-4c7f-b2e1-0495c7cd5d7a" />

It was erroring as I don't think pnpm passes the watch the same as npm.