### PR TITLE
chore(webpack): remove diagramming library from the bundle VSCODE-725

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,6 +43,9 @@ module.exports = (env, argv) => {
 
         'hadron-ipc': false,
 
+        // We don't use the diagramming library from compass-components and it's a large dep.
+        '@mongodb-js/diagramming': false,
+
         // We don't currently support kerberos in our extension.
         kerberos: false,
 


### PR DESCRIPTION
 VSCODE-725

| before | after |
| - | - |
| <img width="1726" height="960" alt="Screenshot 2025-12-18 at 13 27 04" src="https://github.com/user-attachments/assets/fd4aeaf6-8e0c-4157-ab00-3a824791bf14" /> | <img width="1213" height="594" alt="Screenshot 2025-12-18 at 13 17 42" src="https://github.com/user-attachments/assets/f439817d-4002-4e8c-8422-2b8d82a7e059" /> |