### PR TITLE
fix: update feedback forum links VSCODE-716

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ For issues, please create a ticket in our [JIRA Project](https://jira.mongodb.or
 
 For contributing, please refer to [CONTRIBUTING.md](CONTRIBUTING.md).
 
-Is there anything else you’d like to see in MongoDB for VS Code? Let us know by submitting suggestions in our [feedback forum](https://feedback.mongodb.com/forums/929236-mongodb-for-vs-code?utm_source=vscode&utm_medium=product).
+Is there anything else you’d like to see in MongoDB for VS Code? Let us know by submitting suggestions in our [feedback forum](https://feedback.mongodb.com/?category=7548143030521447168&utm_source=vscode&utm_medium=product).
 
 ## Building and Installing from Source
 

--- a/src/test/suite/utils/links.test.ts
+++ b/src/test/suite/utils/links.test.ts
@@ -4,7 +4,7 @@ import LINKS from '../../../utils/links';
 const expectedLinks = {
   changelog: 'https://github.com/mongodb-js/vscode/blob/main/CHANGELOG.md',
   feedback:
-    'https://feedback.mongodb.com/forums/929236-mongodb-for-vs-code/?utm_source=vscode&utm_medium=product',
+    'https://feedback.mongodb.com/?category=7548143030521447168&utm_source=vscode&utm_medium=product',
   github: 'https://github.com/mongodb-js/vscode',
   reportBug: 'https://github.com/mongodb-js/vscode/issues',
   atlas:

--- a/src/utils/links.ts
+++ b/src/utils/links.ts
@@ -10,7 +10,7 @@ const addUTMAttrs = (url: string): string => {
 
 const LINKS = {
   changelog: 'https://github.com/mongodb-js/vscode/blob/main/CHANGELOG.md',
-  feedback: 'https://feedback.mongodb.com/forums/929236-mongodb-for-vs-code/',
+  feedback: 'https://feedback.mongodb.com/?category=7548143030521447168',
   github: 'https://github.com/mongodb-js/vscode',
   reportBug: 'https://github.com/mongodb-js/vscode/issues',
   atlas: 'https://www.mongodb.com/cloud/atlas',


### PR DESCRIPTION
VSCODE-716

Before: https://feedback.mongodb.com/forums/929236-mongodb-for-vs-code?utm_source=vscode&utm_medium=product 

After: https://feedback.mongodb.com/?category=7548143030521447168&utm_source=vscode&utm_medium=product 

We aren't able, at the moment, to redirect from the old forum to the new one so we need to update these. Pending discussion on renaming IDEs to VSCode in the forum: https://mongodb.slack.com/archives/GTTUKDWRH/p1767663903294609?thread_ts=1765818021.053779&cid=GTTUKDWRH