### PR TITLE
chore: remove build status badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # MongoDB for VS Code
 
-[![Build Status](https://github.com/mongodb-js/vscode/actions/workflows/test-and-build.yaml/badge.svg?branchName=main)](https://github.com/mongodb-js/vscode/actions/workflows/test-and-build.yaml)
-
 MongoDB for VS Code makes it easy to work with your data in MongoDB directly from your VS Code environment. MongoDB for VS Code is the perfect companion for [MongoDB Atlas](https://www.mongodb.com/cloud/atlas/register?utm_source=vscode&utm_medium=product), but you can also use it with your self-managed MongoDB instances.
 
 <p align="center">


### PR DESCRIPTION
This badge is shown on the marketplace page, and isn't relevant to the actual release so it can be misleading to folks:

<img width="585" height="412" alt="Screenshot 2026-01-09 at 07 29 38" src="https://github.com/user-attachments/assets/b728ae3a-20e1-468a-9ae5-43e7f6f4f605" />
