### PR TITLE
chore(workflow): fix test and build from fork workflow to work with node version

### DIFF
--- a/.github/workflows/test-and-build-from-fork.yaml
+++ b/.github/workflows/test-and-build-from-fork.yaml
@@ -22,13 +22,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Get VS Code Node.js version
+        id: get-vscode-node-version
+        shell: bash
+        run: |
+          # Fetch Node.js version from VS Code's .nvmrc, default to 22.20.0 if unavailable
+          NODE_VERSION=$(curl -fsSL https://raw.githubusercontent.com/microsoft/vscode/main/.nvmrc | tr -d '[:space:]')
+          if [ -z "$NODE_VERSION" ]; then
+            NODE_VERSION="22.20.0"
+          fi
+          echo "Using Node.js version for VS Code extension tests: $NODE_VERSION"
+          echo "vscode-node-version=$NODE_VERSION" >> $GITHUB_OUTPUT
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
 
       - name: Setup Node.js Environment
         uses: actions/setup-node@v4
         with:
-          node-version: 22.15.1
+          node-version: ${{ steps.get-vscode-node-version.outputs.vscode-node-version }}
           cache: pnpm
 
       - name: Install Dependencies


### PR DESCRIPTION
Should fix issues like https://github.com/mongodb-js/vscode/actions/runs/20858577120/job/59931902554?pr=1214 