### PR TITLE
chore(ci): use npm in publish script

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -22,7 +22,7 @@ jobs:
           curl -sSfLO https://raw.githubusercontent.com/mongodb-js/compass/42e6142ae08be6fec944b80ff6289e6bcd11badf/.evergreen/node-gyp-bug-workaround.sh && bash node-gyp-bug-workaround.sh
 
       - name: Install VSCode publishing dependencies
-        run: npm add -g vsce
+        run: npm install -g vsce
 
       - name: Download release assets
         run: |


### PR DESCRIPTION
Reverts the change to pnpm for the `publish-release` workflow from https://github.com/mongodb-js/vscode/commit/cb73d67530062b083bfa9be14d34f10eed7b3ec6#diff-a6abdc5a2c99b75dc521141aa12b5dc8381ff914e4a7e4383062c94e6f8a4fc7

This workflow currently is minimal, it doesn't check out the repo, and it publishes an existing asset, so using npm is more straight forward. Happy to use pnpm, it will add a bit more setup to this workflow though. Let's get this release out first I'm thinking.