### PR TITLE
chore: webpack-dev was removed in #177

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,19 +20,6 @@
       "envFile": "${workspaceFolder}/.env"
     },
     {
-      "name": "Launch Extension (prod webpack)",
-      "type": "extensionHost",
-      "request": "launch",
-      "runtimeExecutable": "${execPath}",
-      "args": [
-        "--extensionDevelopmentPath=${workspaceFolder}"
-      ],
-      "outFiles": [
-        "${workspaceFolder}/dist/**/*.js"
-      ],
-      "preLaunchTask": "npm: webpack-dev"
-    },
-    {
       "type": "node",
       "request": "attach",
       "name": "Attach to Language Server",


### PR DESCRIPTION
Not the most consequential thing, but `Launch Extension (prod webpack)` references `npm run webpack-dev` which was removed in [October 2020](https://github.com/mongodb-js/vscode/pull/177).