### PR TITLE
fix: use the theme straight after defining it

### DIFF
--- a/src/views/data-browsing-app/monaco-viewer.tsx
+++ b/src/views/data-browsing-app/monaco-viewer.tsx
@@ -156,31 +156,33 @@ const MonacoViewer: React.FC<MonacoViewerProps> = ({
   }, [themeColors]);
 
   useEffect(() => {
-    if (monaco) {
-      monaco.editor.defineTheme('currentVSCodeTheme', {
-        base: themeKind,
-        inherit: true,
-        rules: colors
-          ? ([
-              { token: 'identifier', foreground: colors.key },
-              { token: 'variable', foreground: colors.key },
-              { token: 'variable.name', foreground: colors.key },
-              { token: 'string', foreground: colors.string },
-              { token: 'string.quote', foreground: colors.string },
-              { token: 'string.escape', foreground: colors.string },
-              { token: 'number', foreground: colors.number },
-              { token: 'keyword', foreground: colors.punctuation },
-              { token: 'type', foreground: colors.type },
-              { token: 'comment', foreground: colors.comment },
-              { token: 'delimiter', foreground: colors.punctuation },
-            ].filter((r) => r.foreground !== null) as editor.ITokenThemeRule[])
-          : [],
-        colors: {
-          'editor.background': '#00000000',
-          'editorGutter.background': '#00000000',
-        },
-      });
+    if (!monaco) {
+      return;
     }
+    monaco.editor.defineTheme('currentVSCodeTheme', {
+      base: themeKind,
+      inherit: true,
+      rules: colors
+        ? ([
+            { token: 'identifier', foreground: colors.key },
+            { token: 'variable', foreground: colors.key },
+            { token: 'variable.name', foreground: colors.key },
+            { token: 'string', foreground: colors.string },
+            { token: 'string.quote', foreground: colors.string },
+            { token: 'string.escape', foreground: colors.string },
+            { token: 'number', foreground: colors.number },
+            { token: 'keyword', foreground: colors.punctuation },
+            { token: 'type', foreground: colors.type },
+            { token: 'comment', foreground: colors.comment },
+            { token: 'delimiter', foreground: colors.punctuation },
+          ].filter((r) => r.foreground !== null) as editor.ITokenThemeRule[])
+        : [],
+      colors: {
+        'editor.background': '#00000000',
+        'editorGutter.background': '#00000000',
+      },
+    });
+    monaco.editor.setTheme('currentVSCodeTheme');
   }, [monaco, colors, themeKind]);
 
   const documentString = useMemo(() => {


### PR DESCRIPTION
sometimes we'd get this:
<img width="2304" height="1298" alt="Screenshot 2026-02-11 at 10 18 27" src="https://github.com/user-attachments/assets/b137ab9f-dbef-4c19-9cc2-9e28df2ca85a" />

We do set `theme="currentVSCodeTheme"` and I guess there's some kind of race condition?
