### PR TITLE
fix: don't actually treat this like a typescript editor

### DIFF
--- a/src/views/data-browsing-app/monaco-viewer.tsx
+++ b/src/views/data-browsing-app/monaco-viewer.tsx
@@ -174,6 +174,10 @@ const viewerOptions: Monaco.editor.IStandaloneEditorConstructionOptions = {
     autoFindInSelection: 'never',
     seedSearchStringFromSelection: 'never',
   },
+  quickSuggestions: false,
+  suggestOnTriggerCharacters: false,
+  parameterHints: { enabled: false },
+  hover: { enabled: false },
 };
 
 const MonacoViewer: React.FC<MonacoViewerProps> = ({
@@ -232,6 +236,18 @@ const MonacoViewer: React.FC<MonacoViewerProps> = ({
       },
     });
     monaco.editor.setTheme('currentVSCodeTheme');
+
+    // Configure TypeScript to disable semantic diagnostics
+    // This prevents it from treating object keys as DOM/TypeScript identifiers
+    monaco.typescript.typescriptDefaults.setDiagnosticsOptions({
+      noSemanticValidation: true,
+      noSyntaxValidation: false,
+    });
+    monaco.typescript.typescriptDefaults.setCompilerOptions({
+      target: monaco.typescript.ScriptTarget.Latest,
+      allowNonTsExtensions: true,
+      noLib: true,
+    });
   }, [monaco, colors, themeKind]);
 
   const documentString = useMemo(() => {


### PR DESCRIPTION
After https://github.com/mongodb-js/vscode/pull/1240 monaco is now loading all its code (most notably a web worker) and started to think that a document like `{ name }` is referencing some deprecated DOM variable..

This just turns off lots of things because this isn't actually a typescript editor. 