### PR TITLE
fix: include onFileSystem in activationEvents VSCODE-740

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
     "onLanguage:json",
     "onLanguage:javascript",
     "onLanguage:plaintext",
-    "onUri"
+    "onUri",
+    "onFileSystem:VIEW_DOCUMENT_SCHEME"
   ],
   "contributes": {
     "chatParticipants": [


### PR DESCRIPTION
VSCODE-740

before:

<img width="512" height="477" alt="reopen-error-before" src="https://github.com/user-attachments/assets/8961d4fd-cc1c-40ae-9e21-f40c5ba822d8" />

after:

<img width="655" height="636" alt="Screenshot 2026-03-03 at 12 38 55" src="https://github.com/user-attachments/assets/385c4f0e-abf4-4a88-bd77-68d3780f5e51" />

I had to ask gemini about "CodeExpectedError: ENOPRO: No file system provider found for resource ":

> This specific error, ENOPRO, is the internal VS Code shorthand for "Error: No Provider." It occurs when you attempt to open a URI with a custom scheme (e.g., my-scheme://path/file.txt), but no extension has successfully registered a FileSystemProvider for that scheme.
>
> Like the general "unexpected error," you cannot customize the text of the red toast notification once it is thrown by the VS Code core. However, you can prevent it from ever reaching the user by ensuring your provider is correctly "activated" before the resource is requested.
>
> Why this happens and how to fix it
> 1. The Activation Trap (Most Common)
> VS Code is "lazy." It won't know your provider exists until your extension is activated. If you try to open a URI with your scheme before your activate() function runs, you get ENOPRO.
>
> The Fix: Update your package.json to include onFileSystem in your activation events. This tells VS Code: "If anyone touches this scheme, wake up my extension immediately."
>
> JSON
> "activationEvents": [
>    "onFileSystem:my-scheme"
>]

----

This is still not great. What's worse is that it now displays that `Create File` button that we can't hide. We have no control over this message.

The best alternative is to change MemoryFileSystemProvider.stat() to not throw but to always say that the doc is there. Then in MemoryFileSystemProvider.readFile() we can return a fake but correct-looking document that has a comment where we explain that the connection this doc relates to is closed. I'm not super crazy about that either.

What's extra annoying is you can't seem to tell vscode to try again / reload / refresh when a user does connect to something.