### PR TITLE
fix: remove the background from the fold line in monaco VSCODE-761

### DIFF
--- a/src/views/data-browsing-app/monaco-viewer.tsx
+++ b/src/views/data-browsing-app/monaco-viewer.tsx
@@ -264,6 +264,8 @@ const MonacoViewer: React.FC<MonacoViewerProps> = ({
       colors: {
         'editor.background': '#00000000',
         'editorGutter.background': '#00000000',
+        'editor.foldBackground': '#00000000',
+        'editor.lineHighlightBorder': '#00000000',
       },
     });
     monaco.editor.setTheme('currentVSCodeTheme');


### PR DESCRIPTION
VSCODE-761

fixes these:

<img width="727" height="838" alt="Screenshot 2026-03-04 at 11 45 20" src="https://github.com/user-attachments/assets/cfb56c89-3dd4-4e4d-a00d-e2de5d85f9f9" />
<img width="400" height="384" alt="Screenshot 2026-03-04 at 11 02 57" src="https://github.com/user-attachments/assets/f761bf1c-6340-469c-aaaa-bb376718caae" />
