### PR TITLE
fix: add back some commands accidentally removed VSCODE-730

### DIFF
--- a/package.json
+++ b/package.json
@@ -704,7 +704,7 @@
         {
           "command": "mdb.askCopilotFromTreeItem",
           "when": "mdb.isCopilotActive == true && view == mongoDBConnectionExplorer && (viewItem == databaseTreeItem || viewItem == collectionTreeItem)",
-          "group": "3@1"
+          "group": "3@0"
         },
         {
           "command": "mdb.createNewPlaygroundFromTreeItem",


### PR DESCRIPTION
[VSCODE-730](https://github.com/mongodb-js/vscode/pull/1258/changes#top)

I meant to just remove the commands on document items in the tree because there are no documents in the tree and for some reason accidentally removed these here https://github.com/mongodb-js/vscode/pull/1258/changes#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L715-L726