### PR TITLE
chore: update renamed js vscode setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,7 +16,7 @@
     "out": true
   },
   // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-  "typescript.tsc.autoDetect": "off",
+  "js/ts.tsc.autoDetect": "off",
   "mdb.presetConnections": [
     {
       "name": "Preset Connection",


### PR DESCRIPTION
https://code.visualstudio.com/docs/languages/javascript
`typescript` prefix is now `js/ts`.