### PR TITLE
fix(data-browsing): show error when cannot deserialize EJSON VSCODE-768

### DIFF
--- a/src/views/data-browsing-app/monaco-viewer.tsx
+++ b/src/views/data-browsing-app/monaco-viewer.tsx
@@ -286,7 +286,7 @@ const MonacoViewer: React.FC<MonacoViewerProps> = ({
 
   const documentString = useMemo(() => {
     try {
-      const deserialized = EJSON.deserialize(document);
+      const deserialized = EJSON.deserialize(document, { relaxed: false });
       return toJSString(deserialized) ?? '';
     } catch (e) {
       return `Failed to deserialize and render document: ${(e as Error).message}`;


### PR DESCRIPTION
VSCODE-768

| before | after |
| - | - |
| <img width="1041" height="368" alt="Screenshot 2026-03-26 at 12 51 33" src="https://github.com/user-attachments/assets/9b979818-0b2e-40a2-b69f-498dcb006a89" /> | <img width="742" height="350" alt="Screenshot 2026-03-26 at 12 46 34" src="https://github.com/user-attachments/assets/d9cb4513-e77f-466b-855e-e0c6129b1e3c" /> |

## Description
This is a minimal, temporary fix for the issue. See VSCODE-772 for a more complete fix.

An example document that would cause this would be:
```ts
{
  fieldName: UUID('pineapple')
}
```

I had added a unit test to https://github.com/mongodb-js/vscode/blob/f6c2fdb59442abe9fbd152616d3514da1e8beba1/src/test/suite/views/data-browsing-app/monaco-viewer.test.tsx#L181 and then I noticed that the tests in there aren't actually testing anything so I removed it. 

When we do a fix that fully addresses this issue, rendering these fields as Compass or mongosh would, then we can add a proper e2e test and remove the no-op tests.

Partially addresses https://github.com/mongodb-js/vscode/issues/1287