### PR TITLE
fix: add the missing globals we use to the playground templates

### DIFF
--- a/src/templates/playgroundFromCollectionTreeItemTemplate.ts
+++ b/src/templates/playgroundFromCollectionTreeItemTemplate.ts
@@ -1,7 +1,8 @@
 import { createTemplate } from './templateHelpers';
 
 export const playgroundFromCollectionTreeItemTemplate = createTemplate(
-  (databaseName, collectionName) => `// MongoDB Playground
+  (databaseName, collectionName) => `/* global use, db */
+// MongoDB Playground
 // Use Ctrl+Space inside a snippet or a string literal to trigger completions.
 
 // The current database to use.

--- a/src/templates/playgroundFromDatabaseTreeItemTemplate.ts
+++ b/src/templates/playgroundFromDatabaseTreeItemTemplate.ts
@@ -1,7 +1,8 @@
 import { createTemplate } from './templateHelpers';
 
 export const playgroundFromDatabaseTreeItemTemplate = createTemplate(
-  (currentDatabase) => `// MongoDB Playground
+  (currentDatabase) => `/* global use */
+// MongoDB Playground
 // Use Ctrl+Space inside a snippet or a string literal to trigger completions.
 
 // The current database to use.

--- a/src/templates/playgroundInsertDocumentTemplate.ts
+++ b/src/templates/playgroundInsertDocumentTemplate.ts
@@ -1,4 +1,5 @@
-const template = `// MongoDB Playground
+const template = `/* global use, db */
+// MongoDB Playground
 // Use Ctrl+Space inside a snippet or a string literal to trigger completions.
 
 // The current database to use.


### PR DESCRIPTION
I noticed that this started happening where some newly created playgrounds stated off red:

<img width="2002" height="1482" alt="Screenshot 2026-04-13 at 11 41 13" src="https://github.com/user-attachments/assets/cc7a5547-3eb3-4fb4-852e-82e758fa6a92" />
<img width="428" height="144" alt="Screenshot 2026-04-13 at 11 55 25" src="https://github.com/user-attachments/assets/9aa3f58e-1fa7-477e-a3b5-4e445ddb981e" />

So far it seems to only happen if vscode's active workspace is vscode itself. The error is coming from eslint and I guess at some point something changed in how it resolves the eslint config or in vscode's config or it picks up vscode's config..

Probably not really an issue for most real users, but I did notice that all our playground templates except three have the `/* global use, db */` (or whatever globals get used in the template) pattern at the top and that fixes it.

Might as well align those?

---

Four options:
* it is effectively the user's eslint config breaking it here, so we can decide it is their responsibility
* we can add all the globals they could ever use, add eslint config to ignore unused globals or add eslint config to just turn off validation for using undefined globals, etc. (some variation or combination of those)
* we could not make playgrounds .js files but rather make a new format that just happens to be using js parsers under the hood and then eslint or similar _cannot_ accidentally match it
* we could just live with it ;)