### PR TITLE
chore: add macos-export-certificate-and-key to externals

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -71,6 +71,7 @@ module.exports = (env, argv) => {
       'snappy/package.json': 'snappy/package.json',
       'bson-ext': 'bson-ext',
       'win-export-certificate-and-key': 'win-export-certificate-and-key',
+      'macos-export-certificate-and-key': 'macos-export-certificate-and-key',
       'os-dns-native': 'os-dns-native',
       'mongodb-client-encryption': 'mongodb-client-encryption',
       '@mongodb-js/zstd': '@mongodb-js/zstd',


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. VSCODE-1111: updates ace editor width in agg pipeline view -->
<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
After switching to npm 11.16.0, the issue with resolving bindings appeared. Looks like it is stricter about the transitive deps, so we should explicitely add `macos-export-certificate-and-key` to webpack externals alongside its Windows counterpart.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
