### PR TITLE
DEVPROD-34208: use ECR for signing image

### DIFF
--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -244,6 +244,9 @@ jobs:
     needs: [prepare-version, test, test-install]
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
 
     steps:
       - name: Checkout
@@ -260,10 +263,14 @@ jobs:
         with:
           name: vsix
 
+      - name: Configure AWS credentials for DevProd Platforms ECR
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.DEVPROD_PLATFORMS_ECR_ROLE_ARN }}
+          aws-region: us-east-1
+
       - name: Sign .vsix
         env:
-          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-          ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           GARASIGN_PASSWORD: ${{ secrets.GARASIGN_PASSWORD }}
           GARASIGN_USERNAME: ${{ secrets.GARASIGN_USERNAME }}
         run: |
@@ -273,6 +280,8 @@ jobs:
             echo "Error: No .vsix file found in the current directory." >&2
             exit 1
           fi
+          ECR_LOGIN_PASSWORD="$(aws ecr get-login-password --region us-east-1)"
+          export ECR_LOGIN_PASSWORD
           node scripts/sign-vsix.js "${FILE_TO_SIGN}"
           ls *.vsix.sig
         shell: bash

--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -264,7 +264,7 @@ jobs:
           name: vsix
 
       - name: Configure AWS credentials for DevProd Platforms ECR
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.DEVPROD_PLATFORMS_ECR_ROLE_ARN }}
           aws-region: us-east-1
@@ -281,6 +281,7 @@ jobs:
             exit 1
           fi
           ECR_LOGIN_PASSWORD="$(aws ecr get-login-password --region us-east-1)"
+          echo "::add-mask::$ECR_LOGIN_PASSWORD"
           export ECR_LOGIN_PASSWORD
           node scripts/sign-vsix.js "${FILE_TO_SIGN}"
           ls *.vsix.sig


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. VSCODE-1111: updates ace editor width in agg pipeline view -->
<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
MongoDB Artifactory is now deprecated so we must use ECR for the DevProd container images.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->
N/A

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->
> [!IMPORTANT]  
> The `DEVPROD_PLATFORMS_ECR_ROLE_ARN ` GitHub Actions secret must be added with a value of `arn:aws:iam::901841024863:role/ecr-role-gha-ro`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
