### PR TITLE
fix(participant): copilot chat participant model not found error VSCODE-791

### DIFF
--- a/src/participant/constants.ts
+++ b/src/participant/constants.ts
@@ -3,7 +3,7 @@ import { ChatMetadataStore } from './chatMetadata';
 import type { ParticipantResponseType } from './participantTypes';
 
 export const CHAT_PARTICIPANT_ID = 'mongodb.participant';
-export const CHAT_PARTICIPANT_MODEL = 'gpt-4o';
+export const CHAT_PARTICIPANT_PREFERRED_MODEL = 'gpt-5-mini';
 export const COPILOT_EXTENSION_ID = 'GitHub.copilot';
 export const COPILOT_CHAT_EXTENSION_ID = 'GitHub.copilot-chat';
 

--- a/src/participant/model.ts
+++ b/src/participant/model.ts
@@ -1,6 +1,5 @@
 import * as vscode from 'vscode';
-
-import { CHAT_PARTICIPANT_MODEL } from './constants';
+import { CHAT_PARTICIPANT_PREFERRED_MODEL } from './constants';
 
 let selectedModel: vscode.LanguageModelChat | undefined;
 
@@ -9,11 +8,14 @@ export async function getCopilotModel(): Promise<
 > {
   if (!selectedModel) {
     try {
-      const [model] = await vscode.lm.selectChatModels({
-        vendor: 'copilot',
-        family: CHAT_PARTICIPANT_MODEL,
-      });
-      selectedModel = model;
+      // We select the model by vendor only, because not every family is
+      // available at all times. A missing family would leave the user with no
+      // model and fail their request. We still prefer the model our prompts are
+      // tuned for, but fall back to whichever one Copilot lists first.
+      const models = await vscode.lm.selectChatModels({ vendor: 'copilot' });
+      selectedModel =
+        models.find((m) => CHAT_PARTICIPANT_PREFERRED_MODEL === m.family) ??
+        models[0];
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (err) {
       // Model is not ready yet. It is being initialised with the first user prompt.

--- a/src/test/ai-accuracy-tests/ai-backend.ts
+++ b/src/test/ai-accuracy-tests/ai-backend.ts
@@ -1,13 +1,16 @@
 import OpenAI from 'openai';
 import type { ChatCompletionCreateParamsBase } from 'openai/resources/chat/completions';
 
-import { CHAT_PARTICIPANT_MODEL } from '../../participant/constants';
+import { CHAT_PARTICIPANT_PREFERRED_MODEL } from '../../participant/constants';
 
 let openai: OpenAI;
 function getOpenAIClient(): OpenAI {
   if (!openai) {
+    const apiKey = process.env.OPENAI_API_KEY ?? '';
     openai = new OpenAI({
-      apiKey: process.env.OPENAI_API_KEY,
+      apiKey,
+      baseURL: process.env.OPENAI_BASE_URL, // Run against an OpenAI gateway.
+      defaultHeaders: { 'api-key': apiKey }, // Gateways authenticate with an `api-key` header.
     });
   }
 
@@ -30,9 +33,12 @@ export type ChatCompletion = {
   };
 };
 
+const TEST_MODEL = process.env.OPENAI_MODEL ?? CHAT_PARTICIPANT_PREFERRED_MODEL;
+console.log(`Running accuracy tests against '${TEST_MODEL}'.`);
+
 async function createOpenAIChatCompletion({
   messages,
-  model = CHAT_PARTICIPANT_MODEL,
+  model = TEST_MODEL,
 }: {
   messages: ChatMessages;
   model?: ChatCompletionCreateParamsBase['model'];

--- a/src/test/ai-accuracy-tests/test-setup.ts
+++ b/src/test/ai-accuracy-tests/test-setup.ts
@@ -2,19 +2,34 @@ import Module from 'module';
 
 const AssistantRole = 2;
 const UserRole = 1;
+
+class LanguageModelTextPart {
+  value: string;
+
+  constructor(value: string) {
+    this.value = value;
+  }
+}
+
+// `vscode.LanguageModelChatMessage` stores content as an array of parts rather
+// than a string, so the mock has to do the same for the tests to read it back.
+const toParts = (content: unknown): LanguageModelTextPart[] =>
+  Array.isArray(content) ? content : [new LanguageModelTextPart(`${content}`)];
+
 const vscodeMock = {
   LanguageModelChatMessageRole: {
     Assistant: AssistantRole,
     User: UserRole,
   },
+  LanguageModelTextPart,
   LanguageModelChatMessage: {
     Assistant: (content, name?: string): unknown => ({
       name,
-      content,
+      content: toParts(content),
       role: AssistantRole,
     }),
     User: (content: string, name?: string): unknown => ({
-      content,
+      content: toParts(content),
       name,
       role: UserRole,
     }),

--- a/src/test/ai-accuracy-tests/test-setup.ts
+++ b/src/test/ai-accuracy-tests/test-setup.ts
@@ -13,8 +13,10 @@ class LanguageModelTextPart {
 
 // `vscode.LanguageModelChatMessage` stores content as an array of parts rather
 // than a string, so the mock has to do the same for the tests to read it back.
-const toParts = (content: unknown): LanguageModelTextPart[] =>
-  Array.isArray(content) ? content : [new LanguageModelTextPart(`${content}`)];
+const toParts = (
+  content: string | LanguageModelTextPart[],
+): LanguageModelTextPart[] =>
+  Array.isArray(content) ? content : [new LanguageModelTextPart(content)];
 
 const vscodeMock = {
   LanguageModelChatMessageRole: {
@@ -23,7 +25,7 @@ const vscodeMock = {
   },
   LanguageModelTextPart,
   LanguageModelChatMessage: {
-    Assistant: (content, name?: string): unknown => ({
+    Assistant: (content: string, name?: string): unknown => ({
       name,
       content: toParts(content),
       role: AssistantRole,


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. VSCODE-1111: updates ace editor width in agg pipeline view -->
<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
Copilot doesn't offer every family at all times, so when one is missing the model selection comes back empty and the user's request fail. We now select on vendor alone, prefer the family our prompts are tuned for, and fall back to whichever model Copilot lists first. The constant is set to `gpt-5-mini` because looks like the `gpt-4o` is unofficially deprecated (the accuracy test results are the same).

Also fixed the AI accuracy tests: the vscode mock built message content as a string while the suite reads it as an array of parts, failing every run with `message.content.map is not a function`. And ai-backend.ts now honours `OPENAI_BASE_URL` / `OPENAI_MODEL` so the suite can run against a gateway, defaulting to the previous behaviour when unset.

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
