### PR TITLE
chore(ci): ensure sbom dependencies is build before snyk-test

### DIFF
--- a/.github/workflows/snyk-test.yaml
+++ b/.github/workflows/snyk-test.yaml
@@ -44,6 +44,14 @@ jobs:
             .sbom/snyk-test-result.html
             .sbom/snyk-test-result.json
 
+      # The webpack build writes .sbom/dependencies.json (via WebpackDependenciesPlugin),
+      # which the vulnerability report needs to know which packages are actually bundled.
+      - name: Build extension bundles
+        shell: bash
+        run: |
+          pnpm run compile:constants
+          pnpm run compile:extension-bundles
+
       - name: Generate Vulnerability Report (Fail on >= High)
         continue-on-error: ${{ github.event_name == 'pull_request' }}
         shell: bash


### PR DESCRIPTION
Should fix this CI issue: https://github.com/mongodb-js/vscode/actions/runs/31643203229/job/94270543223 