### PR TITLE
chore(ci): skip changelog task if no prs, don't fail

### DIFF
--- a/.github/workflows/rebuild-changelog.yaml
+++ b/.github/workflows/rebuild-changelog.yaml
@@ -87,6 +87,7 @@ jobs:
           committer: "${{ steps.app-token.outputs.app-slug}}[bot] <${{ steps.app-token.outputs.app-email }}>"
 
       - name: Merge PR
+        if: steps.cpr.outputs.pull-request-number != ''
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}


### PR DESCRIPTION
It was failing: https://github.com/mongodb-js/vscode/actions/runs/32211663689/job/95945401682
Let's skip instead.
https://github.com/mongodb-js/vscode/actions