### PR TITLE
build: missing sbom dependencies.json VSCODE-808

### DIFF
--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -234,6 +234,14 @@ jobs:
             .sbom/snyk-test-result.html
             .sbom/snyk-test-result.json
 
+      # The webpack build writes .sbom/dependencies.json (via WebpackDependenciesPlugin),
+      # which the vulnerability report needs to know which packages are actually bundled.
+      - name: Build extension bundles
+        shell: bash
+        run: |
+          pnpm run compile:constants
+          pnpm run compile:extension-bundles
+
       - name: Generate Vulnerability Report (Fail on >= High)
         shell: bash
         run: |


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. VSCODE-1111: updates ace editor width in agg pipeline view -->
<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
The `generate-vulnerability-report` in `draft-release.yaml` reads `.sbom/dependencies.json` - a file the webpack build produces. The job never builds the bundles, so it fails with ENOENT and blocks the draft release. Added the build step already present in `snyk-test.yaml`.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
