### PR TITLE
build: sign vsix fails VSCODE-809

### DIFF
--- a/package.json
+++ b/package.json
@@ -1504,7 +1504,7 @@
     "@mongodb-js/oidc-plugin": "^2.0.8",
     "@mongodb-js/prettier-config-devtools": "^1.0.3",
     "@mongodb-js/sbom-tools": "^0.10.15",
-    "@mongodb-js/signing-utils": "^0.5.10",
+    "@mongodb-js/signing-utils": "^0.5.14",
     "@mongosh/service-provider-core": "^5.0.6",
     "@playwright/test": "^1.59.1",
     "@testing-library/react": "^16.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,8 +205,8 @@ importers:
         specifier: ^0.10.15
         version: 0.10.16
       '@mongodb-js/signing-utils':
-        specifier: ^0.5.10
-        version: 0.5.11
+        specifier: ^0.5.14
+        version: 0.5.14
       '@mongosh/service-provider-core':
         specifier: ^5.0.6
         version: 5.0.6(@aws-sdk/credential-providers@3.1042.0)(gcp-metadata@7.0.1)(kerberos@7.0.0)(mongodb-client-encryption@7.0.0)(socks@2.8.7)
@@ -2532,8 +2532,8 @@ packages:
     peerDependencies:
       bson: ^7.2.0
 
-  '@mongodb-js/signing-utils@0.5.11':
-    resolution: {integrity: sha512-X8U6vX3RhZKUTs6FNtC1e9q6Df/P5AfEiqIPBdwdDUPjMQg9uXphAyhGB0w81fEmmQMil0CapsVAZZzkyUCr2A==}
+  '@mongodb-js/signing-utils@0.5.14':
+    resolution: {integrity: sha512-7jN8ZEZjT4+t206GRoK0JQRDHAfH5Z3GGhu7eCSkRJOi27WmB6n/JbRVVvppLmWrYyY7l5EOhP8lwGzsLoTpXg==}
 
   '@mongodb-js/socksv5@0.0.10':
     resolution: {integrity: sha512-JDz2fLKsjMiSNUxKrCpGptsgu7DzsXfu4gnUQ3RhUaBS1d4YbLrt6HejpckAiHIAa+niBpZAeiUsoop0IihWsw==}
@@ -13164,7 +13164,7 @@ snapshots:
       acorn: 8.16.0
       bson: 7.2.0
 
-  '@mongodb-js/signing-utils@0.5.11':
+  '@mongodb-js/signing-utils@0.5.14':
     dependencies:
       '@types/ssh2': 1.15.5
       debug: 4.4.3(supports-color@8.1.1)


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. VSCODE-1111: updates ace editor width in agg pipeline view -->
<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
Bump `@mongodb-js/signing-utils`.

The draft release "Sign .vsix" step fails with `artifactory_username` is unset. In 0.5.14 the Artifactory dependency is gone entirely and requires `ecr_login_password` (already used by Compass and mongosh).

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
