### PR TITLE
chore(deps): remove unnecessary overrides in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1574,15 +1574,10 @@
   "pnpm": {
     "overrides": {
       "@hono/node-server": "^1.19.17",
-      "@mongodb-js/devtools-connect": "^3.17.3",
-      "@mongodb-js/devtools-proxy-support": "^0.7.16",
-      "@mongodb-js/oidc-plugin": "^2.0.8",
-      "@mongosh/service-provider-node-driver": "^5.2.0",
       "@xmldom/xmldom": "^0.9.10",
       "bson": "^7.2.0",
       "js-yaml@3": "^3.15.1",
       "js-yaml@4": "^5.2.2",
-      "kerberos": "^7.0.0",
       "mongodb": "^7.2.0",
       "mongodb-client-encryption": "^7.0.0",
       "react": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4787,8 +4787,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.6:
-    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
@@ -13585,7 +13585,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.6
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -15022,7 +15022,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.6: {}
+  fast-uri@3.1.5: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,15 +6,10 @@ settings:
 
 overrides:
   '@hono/node-server': ^1.19.17
-  '@mongodb-js/devtools-connect': ^3.17.3
-  '@mongodb-js/devtools-proxy-support': ^0.7.16
-  '@mongodb-js/oidc-plugin': ^2.0.8
-  '@mongosh/service-provider-node-driver': ^5.2.0
   '@xmldom/xmldom': ^0.9.10
   bson: ^7.2.0
   js-yaml@3: ^3.15.1
   js-yaml@4: ^5.2.2
-  kerberos: ^7.0.0
   mongodb: ^7.2.0
   mongodb-client-encryption: ^7.0.0
   react: ^18.3.1
@@ -4792,8 +4787,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
@@ -13590,7 +13585,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -15027,7 +15022,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:


### PR DESCRIPTION
These overrides aren't needed anymore; they may be nested dependencies that have been bumped in recent updates or weren't needed to begin with. 