### PR TITLE
fix(launch-mongo-shell): quote connection string when launching via cmd VSCODE-796

### DIFF
--- a/src/commands/launchMongoShell.ts
+++ b/src/commands/launchMongoShell.ts
@@ -30,19 +30,22 @@ const launchMongoDBShellWithEnv = ({
 };
 
 const getPowershellEnvString = (): string => {
-  return '$Env:MDB_CONNECTION_STRING';
+  return '"$Env:MDB_CONNECTION_STRING"';
 };
 
 const getCmdEnvString = (): string => {
-  return '%MDB_CONNECTION_STRING%';
+  // Quoting wraps the *substituted* value (cmd.exe expands %VAR% before
+  // parsing for shell metacharacters like |, &, >), so this prevents a
+  // connection string from injecting extra commands.
+  return '"%MDB_CONNECTION_STRING%"';
 };
 
 const getGitBashEnvString = (): string => {
-  return '$MDB_CONNECTION_STRING';
+  return '"$MDB_CONNECTION_STRING"';
 };
 
 const getBashEnvString = (): string => {
-  return '$MDB_CONNECTION_STRING';
+  return '"$MDB_CONNECTION_STRING"';
 };
 
 const openMongoDBShell = (
@@ -82,6 +85,14 @@ const openMongoDBShell = (
   }
 
   const mdbConnectionString = connectionController.getActiveConnectionString();
+
+  if (/["\r\n]/.test(mdbConnectionString)) {
+    void vscode.window.showErrorMessage(
+      'The connection string contains unsupported characters (quotes or line breaks) and cannot be used to launch the MongoDB Shell.',
+    );
+    return Promise.resolve(false);
+  }
+
   const parentHandle =
     connectionController.getMongoClientConnectionOptions()?.options
       .parentHandle;

--- a/src/test/suite/commands/launchMongoShell.test.ts
+++ b/src/test/suite/commands/launchMongoShell.test.ts
@@ -108,9 +108,37 @@ suite('Commands Test Suite', function () {
         );
 
         const shellCommandText = sendTextStub.firstCall.args[0];
-        expect(shellCommandText).to.equal('mongosh $MDB_CONNECTION_STRING;');
+        expect(shellCommandText).to.equal('mongosh "$MDB_CONNECTION_STRING";');
 
         expect(showErrorMessageStub.called).to.be.false;
+      });
+
+      test('openMongoDBShell should reject a connection string containing a double quote', async function () {
+        getMongoClientConnectionOptionsStub.returns({
+          url: 'mongodb://cluster0.example.com/?appName=x"|calc.exe',
+          options: {},
+        });
+
+        await launchMongoShell(testConnectionController);
+
+        expect(createTerminalStub.called).to.be.false;
+        expect(showErrorMessageStub.firstCall.args[0]).to.equal(
+          'The connection string contains unsupported characters (quotes or line breaks) and cannot be used to launch the MongoDB Shell.',
+        );
+      });
+
+      test('openMongoDBShell should reject a connection string containing a newline', async function () {
+        getMongoClientConnectionOptionsStub.returns({
+          url: 'mongodb://cluster0.example.com/?appName=x\ncalc.exe',
+          options: {},
+        });
+
+        await launchMongoShell(testConnectionController);
+
+        expect(createTerminalStub.called).to.be.false;
+        expect(showErrorMessageStub.firstCall.args[0]).to.equal(
+          'The connection string contains unsupported characters (quotes or line breaks) and cannot be used to launch the MongoDB Shell.',
+        );
       });
     });
   });
@@ -146,7 +174,7 @@ suite('Commands Test Suite', function () {
       );
 
       const shellCommandText = sendTextStub.firstCall.args[0];
-      expect(shellCommandText).to.include('$Env:MDB_CONNECTION_STRING');
+      expect(shellCommandText).to.include('"$Env:MDB_CONNECTION_STRING"');
     });
   });
 
@@ -185,7 +213,7 @@ suite('Commands Test Suite', function () {
       );
 
       const shellCommandText = sendTextStub.firstCall.args[0];
-      expect(shellCommandText).to.include('$Env:MDB_CONNECTION_STRING');
+      expect(shellCommandText).to.include('"$Env:MDB_CONNECTION_STRING"');
     });
   });
 
@@ -207,19 +235,19 @@ suite('Commands Test Suite', function () {
     }[] = [
       {
         shell: 'C:\\Program Files\\PowerShell\\7\\Pwsh.exe',
-        expectedEnvVariable: '$Env:MDB_CONNECTION_STRING',
+        expectedEnvVariable: '"$Env:MDB_CONNECTION_STRING"',
       },
       {
         shell: 'C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\PowerShell.exe',
-        expectedEnvVariable: '$Env:MDB_CONNECTION_STRING',
+        expectedEnvVariable: '"$Env:MDB_CONNECTION_STRING"',
       },
       {
         shell: 'C:\\WINDOWS\\System32\\CMD.EXE',
-        expectedEnvVariable: '%MDB_CONNECTION_STRING%',
+        expectedEnvVariable: '"%MDB_CONNECTION_STRING%"',
       },
       {
         shell: 'C:\\Program Files\\Git\\bin\\Bash.exe',
-        expectedEnvVariable: '$MDB_CONNECTION_STRING',
+        expectedEnvVariable: '"$MDB_CONNECTION_STRING"',
       },
     ];
 
@@ -261,6 +289,20 @@ suite('Commands Test Suite', function () {
       expect(terminalOptions.env?.MDB_CONNECTION_STRING).to.equal(
         expectedDriverUrl,
       );
+    });
+
+    test('windows cmd openMongoDBShell should quote the connection string so pipe/redirect payloads are inert', async function () {
+      getMongoClientConnectionOptionsStub.returns({
+        url: 'mongodb://cluster0.example.com/?appName=x|calc.exe',
+        options: {},
+      });
+
+      isCurrentlyConnectedStub.returns(true);
+
+      await launchMongoShell(testConnectionController);
+
+      const shellCommandText = sendTextStub.firstCall.args[0];
+      expect(shellCommandText).to.equal('mongosh "%MDB_CONNECTION_STRING%";');
     });
   });
 });

--- a/src/test/suite/oidc.test.ts
+++ b/src/test/suite/oidc.test.ts
@@ -230,7 +230,7 @@ suite('OIDC Tests', function () {
     expect(terminalCsWithoutAppName.toString()).to.equal(connectionString);
 
     const shellCommandText = sendTextStub.firstCall.args[0];
-    expect(shellCommandText).to.equal('mongosh $MDB_CONNECTION_STRING;');
+    expect(shellCommandText).to.equal('mongosh "$MDB_CONNECTION_STRING";');
 
     // Required for shell to share the OIDC state
     expect(terminalOptions.env?.MONGOSH_OIDC_PARENT_HANDLE).to.not.be.undefined;


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. VSCODE-1111: updates ace editor width in agg pipeline view -->
<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
Prevents to get command injections when launching mongosh via `cmd.exe` .

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)

