### PR TITLE
fix(connections): show redacted connection string in confirmation modal VSCODE-798

### DIFF
--- a/src/commands/launchMongoShell.ts
+++ b/src/commands/launchMongoShell.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 
 import type ConnectionController from '../connectionController';
+import { confirmConnection } from '../utils/confirmConnection';
 
 const launchMongoDBShellWithEnv = ({
   shellCommand,
@@ -48,7 +49,7 @@ const getBashEnvString = (): string => {
   return '"$MDB_CONNECTION_STRING"';
 };
 
-const openMongoDBShell = (
+const openMongoDBShell = async (
   connectionController: ConnectionController,
 ): Promise<boolean> => {
   if (!connectionController.isCurrentlyConnected()) {
@@ -117,6 +118,19 @@ const openMongoDBShell = (
     envVariableString = getBashEnvString();
   }
 
+  // The shell is handed the connection string of whichever connection is active, which
+  // may have been set up a while ago or by someone else, so confirm the destination.
+  const confirmed = await confirmConnection({
+    connectionString: mdbConnectionString,
+    question:
+      'Please verify the details below. Would you like to launch the MongoDB Shell with this connection?',
+    action: 'Launch Shell',
+  });
+
+  if (!confirmed) {
+    return false;
+  }
+
   launchMongoDBShellWithEnv({
     shellCommand,
     mdbConnectionString,
@@ -124,7 +138,7 @@ const openMongoDBShell = (
     envVariableString,
   });
 
-  return Promise.resolve(true);
+  return true;
 };
 
 export default openMongoDBShell;

--- a/src/connectionController.ts
+++ b/src/connectionController.ts
@@ -20,6 +20,7 @@ import {
 } from './views/webview-app/extension-app-message-constants';
 import { createLogger } from './logging';
 import formatError from './utils/formatError';
+import { confirmConnection } from './utils/confirmConnection';
 import type { StorageController } from './storage';
 import type { StatusView } from './views';
 import type { TelemetryService } from './telemetry';
@@ -273,18 +274,13 @@ export default class ConnectionController {
     try {
       if (connectionString) {
         // Connection string came from outside (e.g. deep link) — confirm with user.
-        let host: string;
-        try {
-          host = new ConnectionString(connectionString).hosts.join(', ');
-        } catch {
-          host = connectionString;
-        }
-        const confirmed = await vscode.window.showWarningMessage(
-          `Do you want to connect to "${host}"?`,
-          { modal: true },
-          'Connect',
-        );
-        if (confirmed !== 'Connect') return false;
+        const confirmed = await confirmConnection({
+          connectionString,
+          question:
+            'Please verify the details below. Would you like to proceed with the connection?',
+          action: 'Connect',
+        });
+        if (!confirmed) return false;
       } else {
         connectionString = await vscode.window.showInputBox(
           {

--- a/src/test/suite/commands/launchMongoShell.test.ts
+++ b/src/test/suite/commands/launchMongoShell.test.ts
@@ -11,6 +11,7 @@ import type ConnectionController from '../../../connectionController';
 suite('Commands Test Suite', function () {
   let testConnectionController: ConnectionController;
   let showErrorMessageStub: SinonStub;
+  let showWarningMessageStub: SinonStub;
   let getMongoClientConnectionOptionsStub: SinonStub;
   let isCurrentlyConnectedStub: SinonStub;
   let createTerminalStub: SinonStub;
@@ -24,6 +25,9 @@ suite('Commands Test Suite', function () {
     sandbox = sinon.createSandbox();
     sandbox.stub(vscode.window, 'showInformationMessage');
     showErrorMessageStub = sandbox.stub(vscode.window, 'showErrorMessage');
+    showWarningMessageStub = sandbox
+      .stub(vscode.window, 'showWarningMessage')
+      .resolves('Launch Shell' as any);
     getMongoClientConnectionOptionsStub = sandbox.stub(
       testConnectionController,
       'getMongoClientConnectionOptions',
@@ -139,6 +143,32 @@ suite('Commands Test Suite', function () {
         expect(showErrorMessageStub.firstCall.args[0]).to.equal(
           'The connection string contains unsupported characters (quotes or line breaks) and cannot be used to launch the MongoDB Shell.',
         );
+      });
+
+      test('openMongoDBShell shows the redacted connection string before launching', async function () {
+        getMongoClientConnectionOptionsStub.returns({
+          url: 'mongodb://user:s3cr3t@localhost:27088/?readPreference=primary',
+          options: {},
+        });
+
+        await launchMongoShell(testConnectionController);
+
+        const [message, { detail }] = showWarningMessageStub.firstCall.args as [
+          string,
+          { detail: string },
+        ];
+        expect(detail).to.include('localhost:27088');
+        expect(detail).to.include('readPreference=primary');
+        expect(`${message}${detail}`).to.not.include('s3cr3t');
+      });
+
+      test('openMongoDBShell does not launch the shell when the confirmation is cancelled', async function () {
+        showWarningMessageStub.resolves(undefined);
+
+        const result = await launchMongoShell(testConnectionController);
+
+        expect(result).to.be.false;
+        expect(createTerminalStub.called).to.be.false;
       });
     });
   });

--- a/src/test/suite/connectionController.test.ts
+++ b/src/test/suite/connectionController.test.ts
@@ -1578,9 +1578,67 @@ suite('Connection Controller Test Suite', function () {
           'mongodb+srv://user:s3cr3t@cluster0.example.com/admin',
       });
 
-      const dialogMessage = showWarningMessageStub.firstCall.args[0];
-      expect(dialogMessage).to.include('cluster0.example.com');
-      expect(dialogMessage).to.not.include('s3cr3t');
+      const [message, { detail }] = showWarningMessageStub.firstCall.args as [
+        string,
+        { detail: string },
+      ];
+      expect(detail).to.include('cluster0.example.com');
+      expect(`${message}${detail}`).to.not.include('s3cr3t');
+    });
+
+    test('with pre-supplied connection string, shows the whole connection string in the confirmation dialog', async function () {
+      const showWarningMessageStub = sandbox
+        .stub(vscode.window, 'showWarningMessage')
+        .resolves('Connect' as any);
+      addNewConnectionAndConnectStub.returns(true);
+
+      await testConnectionController.connectWithURI({
+        connectionString:
+          'mongodb+srv://cluster0.example.com/?appName=evil&proxyHost=proxy.example.com',
+      });
+
+      const { detail } = showWarningMessageStub.firstCall.args[1] as {
+        detail: string;
+      };
+      expect(detail).to.include('cluster0.example.com');
+      expect(detail).to.include('appName=evil');
+      expect(detail).to.include('proxyHost=proxy.example.com');
+    });
+
+    test('with pre-supplied connection string, does not show credentials in the confirmation dialog', async function () {
+      const showWarningMessageStub = sandbox
+        .stub(vscode.window, 'showWarningMessage')
+        .resolves('Connect' as any);
+      addNewConnectionAndConnectStub.returns(true);
+
+      await testConnectionController.connectWithURI({
+        connectionString:
+          'mongodb+srv://user:s3cr3t@cluster0.example.com/admin?proxyPassword=alsosecret',
+      });
+
+      const [message, { detail }] = showWarningMessageStub.firstCall.args as [
+        string,
+        { detail: string },
+      ];
+      expect(detail).to.include('cluster0.example.com');
+      expect(`${message}${detail}`).to.not.include('s3cr3t');
+      expect(`${message}${detail}`).to.not.include('alsosecret');
+    });
+
+    test('with an unparseable pre-supplied connection string, does not show credentials in the confirmation dialog', async function () {
+      const showWarningMessageStub = sandbox
+        .stub(vscode.window, 'showWarningMessage')
+        .resolves(undefined);
+
+      await testConnectionController.connectWithURI({
+        connectionString: 'mongodb://user:s3cr3t@',
+      });
+
+      const [message, { detail }] = showWarningMessageStub.firstCall.args as [
+        string,
+        { detail: string },
+      ];
+      expect(`${message}${detail}`).to.not.include('s3cr3t');
     });
 
     test('with pre-supplied connection string, cancelling dialog does not connect', async function () {

--- a/src/test/suite/oidc.test.ts
+++ b/src/test/suite/oidc.test.ts
@@ -186,6 +186,10 @@ suite('OIDC Tests', function () {
       'showInformationMessage',
     );
 
+    sandbox
+      .stub(vscode.window, 'showWarningMessage')
+      .resolves('Launch Shell' as any);
+
     createTerminalStub = sandbox.stub(vscode.window, 'createTerminal');
     sendTextStub = sandbox.stub();
     createTerminalStub.returns({

--- a/src/test/suite/utils/confirmConnection.test.ts
+++ b/src/test/suite/utils/confirmConnection.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach } from 'mocha';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import type { SinonStub } from 'sinon';
+import vscode from 'vscode';
+
+import { confirmConnection } from '../../../utils/confirmConnection';
+
+suite('Confirm Connection Test Suite', function () {
+  let sandbox: sinon.SinonSandbox;
+  let showWarningMessageStub: SinonStub;
+
+  beforeEach(function () {
+    sandbox = sinon.createSandbox();
+    showWarningMessageStub = sandbox.stub(vscode.window, 'showWarningMessage');
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  test('asks the question with the redacted connection string as the detail', async function () {
+    showWarningMessageStub.resolves('Connect');
+
+    await confirmConnection({
+      connectionString: 'mongodb+srv://user:s3cr3t@cluster0.example.com/admin',
+      question: 'Do the thing?',
+      action: 'Connect',
+    });
+
+    const [question, options, action] = showWarningMessageStub.firstCall
+      .args as [string, { modal: boolean; detail: string }, string];
+    expect(question).to.equal('Do the thing?');
+    expect(action).to.equal('Connect');
+    expect(options.modal).to.be.true;
+    expect(options.detail).to.include('cluster0.example.com');
+    expect(options.detail).to.not.include('s3cr3t');
+  });
+
+  test('is confirmed only when the action is picked', async function () {
+    showWarningMessageStub.resolves('Connect');
+    expect(
+      await confirmConnection({
+        connectionString: 'mongodb://localhost:27017',
+        question: 'Do the thing?',
+        action: 'Connect',
+      }),
+    ).to.be.true;
+
+    showWarningMessageStub.resolves(undefined);
+    expect(
+      await confirmConnection({
+        connectionString: 'mongodb://localhost:27017',
+        question: 'Do the thing?',
+        action: 'Connect',
+      }),
+    ).to.be.false;
+  });
+
+  test('redacts credentials from a connection string it cannot parse', async function () {
+    showWarningMessageStub.resolves(undefined);
+
+    await confirmConnection({
+      connectionString: 'mongodb://bob:p4ssw0rd@',
+      question: 'Do the thing?',
+      action: 'Connect',
+    });
+
+    const [, options] = showWarningMessageStub.firstCall.args as [
+      string,
+      { detail: string },
+    ];
+    expect(options.detail).to.not.include('p4ssw0rd');
+  });
+});

--- a/src/utils/confirmConnection.ts
+++ b/src/utils/confirmConnection.ts
@@ -1,0 +1,25 @@
+import * as vscode from 'vscode';
+import { redactConnectionString } from 'mongodb-connection-string-url';
+
+/**
+ * Ask the user to confirm something we are about to do with a connection string,
+ * showing them the whole connection string with its credentials removed so that they
+ * can see the options it sets and not just the host they recognise.
+ */
+export const confirmConnection = async ({
+  connectionString,
+  question,
+  action,
+}: {
+  connectionString: string;
+  question: string;
+  action: string;
+}): Promise<boolean> => {
+  const confirmed = await vscode.window.showWarningMessage(
+    question,
+    { modal: true, detail: redactConnectionString(connectionString) },
+    action,
+  );
+
+  return confirmed === action;
+};


### PR DESCRIPTION
## Description

When a connection string arrives from outside the extension, such as through a deep link, the confirmation modal only showed the hosts it parsed out of the string. Anything else the string carried — the database, the auth mechanism, options such as `proxyHost` or `tls=false` — was not shown, so a user who recognised the hostname had no way to see what else they were agreeing to.

The modal now also shows the whole connection string, with credentials redacted.

Deeplink example:

```
vscode://mongodb.mongodb-vscode/connectWithURI?connectionString=mongodb%252Bsrv%253A%252F%252Falice%253As3cr3t%2540cluster0.example.com%252Fadmin%253FappName%253Dx%257Ccalc.exe%2526proxyHost%253Devil.example.com%2526proxyPassword%253Dhunter2%2526tls%253Dfalse
```

<img width="259" height="299" alt="Screenshot 2026-09-01 at 07 39 25" src="https://github.com/user-attachments/assets/6564cbed-1128-46dd-8401-757fc95b420f" />

Also, showing the modal when trying to launch the mongodb shell from a saved connection:



https://github.com/user-attachments/assets/8c89e17a-520d-4b71-9de0-def201aca417



### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions

## Dependents

## Types of changes
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)

