### PR TITLE
fix(connections): wrap the connection string in the confirmation modal VSCODE-820

### DIFF
--- a/src/test/suite/utils/confirmConnection.test.ts
+++ b/src/test/suite/utils/confirmConnection.test.ts
@@ -4,7 +4,10 @@ import sinon from 'sinon';
 import type { SinonStub } from 'sinon';
 import vscode from 'vscode';
 
-import { confirmConnection } from '../../../utils/confirmConnection';
+import {
+  confirmConnection,
+  formatConnectionStringForDisplay,
+} from '../../../utils/confirmConnection';
 
 suite('Confirm Connection Test Suite', function () {
   let sandbox: sinon.SinonSandbox;
@@ -71,5 +74,62 @@ suite('Confirm Connection Test Suite', function () {
       { detail: string },
     ];
     expect(options.detail).to.not.include('p4ssw0rd');
+  });
+
+  suite('formatConnectionStringForDisplay', function () {
+    test('puts each host and option on its own line', function () {
+      expect(
+        formatConnectionStringForDisplay(
+          'mongodb://user:s3cr3t@host1.example.com:27017,host2.example.com:27017/admin?replicaSet=rs0&readPreference=primary',
+        ),
+      ).to.equal(
+        [
+          'mongodb://<credentials>@',
+          'host1.example.com:27017,',
+          'host2.example.com:27017/admin',
+          '?replicaSet=rs0',
+          '&readPreference=primary',
+        ].join('\n'),
+      );
+    });
+
+    test('keeps the scheme and the host together when there are no credentials', function () {
+      expect(
+        formatConnectionStringForDisplay('mongodb://localhost:27017'),
+      ).to.equal('mongodb://localhost:27017');
+      expect(
+        formatConnectionStringForDisplay(
+          'mongodb://localhost:27017/?appName=mongodb-vscode',
+        ),
+      ).to.equal('mongodb://localhost:27017\n?appName=mongodb-vscode');
+    });
+
+    test('keeps every option of a long connection string visible', function () {
+      const detail = formatConnectionStringForDisplay(
+        'mongodb+srv://user:s3cr3t@cluster0.abcdef.mongodb.net/admin?appName=mongodb-vscode&authSource=admin&retryWrites=true&w=majority&readPreference=secondaryPreferred&proxyHost=proxy.example.com',
+      );
+
+      expect(detail).to.not.include('s3cr3t');
+      for (const option of [
+        'appName=mongodb-vscode',
+        'authSource=admin',
+        'retryWrites=true',
+        'w=majority',
+        'readPreference=secondaryPreferred',
+        'proxyHost=proxy.example.com',
+      ]) {
+        expect(detail).to.include(option);
+      }
+      // Nothing is left as one long unbreakable token for Windows to ellipsize.
+      for (const line of detail.split('\n')) {
+        expect(line.length).to.be.lessThan(60);
+      }
+    });
+
+    test('redacts a connection string it cannot take apart', function () {
+      expect(
+        formatConnectionStringForDisplay('mongodb://bob:p4ssw0rd@'),
+      ).to.not.include('p4ssw0rd');
+    });
   });
 });

--- a/src/utils/confirmConnection.ts
+++ b/src/utils/confirmConnection.ts
@@ -1,5 +1,44 @@
 import * as vscode from 'vscode';
-import { redactConnectionString } from 'mongodb-connection-string-url';
+import ConnectionString, {
+  redactConnectionString,
+} from 'mongodb-connection-string-url';
+
+/**
+ * A connection string is a single unbroken token, and the native dialog VS Code
+ * uses for modals on Windows ellipsizes those instead of wrapping them, hiding
+ * exactly the options we want the user to look at. Breaking it over lines gives
+ * the dialog somewhere to wrap.
+ */
+export const formatConnectionStringForDisplay = (
+  connectionString: string,
+): string => {
+  // Redact before taking it apart, so that redactConnectionString stays the only
+  // thing that decides which parts of a connection string hold secrets.
+  const redacted = redactConnectionString(connectionString);
+
+  let url: ConnectionString;
+  try {
+    url = new ConnectionString(redacted);
+  } catch {
+    return redacted;
+  }
+
+  const credentials = url.username || url.password ? '<credentials>@' : '';
+  const pathname = url.pathname === '/' ? '' : url.pathname;
+  const hosts = `${url.hosts.join(',\n')}${pathname}`;
+  // No indentation: the dialog renders the detail as HTML and collapses it.
+  const lines = [
+    // The scheme only earns a line of its own when it is followed by credentials.
+    ...(credentials
+      ? [`${url.protocol}//${credentials}`, hosts]
+      : [`${url.protocol}//${hosts}`]),
+    ...[...url.searchParams.entries()].map(
+      ([key, value], index) => `${index === 0 ? '?' : '&'}${key}=${value}`,
+    ),
+  ];
+
+  return lines.join('\n');
+};
 
 /**
  * Ask the user to confirm something we are about to do with a connection string,
@@ -17,7 +56,7 @@ export const confirmConnection = async ({
 }): Promise<boolean> => {
   const confirmed = await vscode.window.showWarningMessage(
     question,
-    { modal: true, detail: redactConnectionString(connectionString) },
+    { modal: true, detail: formatConnectionStringForDisplay(connectionString) },
     action,
   );
 


### PR DESCRIPTION
## Description

The Launch Shell confirmation modal truncated the connection string on Windows, so you could not see all the connection options — which is what the confirmation added in VSCODE-798 is there to show.

A connection string is a single unbroken token, and `MessageOptions` only exposes `modal` and `detail` (no wrap or width option), so the redacted string is now broken over lines the dialog can wrap on:

```
mongodb+srv://<credentials>@
cluster0.abcdef.mongodb.net/admin
?appName=mongodb-vscode
&authSource=admin
&retryWrites=true
```
<img width="261" height="362" alt="Screenshot 2026-09-02 at 14 13 39" src="https://github.com/user-attachments/assets/c9dc484e-4277-449d-bc1d-becd3053e49d" />
<img width="1206" height="800" alt="Screenshot 2026-09-02 at 14 24 12" src="https://github.com/user-attachments/assets/7d05431a-b497-4eef-972f-bd740033f9c8" />



### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions

## Dependents

Follow-up to #9 (VSCODE-798), which added the confirmation modal.

## Types of changes
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)

